### PR TITLE
TeamCard & TeamCardMember Models

### DIFF
--- a/src/akgentic/team/__init__.py
+++ b/src/akgentic/team/__init__.py
@@ -6,7 +6,12 @@ re-exported here via explicit __all__.
 
 from __future__ import annotations
 
+from akgentic.team.models import TeamCard, TeamCardMember
+
 __version__ = "1.0.0-alpha.1"
 
-# Public types will be added as modules are implemented in Stories 1.2-1.5
-__all__: list[str] = ["__version__"]
+__all__: list[str] = [
+    "__version__",
+    "TeamCard",
+    "TeamCardMember",
+]

--- a/src/akgentic/team/models.py
+++ b/src/akgentic/team/models.py
@@ -5,3 +5,121 @@ AgentStateSnapshot.
 """
 
 from __future__ import annotations
+
+from pydantic import Field
+
+from akgentic.core.agent_card import AgentCard
+from akgentic.core.utils.serializer import SerializableBaseModel
+
+
+class TeamCardMember(SerializableBaseModel):
+    """A member slot in a team card, wrapping an AgentCard with multiplicity.
+
+    TeamCardMember is self-referential: each member can contain subordinate
+    members, forming a tree that describes hierarchical team structures.
+
+    Attributes:
+        card: The agent card describing this member's role and capabilities.
+        headcount: Number of agent instances to create for this slot.
+        members: Subordinate members managed by this member.
+    """
+
+    card: AgentCard = Field(description="Agent card describing this member's role and capabilities")
+    headcount: int = Field(default=1, description="Number of agent instances for this slot")
+    members: list[TeamCardMember] = Field(
+        default_factory=list,
+        description="Subordinate members managed by this member",
+    )
+
+
+class TeamCard(SerializableBaseModel):
+    """Declarative definition of a team's structure, entry point, and routing.
+
+    TeamCard describes the full hierarchy of agents in a team. The entry_point
+    is the agent that receives external messages. Members form a tree that can
+    be walked to discover all agent cards and supervisory relationships.
+
+    Attributes:
+        name: Unique name identifying this team definition.
+        description: Human-readable summary of what the team does.
+        entry_point: The member that serves as the team's external interface.
+        members: Top-level members of the team (excluding the entry point).
+        message_types: Message classes the team handles; first is the default.
+    """
+
+    name: str = Field(description="Unique name identifying this team definition")
+    description: str = Field(description="Human-readable summary of what the team does")
+    entry_point: TeamCardMember = Field(
+        description="The member that serves as the team's external interface",
+    )
+    members: list[TeamCardMember] = Field(
+        default_factory=list,
+        description="Top-level members of the team excluding the entry point",
+    )
+    message_types: list[type] = Field(
+        default_factory=list,
+        description="Message classes the team handles; first is the default",
+    )
+
+    @property
+    def agent_cards(self) -> dict[str, AgentCard]:
+        """Return a flat index of all AgentCards in the member tree.
+
+        Walks the entry_point and all members recursively, collecting every
+        AgentCard keyed by its ``config.name``.
+
+        Returns:
+            Dictionary mapping config name to AgentCard for every member.
+        """
+        result: dict[str, AgentCard] = {}
+        self._collect_cards(self.entry_point, result)
+        for member in self.members:
+            self._collect_cards(member, result)
+        return result
+
+    @property
+    def supervisors(self) -> list[AgentCard]:
+        """Return AgentCards for members that have subordinate members.
+
+        A member is a supervisor if its ``members`` list is non-empty,
+        meaning it manages at least one subordinate.
+
+        Returns:
+            List of AgentCards belonging to supervisory members.
+        """
+        result: list[AgentCard] = []
+        self._collect_supervisors(self.entry_point, result)
+        for member in self.members:
+            self._collect_supervisors(member, result)
+        return result
+
+    @staticmethod
+    def _collect_cards(
+        member: TeamCardMember,
+        result: dict[str, AgentCard],
+    ) -> None:
+        """Recursively collect AgentCards from a member subtree.
+
+        Args:
+            member: The member node to start from.
+            result: Accumulator dict to populate with discovered cards.
+        """
+        result[member.card.config.name] = member.card
+        for child in member.members:
+            TeamCard._collect_cards(child, result)
+
+    @staticmethod
+    def _collect_supervisors(
+        member: TeamCardMember,
+        result: list[AgentCard],
+    ) -> None:
+        """Recursively collect supervisor AgentCards from a member subtree.
+
+        Args:
+            member: The member node to start from.
+            result: Accumulator list to populate with supervisor cards.
+        """
+        if member.members:
+            result.append(member.card)
+        for child in member.members:
+            TeamCard._collect_supervisors(child, result)

--- a/src/akgentic/team/models.py
+++ b/src/akgentic/team/models.py
@@ -103,8 +103,18 @@ class TeamCard(SerializableBaseModel):
         Args:
             member: The member node to start from.
             result: Accumulator dict to populate with discovered cards.
+
+        Raises:
+            ValueError: If a duplicate config name is detected in the tree.
         """
-        result[member.card.config.name] = member.card
+        name = member.card.config.name
+        if name in result:
+            msg = (
+                f"Duplicate config name '{name}' in team member tree. "
+                f"Each AgentCard must have a unique config.name."
+            )
+            raise ValueError(msg)
+        result[name] = member.card
         for child in member.members:
             TeamCard._collect_cards(child, result)
 

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -1,3 +1,61 @@
 """Test fixtures for team domain model tests."""
 
 from __future__ import annotations
+
+from akgentic.core.agent_card import AgentCard
+from akgentic.core.agent_config import BaseConfig
+from akgentic.team.models import TeamCard, TeamCardMember
+
+
+def make_agent_card(
+    name: str = "test-agent",
+    role: str = "TestAgent",
+    routes_to: list[str] | None = None,
+) -> AgentCard:
+    """Create a minimal AgentCard for testing."""
+    return AgentCard(
+        role=role,
+        description=f"Test agent: {role}",
+        skills=["testing"],
+        agent_class="tests.fixtures.MockAgent",
+        config=BaseConfig(name=name, role=role),
+        routes_to=routes_to or [],
+    )
+
+
+def make_team_card(
+    name: str = "test-team",
+    description: str = "A test team",
+    entry_point_name: str = "lead",
+    entry_point_role: str = "Lead",
+    member_names: list[str] | None = None,
+    member_roles: list[str] | None = None,
+) -> TeamCard:
+    """Create a minimal TeamCard for testing.
+
+    Args:
+        name: Team name.
+        description: Team description.
+        entry_point_name: Config name of the entry point agent.
+        entry_point_role: Role of the entry point agent.
+        member_names: Config names for additional members.
+        member_roles: Roles for additional members.
+
+    Returns:
+        A TeamCard with the specified structure.
+    """
+    entry_point = TeamCardMember(
+        card=make_agent_card(name=entry_point_name, role=entry_point_role),
+    )
+    members: list[TeamCardMember] = []
+    if member_names and member_roles:
+        for mname, mrole in zip(member_names, member_roles):
+            members.append(
+                TeamCardMember(card=make_agent_card(name=mname, role=mrole)),
+            )
+    return TeamCard(
+        name=name,
+        description=description,
+        entry_point=entry_point,
+        members=members,
+    )

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from akgentic.core.agent_card import AgentCard
 from akgentic.core.agent_config import BaseConfig
+
 from akgentic.team.models import TeamCard, TeamCardMember
 
 
@@ -49,7 +50,7 @@ def make_team_card(
     )
     members: list[TeamCardMember] = []
     if member_names and member_roles:
-        for mname, mrole in zip(member_names, member_roles):
+        for mname, mrole in zip(member_names, member_roles, strict=True):
             members.append(
                 TeamCardMember(card=make_agent_card(name=mname, role=mrole)),
             )

--- a/tests/models/test_team_card.py
+++ b/tests/models/test_team_card.py
@@ -1,0 +1,207 @@
+"""Tests for TeamCard and TeamCardMember models."""
+
+from __future__ import annotations
+
+from akgentic.core.agent_card import AgentCard
+from akgentic.core.agent_config import BaseConfig
+from akgentic.team.models import TeamCard, TeamCardMember
+
+from .conftest import make_agent_card, make_team_card
+
+
+class TestTeamCardMember:
+    """Tests for the TeamCardMember model."""
+
+    def test_construction_with_defaults(self) -> None:
+        """TeamCardMember with only card uses default headcount=1 and empty members."""
+        card = make_agent_card(name="worker", role="Worker")
+        member = TeamCardMember(card=card)
+        assert member.card.config.name == "worker"
+        assert member.headcount == 1
+        assert member.members == []
+
+    def test_construction_with_explicit_headcount(self) -> None:
+        """TeamCardMember accepts an explicit headcount value."""
+        card = make_agent_card(name="pool-agent", role="PoolAgent")
+        member = TeamCardMember(card=card, headcount=5)
+        assert member.headcount == 5
+
+    def test_nested_members(self) -> None:
+        """TeamCardMember can contain nested members (self-referential)."""
+        child = TeamCardMember(card=make_agent_card(name="child", role="Child"))
+        parent = TeamCardMember(
+            card=make_agent_card(name="parent", role="Parent"),
+            members=[child],
+        )
+        assert len(parent.members) == 1
+        assert parent.members[0].card.config.name == "child"
+
+
+class TestTeamCard:
+    """Tests for the TeamCard model."""
+
+    def test_agent_cards_returns_flat_index(self) -> None:
+        """agent_cards property returns dict keyed by config name."""
+        team = make_team_card(
+            entry_point_name="lead",
+            entry_point_role="Lead",
+            member_names=["dev", "qa"],
+            member_roles=["Developer", "QA"],
+        )
+        cards = team.agent_cards
+        assert isinstance(cards, dict)
+        assert set(cards.keys()) == {"lead", "dev", "qa"}
+        assert all(isinstance(v, AgentCard) for v in cards.values())
+
+    def test_agent_cards_includes_nested_members(self) -> None:
+        """agent_cards flattens nested member trees."""
+        grandchild = TeamCardMember(
+            card=make_agent_card(name="gc", role="GrandChild"),
+        )
+        child = TeamCardMember(
+            card=make_agent_card(name="child", role="Child"),
+            members=[grandchild],
+        )
+        entry = TeamCardMember(
+            card=make_agent_card(name="root", role="Root"),
+        )
+        team = TeamCard(
+            name="nested-team",
+            description="A nested team",
+            entry_point=entry,
+            members=[child],
+        )
+        cards = team.agent_cards
+        assert set(cards.keys()) == {"root", "child", "gc"}
+
+    def test_supervisors_returns_members_with_subordinates(self) -> None:
+        """supervisors property returns AgentCards that have subordinate members."""
+        worker = TeamCardMember(card=make_agent_card(name="worker", role="Worker"))
+        supervisor = TeamCardMember(
+            card=make_agent_card(name="sup", role="Supervisor"),
+            members=[worker],
+        )
+        entry = TeamCardMember(card=make_agent_card(name="entry", role="Entry"))
+        team = TeamCard(
+            name="sup-team",
+            description="Team with supervisor",
+            entry_point=entry,
+            members=[supervisor],
+        )
+        sups = team.supervisors
+        assert len(sups) == 1
+        assert sups[0].config.name == "sup"
+
+    def test_supervisors_excludes_leaf_members(self) -> None:
+        """supervisors does not include leaf members with no subordinates."""
+        team = make_team_card(
+            member_names=["a", "b"],
+            member_roles=["A", "B"],
+        )
+        # No member has subordinates, so supervisors should be empty
+        assert team.supervisors == []
+
+    def test_empty_members_list(self) -> None:
+        """TeamCard with only entry_point and no members works correctly."""
+        team = TeamCard(
+            name="solo-team",
+            description="Just the entry point",
+            entry_point=TeamCardMember(
+                card=make_agent_card(name="solo", role="Solo"),
+            ),
+            members=[],
+        )
+        assert set(team.agent_cards.keys()) == {"solo"}
+        assert team.supervisors == []
+
+    def test_message_types_default_empty(self) -> None:
+        """message_types defaults to an empty list."""
+        team = make_team_card()
+        assert team.message_types == []
+
+
+class TestTeamCardSerialization:
+    """Tests for serialization round-trip of TeamCard and TeamCardMember."""
+
+    def test_team_card_member_round_trip(self) -> None:
+        """TeamCardMember survives model_dump/model_validate round-trip."""
+        card = make_agent_card(name="rt-agent", role="RoundTrip")
+        member = TeamCardMember(card=card, headcount=3)
+        dumped = member.model_dump()
+        restored = TeamCardMember.model_validate(dumped)
+        assert restored.card.config.name == "rt-agent"
+        assert restored.headcount == 3
+        assert restored.members == []
+
+    def test_team_card_round_trip(self) -> None:
+        """TeamCard survives model_dump/model_validate round-trip."""
+        team = make_team_card(
+            name="rt-team",
+            member_names=["x", "y"],
+            member_roles=["X", "Y"],
+        )
+        dumped = team.model_dump()
+        restored = TeamCard.model_validate(dumped)
+        assert restored.name == "rt-team"
+        assert len(restored.agent_cards) == len(team.agent_cards)
+        assert set(restored.agent_cards.keys()) == set(team.agent_cards.keys())
+
+    def test_nested_tree_round_trip(self) -> None:
+        """3+ level deep nested tree preserves data through serialization."""
+        l3 = TeamCardMember(card=make_agent_card(name="l3", role="L3"))
+        l2 = TeamCardMember(
+            card=make_agent_card(name="l2", role="L2"),
+            members=[l3],
+        )
+        l1 = TeamCardMember(
+            card=make_agent_card(name="l1", role="L1"),
+            members=[l2],
+        )
+        entry = TeamCardMember(card=make_agent_card(name="root", role="Root"))
+        team = TeamCard(
+            name="deep-team",
+            description="Deep nesting",
+            entry_point=entry,
+            members=[l1],
+        )
+        dumped = team.model_dump()
+        restored = TeamCard.model_validate(dumped)
+        assert set(restored.agent_cards.keys()) == {"root", "l1", "l2", "l3"}
+        # Verify supervisors preserved
+        sup_names = {s.config.name for s in restored.supervisors}
+        assert sup_names == {"l1", "l2"}
+
+    def test_routes_to_preserved_through_serialization(self) -> None:
+        """routes_to on AgentCards within the tree survive round-trip."""
+        card_with_routes = make_agent_card(
+            name="router",
+            role="Router",
+            routes_to=["TargetA", "TargetB"],
+        )
+        member = TeamCardMember(card=card_with_routes)
+        entry = TeamCardMember(card=make_agent_card(name="entry", role="Entry"))
+        team = TeamCard(
+            name="routing-team",
+            description="Team with routing",
+            entry_point=entry,
+            members=[member],
+        )
+        dumped = team.model_dump()
+        restored = TeamCard.model_validate(dumped)
+        router_card = restored.agent_cards["router"]
+        assert router_card.routes_to == ["TargetA", "TargetB"]
+
+    def test_single_member_team_round_trip(self) -> None:
+        """Entry-point only team serializes and deserializes correctly."""
+        team = TeamCard(
+            name="singleton",
+            description="Single agent team",
+            entry_point=TeamCardMember(
+                card=make_agent_card(name="only", role="Only"),
+            ),
+            members=[],
+        )
+        dumped = team.model_dump()
+        restored = TeamCard.model_validate(dumped)
+        assert restored.name == "singleton"
+        assert set(restored.agent_cards.keys()) == {"only"}

--- a/tests/models/test_team_card.py
+++ b/tests/models/test_team_card.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import pytest
 from akgentic.core.agent_card import AgentCard
-from akgentic.core.agent_config import BaseConfig
+from akgentic.core.messages import UserMessage
+
 from akgentic.team.models import TeamCard, TeamCardMember
 
 from .conftest import make_agent_card, make_team_card
@@ -119,6 +121,37 @@ class TestTeamCard:
         team = make_team_card()
         assert team.message_types == []
 
+    def test_agent_cards_raises_on_duplicate_config_name(self) -> None:
+        """agent_cards raises ValueError when two members share config.name."""
+        entry = TeamCardMember(card=make_agent_card(name="entry", role="Entry"))
+        dupe1 = TeamCardMember(card=make_agent_card(name="dupe", role="Role1"))
+        dupe2 = TeamCardMember(card=make_agent_card(name="dupe", role="Role2"))
+        team = TeamCard(
+            name="dupe-team",
+            description="Duplicate names",
+            entry_point=entry,
+            members=[dupe1, dupe2],
+        )
+        with pytest.raises(ValueError, match="Duplicate config name 'dupe'"):
+            team.agent_cards
+
+    def test_supervisors_includes_entry_point_with_subordinates(self) -> None:
+        """Entry point with subordinates is detected as a supervisor."""
+        child = TeamCardMember(card=make_agent_card(name="child", role="Child"))
+        entry = TeamCardMember(
+            card=make_agent_card(name="boss", role="Boss"),
+            members=[child],
+        )
+        team = TeamCard(
+            name="entry-sup-team",
+            description="Entry point supervises",
+            entry_point=entry,
+            members=[],
+        )
+        sups = team.supervisors
+        assert len(sups) == 1
+        assert sups[0].config.name == "boss"
+
 
 class TestTeamCardSerialization:
     """Tests for serialization round-trip of TeamCard and TeamCardMember."""
@@ -205,3 +238,19 @@ class TestTeamCardSerialization:
         restored = TeamCard.model_validate(dumped)
         assert restored.name == "singleton"
         assert set(restored.agent_cards.keys()) == {"only"}
+
+    def test_message_types_round_trip(self) -> None:
+        """message_types with actual type references survive round-trip."""
+        team = TeamCard(
+            name="typed-team",
+            description="Team with message types",
+            entry_point=TeamCardMember(
+                card=make_agent_card(name="entry", role="Entry"),
+            ),
+            members=[],
+            message_types=[UserMessage],
+        )
+        dumped = team.model_dump()
+        restored = TeamCard.model_validate(dumped)
+        assert len(restored.message_types) == 1
+        assert restored.message_types[0] is UserMessage


### PR DESCRIPTION
## Summary

- Implement `TeamCard` and `TeamCardMember` models extending `SerializableBaseModel` with full recursive tree walking (`agent_cards`, `supervisors` properties)
- Code review fixes: duplicate config.name guard (ValueError), lint fixes, 3 additional tests (message_types round-trip, duplicate name rejection, entry_point supervisor)
- 22 tests passing, 85.5% coverage, ruff + mypy clean

Closes #3