### PR TITLE
TeamRuntime Model

### DIFF
--- a/src/akgentic/team/__init__.py
+++ b/src/akgentic/team/__init__.py
@@ -6,7 +6,7 @@ re-exported here via explicit __all__.
 
 from __future__ import annotations
 
-from akgentic.team.models import TeamCard, TeamCardMember
+from akgentic.team.models import TeamCard, TeamCardMember, TeamRuntime
 
 __version__ = "1.0.0-alpha.1"
 
@@ -14,4 +14,5 @@ __all__: list[str] = [
     "__version__",
     "TeamCard",
     "TeamCardMember",
+    "TeamRuntime",
 ]

--- a/src/akgentic/team/models.py
+++ b/src/akgentic/team/models.py
@@ -6,9 +6,17 @@ AgentStateSnapshot.
 
 from __future__ import annotations
 
-from pydantic import Field
+import uuid
+from typing import Any
 
+from pydantic import Field, PrivateAttr
+
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.agent import Akgent
 from akgentic.core.agent_card import AgentCard
+from akgentic.core.messages.message import Message
+from akgentic.core.orchestrator import Orchestrator
 from akgentic.core.utils.serializer import SerializableBaseModel
 
 
@@ -133,3 +141,145 @@ class TeamCard(SerializableBaseModel):
             result.append(member.card)
         for child in member.members:
             TeamCard._collect_supervisors(child, result)
+
+
+# --- TeamRuntime ---
+
+
+class TeamRuntime(SerializableBaseModel):
+    """Live handle to a running team that survives serialization for persistence.
+
+    Stores persistent actor addresses and rebuilds ephemeral proxies on
+    construction via ``model_post_init``. Persistent fields survive
+    ``model_dump()`` / ``model_validate()`` round-trips while ephemeral
+    proxies are excluded from serialization.
+
+    Attributes:
+        id: Externally assigned unique identifier for this runtime instance.
+        team: The declarative team definition this runtime is based on.
+        actor_system: The actor system hosting this team's actors.
+        orchestrator_addr: Persistent address of the orchestrator actor.
+        entry_addr: Persistent address of the team's entry-point actor.
+        supervisor_addrs: Persistent addresses of supervisor actors keyed by name.
+        addrs: Persistent addresses of all actors keyed by name.
+    """
+
+    id: uuid.UUID = Field(description="Externally assigned unique identifier for this runtime")
+    team: TeamCard = Field(description="Declarative team definition this runtime is based on")
+    actor_system: ActorSystem = Field(
+        exclude=True,
+        description="Actor system hosting this team's actors",
+    )
+    orchestrator_addr: ActorAddress = Field(
+        description="Persistent address of the orchestrator actor",
+    )
+    entry_addr: ActorAddress = Field(
+        description="Persistent address of the entry-point actor",
+    )
+    supervisor_addrs: dict[str, ActorAddress] = Field(
+        default_factory=dict,
+        description="Persistent addresses of supervisor actors keyed by name",
+    )
+    addrs: dict[str, ActorAddress] = Field(
+        default_factory=dict,
+        description="Persistent addresses of all actors keyed by name",
+    )
+
+    _orchestrator_proxy: Orchestrator = PrivateAttr()
+    _entry_proxy: Akgent[Any, Any] = PrivateAttr()
+    _supervisor_proxies: dict[str, Akgent[Any, Any]] = PrivateAttr(default_factory=dict)
+    _message_cls: type[Message] | None = PrivateAttr(default=None)
+
+    def model_post_init(self, __context: Any) -> None:
+        """Rebuild all ephemeral proxies from persistent addresses.
+
+        Always overwrites all ephemeral fields completely to ensure
+        idempotency — safe to call multiple times.
+
+        Args:
+            __context: Pydantic validation context (unused).
+        """
+        self._orchestrator_proxy = self.actor_system.proxy_ask(
+            self.orchestrator_addr, Orchestrator
+        )
+        entry_agent_class = self.team.entry_point.card.get_agent_class()
+        self._entry_proxy = self.actor_system.proxy_tell(
+            self.entry_addr, entry_agent_class
+        )
+
+        self._supervisor_proxies = {}
+        for card in self.team.supervisors:
+            addr = self.supervisor_addrs.get(card.config.name)
+            if addr is not None:
+                self._supervisor_proxies[card.config.name] = (
+                    self.actor_system.proxy_ask(addr, card.get_agent_class())
+                )
+
+        self._message_cls = (
+            self.team.message_types[0] if self.team.message_types else None
+        )
+
+    def _make_message(self, content: str) -> Message:
+        """Create a message from the team's declared message type.
+
+        Args:
+            content: The message content.
+
+        Returns:
+            A Message instance of the team's declared type.
+
+        Raises:
+            RuntimeError: If no message type is declared for this team.
+        """
+        if self._message_cls is None:
+            msg = "No message type declared for this team"
+            raise RuntimeError(msg)
+        return self._message_cls(content=content)  # type: ignore[call-arg]
+
+    def send(self, content: str) -> None:
+        """Broadcast a message to all supervisors via the entry proxy.
+
+        Creates a message from the team's declared message type and sends
+        it via the entry proxy to each supervisor address.
+
+        Args:
+            content: The message content to broadcast.
+        """
+        message = self._make_message(content)
+        for addr in self.supervisor_addrs.values():
+            self._entry_proxy.send(addr, message)
+
+    def send_to(self, agent_name: str, content: str) -> None:
+        """Send a directed message to a specific agent by name.
+
+        Looks up the agent via the orchestrator proxy and sends a message
+        via the entry proxy.
+
+        Args:
+            agent_name: Name of the target agent.
+            content: The message content.
+
+        Raises:
+            ValueError: If the agent is not found in the team.
+        """
+        actor_addr = self._orchestrator_proxy.get_team_member(agent_name)
+        if actor_addr is None:
+            msg = f"Agent '{agent_name}' not found in team '{self.team.name}'"
+            raise ValueError(msg)
+        message = self._make_message(content)
+        self._entry_proxy.send(actor_addr, message)
+
+    @property
+    def orchestrator_proxy(self) -> Orchestrator:
+        """Read-only access to the orchestrator proxy."""
+        return self._orchestrator_proxy
+
+    @property
+    def entry_proxy(self) -> Akgent[Any, Any]:
+        """Read-only access to the entry-point proxy."""
+        return self._entry_proxy
+
+    @property
+    def supervisor_proxies(self) -> dict[str, Akgent[Any, Any]]:
+        """Read-only access to the supervisor proxies."""
+        return self._supervisor_proxies

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -2,23 +2,39 @@
 
 from __future__ import annotations
 
+import uuid
+from unittest.mock import MagicMock
+
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_system_impl import ActorSystem
 from akgentic.core.agent_card import AgentCard
 from akgentic.core.agent_config import BaseConfig
 
-from akgentic.team.models import TeamCard, TeamCardMember
+from akgentic.team.models import TeamCard, TeamCardMember, TeamRuntime
 
 
 def make_agent_card(
     name: str = "test-agent",
     role: str = "TestAgent",
     routes_to: list[str] | None = None,
+    agent_class: str | type = "tests.fixtures.MockAgent",
 ) -> AgentCard:
-    """Create a minimal AgentCard for testing."""
+    """Create a minimal AgentCard for testing.
+
+    Args:
+        name: Config name for the agent.
+        role: Agent role.
+        routes_to: List of agent names this agent routes to.
+        agent_class: Agent class or FQCN string.
+
+    Returns:
+        An AgentCard with the specified configuration.
+    """
     return AgentCard(
         role=role,
         description=f"Test agent: {role}",
         skills=["testing"],
-        agent_class="tests.fixtures.MockAgent",
+        agent_class=agent_class,
         config=BaseConfig(name=name, role=role),
         routes_to=routes_to or [],
     )
@@ -31,6 +47,8 @@ def make_team_card(
     entry_point_role: str = "Lead",
     member_names: list[str] | None = None,
     member_roles: list[str] | None = None,
+    message_types: list[type] | None = None,
+    agent_class: str | type = "tests.fixtures.MockAgent",
 ) -> TeamCard:
     """Create a minimal TeamCard for testing.
 
@@ -41,22 +59,88 @@ def make_team_card(
         entry_point_role: Role of the entry point agent.
         member_names: Config names for additional members.
         member_roles: Roles for additional members.
+        message_types: Message classes the team handles.
+        agent_class: Agent class or FQCN string for all members.
 
     Returns:
         A TeamCard with the specified structure.
     """
     entry_point = TeamCardMember(
-        card=make_agent_card(name=entry_point_name, role=entry_point_role),
+        card=make_agent_card(
+            name=entry_point_name, role=entry_point_role, agent_class=agent_class
+        ),
     )
     members: list[TeamCardMember] = []
     if member_names and member_roles:
         for mname, mrole in zip(member_names, member_roles, strict=True):
             members.append(
-                TeamCardMember(card=make_agent_card(name=mname, role=mrole)),
+                TeamCardMember(
+                    card=make_agent_card(name=mname, role=mrole, agent_class=agent_class)
+                ),
             )
     return TeamCard(
         name=name,
         description=description,
         entry_point=entry_point,
         members=members,
+        message_types=message_types or [],
+    )
+
+
+def make_stub_addr(name: str = "stub") -> MagicMock:
+    """Create a MagicMock that behaves like an ActorAddress.
+
+    Args:
+        name: Name for the stub address.
+
+    Returns:
+        A MagicMock with ActorAddress spec.
+    """
+    addr = MagicMock(spec=ActorAddress)
+    addr.agent_id = uuid.uuid4()
+    addr.name = name
+    return addr
+
+
+def make_stub_actor_system() -> MagicMock:
+    """Create a MagicMock that behaves like an ActorSystem.
+
+    Returns:
+        A MagicMock with ActorSystem spec and proxy methods.
+    """
+    system = MagicMock(spec=ActorSystem)
+    system.proxy_ask = MagicMock(return_value=MagicMock())
+    system.proxy_tell = MagicMock(return_value=MagicMock())
+    return system
+
+
+def make_team_runtime(
+    *,
+    team_card: TeamCard | None = None,
+    message_types: list[type] | None = None,
+    supervisor_addrs: dict[str, ActorAddress] | None = None,
+    addrs: dict[str, ActorAddress] | None = None,
+) -> TeamRuntime:
+    """Create a TeamRuntime with mock dependencies for testing.
+
+    Args:
+        team_card: Optional pre-built TeamCard.
+        message_types: Message types for auto-generated TeamCard.
+        supervisor_addrs: Supervisor address mapping.
+        addrs: All agent address mapping.
+
+    Returns:
+        A TeamRuntime with mock ActorSystem and addresses.
+    """
+    from akgentic.core.agent import Akgent
+
+    tc = team_card or make_team_card(message_types=message_types, agent_class=Akgent)
+    return TeamRuntime(
+        id=uuid.uuid4(),
+        team=tc,
+        actor_system=make_stub_actor_system(),
+        orchestrator_addr=make_stub_addr("orchestrator"),
+        entry_addr=make_stub_addr("entry"),
+        supervisor_addrs=supervisor_addrs or {},
+        addrs=addrs or {},
     )

--- a/tests/models/test_team_runtime.py
+++ b/tests/models/test_team_runtime.py
@@ -6,96 +6,25 @@ import uuid
 from unittest.mock import MagicMock
 
 import pytest
+from akgentic.core.agent import Akgent
+from akgentic.core.messages.message import UserMessage
 from pydantic import ValidationError
 
-from akgentic.core.actor_address import ActorAddress
-from akgentic.core.actor_system_impl import ActorSystem
-from akgentic.core.agent import Akgent
-from akgentic.core.agent_card import AgentCard
-from akgentic.core.agent_config import BaseConfig
-from akgentic.core.messages.message import UserMessage
-from akgentic.core.orchestrator import Orchestrator
-
 from akgentic.team.models import TeamCard, TeamCardMember, TeamRuntime
-
-
-def _make_agent_card(
-    name: str = "test-agent",
-    role: str = "TestAgent",
-    routes_to: list[str] | None = None,
-) -> AgentCard:
-    """Create an AgentCard with agent_class as a real type (Akgent)."""
-    return AgentCard(
-        role=role,
-        description=f"Test agent: {role}",
-        skills=["testing"],
-        agent_class=Akgent,
-        config=BaseConfig(name=name, role=role),
-        routes_to=routes_to or [],
-    )
-
-
-def _make_team_card(
-    name: str = "test-team",
-    message_types: list[type] | None = None,
-) -> TeamCard:
-    """Create a TeamCard with real type agent_class for TeamRuntime tests."""
-    entry_point = TeamCardMember(card=_make_agent_card(name="lead", role="Lead"))
-    return TeamCard(
-        name=name,
-        description="A test team",
-        entry_point=entry_point,
-        members=[],
-        message_types=message_types or [],
-    )
-
-
-def _make_stub_addr(name: str = "stub") -> MagicMock:
-    """Create a MagicMock that behaves like an ActorAddress."""
-    addr = MagicMock(spec=ActorAddress)
-    addr.agent_id = uuid.uuid4()
-    addr.name = name
-    return addr
-
-
-def _make_stub_actor_system() -> MagicMock:
-    """Create a MagicMock that behaves like an ActorSystem."""
-    system = MagicMock(spec=ActorSystem)
-    system.proxy_ask = MagicMock(return_value=MagicMock())
-    system.proxy_tell = MagicMock(return_value=MagicMock())
-    return system
-
-
-def _make_team_runtime(
-    *,
-    team_card: TeamCard | None = None,
-    message_types: list[type] | None = None,
-    supervisor_addrs: dict[str, ActorAddress] | None = None,
-    addrs: dict[str, ActorAddress] | None = None,
-) -> TeamRuntime:
-    """Create a TeamRuntime with mock dependencies for testing."""
-    tc = team_card or _make_team_card(message_types=message_types)
-    rt_id = uuid.uuid4()
-    system = _make_stub_actor_system()
-    orch_addr = _make_stub_addr("orchestrator")
-    entry_addr = _make_stub_addr("entry")
-
-    return TeamRuntime(
-        id=rt_id,
-        team=tc,
-        actor_system=system,
-        orchestrator_addr=orch_addr,
-        entry_addr=entry_addr,
-        supervisor_addrs=supervisor_addrs or {},
-        addrs=addrs or {},
-    )
+from tests.models.conftest import (
+    make_agent_card,
+    make_stub_actor_system,
+    make_stub_addr,
+    make_team_card,
+    make_team_runtime,
+)
 
 
 class TestTeamRuntimeConstruction:
-    """Test TeamRuntime construction with all required fields."""
+    """AC 1-4: TeamRuntime construction with persistent and ephemeral fields."""
 
     def test_construction_with_all_fields(self) -> None:
-        runtime = _make_team_runtime()
+        runtime = make_team_runtime()
         assert isinstance(runtime.id, uuid.UUID)
         assert runtime.team is not None
         assert runtime.actor_system is not None
@@ -106,53 +35,77 @@ class TestTeamRuntimeConstruction:
 
     def test_id_has_no_default(self) -> None:
         """AC4: Construction without explicit id raises ValidationError."""
-        system = _make_stub_actor_system()
-        tc = _make_team_card()
-        orch_addr = _make_stub_addr()
-        entry_addr = _make_stub_addr()
+        system = make_stub_actor_system()
+        tc = make_team_card(agent_class=Akgent)
         with pytest.raises(ValidationError):
             TeamRuntime(
                 team=tc,
                 actor_system=system,
-                orchestrator_addr=orch_addr,
-                entry_addr=entry_addr,
+                orchestrator_addr=make_stub_addr(),
+                entry_addr=make_stub_addr(),
             )
 
     def test_supervisor_addrs_defaults_to_empty_dict(self) -> None:
-        system = _make_stub_actor_system()
-        tc = _make_team_card()
+        system = make_stub_actor_system()
+        tc = make_team_card(agent_class=Akgent)
         rt = TeamRuntime(
             id=uuid.uuid4(),
             team=tc,
             actor_system=system,
-            orchestrator_addr=_make_stub_addr(),
-            entry_addr=_make_stub_addr(),
+            orchestrator_addr=make_stub_addr(),
+            entry_addr=make_stub_addr(),
         )
         assert rt.supervisor_addrs == {}
         assert rt.addrs == {}
 
     def test_model_post_init_rebuilds_proxies(self) -> None:
         """AC3: model_post_init rebuilds all proxies from addresses."""
-        runtime = _make_team_runtime()
-        # Proxies should have been built by model_post_init
+        runtime = make_team_runtime()
         assert runtime._orchestrator_proxy is not None
         assert runtime._entry_proxy is not None
 
     def test_model_post_init_is_idempotent(self) -> None:
-        """AC3: model_post_init is idempotent."""
-        runtime = _make_team_runtime()
-        first_orch_proxy = runtime._orchestrator_proxy
-        # Call again — should overwrite without error
+        """AC3: model_post_init is idempotent — safe to call multiple times."""
+        runtime = make_team_runtime()
+        initial_call_count = runtime.actor_system.proxy_ask.call_count
         runtime.model_post_init(None)
+        # proxy_ask was called again, confirming proxies were rebuilt
+        assert runtime.actor_system.proxy_ask.call_count > initial_call_count
         assert runtime._orchestrator_proxy is not None
+
+    def test_model_post_init_builds_supervisor_proxies(self) -> None:
+        """AC3: model_post_init rebuilds supervisor proxies from addresses."""
+        supervisor_card = make_agent_card(name="supervisor", role="Supervisor", agent_class=Akgent)
+        worker_card = make_agent_card(name="worker", role="Worker", agent_class=Akgent)
+        entry_member = TeamCardMember(
+            card=make_agent_card(name="lead", role="Lead", agent_class=Akgent),
+        )
+        # Supervisor has a subordinate worker — makes it a supervisor
+        supervisor_member = TeamCardMember(
+            card=supervisor_card,
+            members=[TeamCardMember(card=worker_card)],
+        )
+        tc = TeamCard(
+            name="team-with-supervisors",
+            description="A team with supervisor hierarchy",
+            entry_point=entry_member,
+            members=[supervisor_member],
+            message_types=[UserMessage],
+        )
+        sup_addr = make_stub_addr("supervisor")
+        runtime = make_team_runtime(
+            team_card=tc,
+            supervisor_addrs={"supervisor": sup_addr},
+        )
+        assert "supervisor" in runtime._supervisor_proxies
+        runtime.actor_system.proxy_ask.assert_any_call(sup_addr, Akgent)
 
 
 class TestTeamRuntimeSerialization:
-    """Test persistent/ephemeral field separation and serialization round-trip."""
+    """AC 2, 7: Persistent/ephemeral field separation and serialization round-trip."""
 
     def test_ephemeral_fields_excluded_from_dump(self) -> None:
-        """AC2/AC7: PrivateAttr fields are excluded from model_dump."""
-        runtime = _make_team_runtime()
+        runtime = make_team_runtime()
         data = runtime.model_dump()
         assert "_orchestrator_proxy" not in data
         assert "_entry_proxy" not in data
@@ -160,14 +113,12 @@ class TestTeamRuntimeSerialization:
         assert "_message_cls" not in data
 
     def test_actor_system_excluded_from_dump(self) -> None:
-        """AC1: actor_system with Field(exclude=True) is excluded."""
-        runtime = _make_team_runtime()
+        runtime = make_team_runtime()
         data = runtime.model_dump()
         assert "actor_system" not in data
 
     def test_persistent_fields_in_dump(self) -> None:
-        """AC7: Persistent fields appear in model_dump."""
-        runtime = _make_team_runtime()
+        runtime = make_team_runtime()
         data = runtime.model_dump()
         assert "id" in data
         assert "team" in data
@@ -178,51 +129,64 @@ class TestTeamRuntimeSerialization:
 
 
 class TestTeamRuntimeMessaging:
-    """Test send() and send_to() methods."""
+    """AC 5, 6: send() and send_to() messaging facade."""
 
-    def test_send_calls_entry_proxy(self) -> None:
-        """AC5: send() creates message and sends via entry proxy."""
-        sup_addr = _make_stub_addr("supervisor")
-        runtime = _make_team_runtime(
+    def test_send_broadcasts_to_all_supervisors(self) -> None:
+        """AC5: send() creates message and sends via entry proxy to each supervisor."""
+        sup_addr_1 = make_stub_addr("supervisor-1")
+        sup_addr_2 = make_stub_addr("supervisor-2")
+        runtime = make_team_runtime(
             message_types=[UserMessage],
-            supervisor_addrs={"supervisor": sup_addr},
+            supervisor_addrs={"sup1": sup_addr_1, "sup2": sup_addr_2},
         )
         runtime.send("hello")
-        # The entry proxy's send should have been called
-        runtime._entry_proxy.send.assert_called()
+        assert runtime._entry_proxy.send.call_count == 2
+        call_addrs = {call.args[0] for call in runtime._entry_proxy.send.call_args_list}
+        assert call_addrs == {sup_addr_1, sup_addr_2}
+        # Verify message content
+        sent_msg = runtime._entry_proxy.send.call_args_list[0].args[1]
+        assert isinstance(sent_msg, UserMessage)
+        assert sent_msg.content == "hello"
+
+    def test_send_with_empty_supervisors_is_noop(self) -> None:
+        """AC5: send() with no supervisor_addrs does not call entry proxy."""
+        runtime = make_team_runtime(message_types=[UserMessage])
+        runtime.send("hello")
+        runtime._entry_proxy.send.assert_not_called()
 
     def test_send_to_looks_up_agent(self) -> None:
         """AC6: send_to() looks up agent via orchestrator proxy."""
-        target_addr = _make_stub_addr("worker")
-        runtime = _make_team_runtime(message_types=[UserMessage])
+        target_addr = make_stub_addr("worker")
+        runtime = make_team_runtime(message_types=[UserMessage])
         runtime._orchestrator_proxy.get_team_member = MagicMock(return_value=target_addr)
         runtime.send_to("worker", "hello")
         runtime._orchestrator_proxy.get_team_member.assert_called_once_with("worker")
-        runtime._entry_proxy.send.assert_called()
+        runtime._entry_proxy.send.assert_called_once()
+        call_args = runtime._entry_proxy.send.call_args
+        assert call_args.args[0] is target_addr
+        assert isinstance(call_args.args[1], UserMessage)
+        assert call_args.args[1].content == "hello"
 
     def test_send_to_raises_for_unknown_agent(self) -> None:
         """AC6: send_to() raises ValueError if agent not found."""
-        runtime = _make_team_runtime(message_types=[UserMessage])
+        runtime = make_team_runtime(message_types=[UserMessage])
         runtime._orchestrator_proxy.get_team_member = MagicMock(return_value=None)
         with pytest.raises(ValueError, match="not found"):
             runtime.send_to("nonexistent", "hello")
 
     def test_make_message_raises_when_no_message_types(self) -> None:
-        """AC5: _make_message raises RuntimeError when no message_types declared."""
-        runtime = _make_team_runtime(message_types=[])
+        runtime = make_team_runtime(message_types=[])
         with pytest.raises(RuntimeError, match="No message type"):
             runtime._make_message("hello")
 
     def test_make_message_creates_correct_type(self) -> None:
-        """_make_message instantiates the first message_type."""
-        runtime = _make_team_runtime(message_types=[UserMessage])
+        runtime = make_team_runtime(message_types=[UserMessage])
         msg = runtime._make_message("hello world")
         assert isinstance(msg, UserMessage)
         assert msg.content == "hello world"
 
     def test_read_only_properties(self) -> None:
-        """AC: read-only properties expose proxies."""
-        runtime = _make_team_runtime()
+        runtime = make_team_runtime()
         assert runtime.orchestrator_proxy is runtime._orchestrator_proxy
         assert runtime.entry_proxy is runtime._entry_proxy
         assert runtime.supervisor_proxies is runtime._supervisor_proxies

--- a/tests/models/test_team_runtime.py
+++ b/tests/models/test_team_runtime.py
@@ -1,0 +1,228 @@
+"""Tests for TeamRuntime model — persistent/ephemeral field separation and serialization."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_card import AgentCard
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.messages.message import UserMessage
+from akgentic.core.orchestrator import Orchestrator
+
+from akgentic.team.models import TeamCard, TeamCardMember, TeamRuntime
+
+
+def _make_agent_card(
+    name: str = "test-agent",
+    role: str = "TestAgent",
+    routes_to: list[str] | None = None,
+) -> AgentCard:
+    """Create an AgentCard with agent_class as a real type (Akgent)."""
+    return AgentCard(
+        role=role,
+        description=f"Test agent: {role}",
+        skills=["testing"],
+        agent_class=Akgent,
+        config=BaseConfig(name=name, role=role),
+        routes_to=routes_to or [],
+    )
+
+
+def _make_team_card(
+    name: str = "test-team",
+    message_types: list[type] | None = None,
+) -> TeamCard:
+    """Create a TeamCard with real type agent_class for TeamRuntime tests."""
+    entry_point = TeamCardMember(card=_make_agent_card(name="lead", role="Lead"))
+    return TeamCard(
+        name=name,
+        description="A test team",
+        entry_point=entry_point,
+        members=[],
+        message_types=message_types or [],
+    )
+
+
+def _make_stub_addr(name: str = "stub") -> MagicMock:
+    """Create a MagicMock that behaves like an ActorAddress."""
+    addr = MagicMock(spec=ActorAddress)
+    addr.agent_id = uuid.uuid4()
+    addr.name = name
+    return addr
+
+
+def _make_stub_actor_system() -> MagicMock:
+    """Create a MagicMock that behaves like an ActorSystem."""
+    system = MagicMock(spec=ActorSystem)
+    system.proxy_ask = MagicMock(return_value=MagicMock())
+    system.proxy_tell = MagicMock(return_value=MagicMock())
+    return system
+
+
+def _make_team_runtime(
+    *,
+    team_card: TeamCard | None = None,
+    message_types: list[type] | None = None,
+    supervisor_addrs: dict[str, ActorAddress] | None = None,
+    addrs: dict[str, ActorAddress] | None = None,
+) -> TeamRuntime:
+    """Create a TeamRuntime with mock dependencies for testing."""
+    tc = team_card or _make_team_card(message_types=message_types)
+    rt_id = uuid.uuid4()
+    system = _make_stub_actor_system()
+    orch_addr = _make_stub_addr("orchestrator")
+    entry_addr = _make_stub_addr("entry")
+
+    return TeamRuntime(
+        id=rt_id,
+        team=tc,
+        actor_system=system,
+        orchestrator_addr=orch_addr,
+        entry_addr=entry_addr,
+        supervisor_addrs=supervisor_addrs or {},
+        addrs=addrs or {},
+    )
+
+
+class TestTeamRuntimeConstruction:
+    """Test TeamRuntime construction with all required fields."""
+
+    def test_construction_with_all_fields(self) -> None:
+        runtime = _make_team_runtime()
+        assert isinstance(runtime.id, uuid.UUID)
+        assert runtime.team is not None
+        assert runtime.actor_system is not None
+        assert runtime.orchestrator_addr is not None
+        assert runtime.entry_addr is not None
+        assert isinstance(runtime.supervisor_addrs, dict)
+        assert isinstance(runtime.addrs, dict)
+
+    def test_id_has_no_default(self) -> None:
+        """AC4: Construction without explicit id raises ValidationError."""
+        system = _make_stub_actor_system()
+        tc = _make_team_card()
+        orch_addr = _make_stub_addr()
+        entry_addr = _make_stub_addr()
+        with pytest.raises(ValidationError):
+            TeamRuntime(
+                team=tc,
+                actor_system=system,
+                orchestrator_addr=orch_addr,
+                entry_addr=entry_addr,
+            )
+
+    def test_supervisor_addrs_defaults_to_empty_dict(self) -> None:
+        system = _make_stub_actor_system()
+        tc = _make_team_card()
+        rt = TeamRuntime(
+            id=uuid.uuid4(),
+            team=tc,
+            actor_system=system,
+            orchestrator_addr=_make_stub_addr(),
+            entry_addr=_make_stub_addr(),
+        )
+        assert rt.supervisor_addrs == {}
+        assert rt.addrs == {}
+
+    def test_model_post_init_rebuilds_proxies(self) -> None:
+        """AC3: model_post_init rebuilds all proxies from addresses."""
+        runtime = _make_team_runtime()
+        # Proxies should have been built by model_post_init
+        assert runtime._orchestrator_proxy is not None
+        assert runtime._entry_proxy is not None
+
+    def test_model_post_init_is_idempotent(self) -> None:
+        """AC3: model_post_init is idempotent."""
+        runtime = _make_team_runtime()
+        first_orch_proxy = runtime._orchestrator_proxy
+        # Call again — should overwrite without error
+        runtime.model_post_init(None)
+        assert runtime._orchestrator_proxy is not None
+
+
+class TestTeamRuntimeSerialization:
+    """Test persistent/ephemeral field separation and serialization round-trip."""
+
+    def test_ephemeral_fields_excluded_from_dump(self) -> None:
+        """AC2/AC7: PrivateAttr fields are excluded from model_dump."""
+        runtime = _make_team_runtime()
+        data = runtime.model_dump()
+        assert "_orchestrator_proxy" not in data
+        assert "_entry_proxy" not in data
+        assert "_supervisor_proxies" not in data
+        assert "_message_cls" not in data
+
+    def test_actor_system_excluded_from_dump(self) -> None:
+        """AC1: actor_system with Field(exclude=True) is excluded."""
+        runtime = _make_team_runtime()
+        data = runtime.model_dump()
+        assert "actor_system" not in data
+
+    def test_persistent_fields_in_dump(self) -> None:
+        """AC7: Persistent fields appear in model_dump."""
+        runtime = _make_team_runtime()
+        data = runtime.model_dump()
+        assert "id" in data
+        assert "team" in data
+        assert "orchestrator_addr" in data
+        assert "entry_addr" in data
+        assert "supervisor_addrs" in data
+        assert "addrs" in data
+
+
+class TestTeamRuntimeMessaging:
+    """Test send() and send_to() methods."""
+
+    def test_send_calls_entry_proxy(self) -> None:
+        """AC5: send() creates message and sends via entry proxy."""
+        sup_addr = _make_stub_addr("supervisor")
+        runtime = _make_team_runtime(
+            message_types=[UserMessage],
+            supervisor_addrs={"supervisor": sup_addr},
+        )
+        runtime.send("hello")
+        # The entry proxy's send should have been called
+        runtime._entry_proxy.send.assert_called()
+
+    def test_send_to_looks_up_agent(self) -> None:
+        """AC6: send_to() looks up agent via orchestrator proxy."""
+        target_addr = _make_stub_addr("worker")
+        runtime = _make_team_runtime(message_types=[UserMessage])
+        runtime._orchestrator_proxy.get_team_member = MagicMock(return_value=target_addr)
+        runtime.send_to("worker", "hello")
+        runtime._orchestrator_proxy.get_team_member.assert_called_once_with("worker")
+        runtime._entry_proxy.send.assert_called()
+
+    def test_send_to_raises_for_unknown_agent(self) -> None:
+        """AC6: send_to() raises ValueError if agent not found."""
+        runtime = _make_team_runtime(message_types=[UserMessage])
+        runtime._orchestrator_proxy.get_team_member = MagicMock(return_value=None)
+        with pytest.raises(ValueError, match="not found"):
+            runtime.send_to("nonexistent", "hello")
+
+    def test_make_message_raises_when_no_message_types(self) -> None:
+        """AC5: _make_message raises RuntimeError when no message_types declared."""
+        runtime = _make_team_runtime(message_types=[])
+        with pytest.raises(RuntimeError, match="No message type"):
+            runtime._make_message("hello")
+
+    def test_make_message_creates_correct_type(self) -> None:
+        """_make_message instantiates the first message_type."""
+        runtime = _make_team_runtime(message_types=[UserMessage])
+        msg = runtime._make_message("hello world")
+        assert isinstance(msg, UserMessage)
+        assert msg.content == "hello world"
+
+    def test_read_only_properties(self) -> None:
+        """AC: read-only properties expose proxies."""
+        runtime = _make_team_runtime()
+        assert runtime.orchestrator_proxy is runtime._orchestrator_proxy
+        assert runtime.entry_proxy is runtime._entry_proxy
+        assert runtime.supervisor_proxies is runtime._supervisor_proxies


### PR DESCRIPTION
## Summary

- Implements `TeamRuntime(SerializableBaseModel)` with 7 persistent fields and 4 ephemeral `PrivateAttr` fields
- `model_post_init` rebuilds orchestrator proxy (proxy_ask), entry proxy (proxy_tell), supervisor proxies, and message class from persistent addresses
- Messaging facade: `send()` broadcasts to all supervisors, `send_to()` routes via orchestrator lookup
- Code review fixes: consolidated test factories into conftest, added supervisor proxy coverage, improved assertions, added edge case tests

## Results

- 38 tests passing (16 for TeamRuntime + 17 TeamCard + 5 public API)
- Coverage: 91.04% (models.py at 99%)
- ruff check: clean
- mypy strict: clean

Closes #5