### PR TITLE
Story 1.4: Persistence Models

### DIFF
--- a/src/akgentic/team/__init__.py
+++ b/src/akgentic/team/__init__.py
@@ -6,13 +6,25 @@ re-exported here via explicit __all__.
 
 from __future__ import annotations
 
-from akgentic.team.models import TeamCard, TeamCardMember, TeamRuntime
+from akgentic.team.models import (
+    AgentStateSnapshot,
+    PersistedEvent,
+    Process,
+    TeamCard,
+    TeamCardMember,
+    TeamRuntime,
+    TeamStatus,
+)
 
 __version__ = "1.0.0-alpha.1"
 
 __all__: list[str] = [
     "__version__",
+    "AgentStateSnapshot",
+    "PersistedEvent",
+    "Process",
     "TeamCard",
     "TeamCardMember",
     "TeamRuntime",
+    "TeamStatus",
 ]

--- a/src/akgentic/team/models.py
+++ b/src/akgentic/team/models.py
@@ -7,6 +7,8 @@ AgentStateSnapshot.
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
+from enum import StrEnum
 from typing import Any
 
 from pydantic import Field, PrivateAttr
@@ -15,6 +17,7 @@ from akgentic.core.actor_address import ActorAddress
 from akgentic.core.actor_system_impl import ActorSystem
 from akgentic.core.agent import Akgent
 from akgentic.core.agent_card import AgentCard
+from akgentic.core.agent_state import BaseState
 from akgentic.core.messages.message import Message
 from akgentic.core.orchestrator import Orchestrator
 from akgentic.core.utils.serializer import SerializableBaseModel
@@ -283,3 +286,60 @@ class TeamRuntime(SerializableBaseModel):
     def supervisor_proxies(self) -> dict[str, Akgent[Any, Any]]:
         """Read-only access to the supervisor proxies."""
         return self._supervisor_proxies
+
+
+# --- Persistence Models ---
+
+
+class TeamStatus(StrEnum):
+    """Lifecycle states for a team instance."""
+
+    RUNNING = "running"
+    STOPPED = "stopped"
+    DELETED = "deleted"
+
+
+class Process(SerializableBaseModel):
+    """Persisted team metadata for crash recovery.
+
+    Stores the TeamCard blueprint so the team can be rebuilt on resume,
+    along with lifecycle status and audit fields. This is NOT the
+    TeamRuntime -- addresses are stale after stop/crash.
+    """
+
+    team_id: uuid.UUID = Field(description="Unique identifier for this team instance")
+    team_card: TeamCard = Field(description="Declarative team definition for rebuilding on resume")
+    status: TeamStatus = Field(description="Current lifecycle state of the team")
+    user_id: str = Field(default="cli", description="Identifier of the user who owns this team")
+    user_email: str = Field(default="", description="Email of the user who owns this team")
+    created_at: datetime = Field(description="Timestamp when the team was created")
+    updated_at: datetime = Field(description="Timestamp of the last status change")
+
+
+class PersistedEvent(SerializableBaseModel):
+    """Append-only event log entry for event-sourced persistence.
+
+    Each entry captures a single event (Message subclass) with its
+    sequence number for ordered replay during team restoration.
+    """
+
+    team_id: uuid.UUID = Field(description="Team instance this event belongs to")
+    sequence: int = Field(description="Monotonically increasing event sequence number")
+    event: Message = Field(description="Polymorphic event payload preserving concrete Message type")
+    timestamp: datetime = Field(description="Timestamp when the event was persisted")
+
+
+class AgentStateSnapshot(SerializableBaseModel):
+    """Overwrite-strategy snapshot of an agent's state.
+
+    Captures the latest state of a single agent for fast recovery
+    without full event replay. Each snapshot overwrites the previous
+    one for the same (team_id, agent_id) pair.
+    """
+
+    team_id: uuid.UUID = Field(description="Team instance this snapshot belongs to")
+    agent_id: str = Field(description="Identifier of the agent whose state is captured")
+    state: BaseState = Field(
+        description="Polymorphic agent state preserving concrete BaseState type"
+    )
+    updated_at: datetime = Field(description="Timestamp when the snapshot was taken")

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -11,7 +11,7 @@ from akgentic.core.actor_system_impl import ActorSystem
 from akgentic.core.agent_card import AgentCard
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.agent_state import BaseState
-from akgentic.core.messages.message import UserMessage
+from akgentic.core.messages.message import Message, UserMessage
 
 from akgentic.team.models import (
     AgentStateSnapshot,
@@ -190,7 +190,7 @@ def make_process(
 def make_persisted_event(
     team_id: uuid.UUID | None = None,
     sequence: int = 0,
-    event: UserMessage | None = None,
+    event: Message | None = None,
 ) -> PersistedEvent:
     """Create a PersistedEvent with sensible defaults for testing.
 

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -3,14 +3,25 @@
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 from akgentic.core.actor_address import ActorAddress
 from akgentic.core.actor_system_impl import ActorSystem
 from akgentic.core.agent_card import AgentCard
 from akgentic.core.agent_config import BaseConfig
+from akgentic.core.agent_state import BaseState
+from akgentic.core.messages.message import UserMessage
 
-from akgentic.team.models import TeamCard, TeamCardMember, TeamRuntime
+from akgentic.team.models import (
+    AgentStateSnapshot,
+    PersistedEvent,
+    Process,
+    TeamCard,
+    TeamCardMember,
+    TeamRuntime,
+    TeamStatus,
+)
 
 
 def make_agent_card(
@@ -143,4 +154,80 @@ def make_team_runtime(
         entry_addr=make_stub_addr("entry"),
         supervisor_addrs=supervisor_addrs or {},
         addrs=addrs or {},
+    )
+
+
+class SampleAgentState(BaseState):
+    """Minimal BaseState subclass for testing polymorphic serialization."""
+
+    task_count: int = 0
+
+
+def make_process(
+    team_id: uuid.UUID | None = None,
+    team_card: TeamCard | None = None,
+    status: TeamStatus = TeamStatus.RUNNING,
+) -> Process:
+    """Create a Process with sensible defaults for testing.
+
+    Args:
+        team_id: Optional team identifier.
+        team_card: Optional pre-built TeamCard.
+        status: Lifecycle status.
+
+    Returns:
+        A Process with the specified or default configuration.
+    """
+    return Process(
+        team_id=team_id or uuid.uuid4(),
+        team_card=team_card or make_team_card(),
+        status=status,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+def make_persisted_event(
+    team_id: uuid.UUID | None = None,
+    sequence: int = 0,
+    event: UserMessage | None = None,
+) -> PersistedEvent:
+    """Create a PersistedEvent with sensible defaults for testing.
+
+    Args:
+        team_id: Optional team identifier.
+        sequence: Event sequence number.
+        event: Optional Message subclass instance.
+
+    Returns:
+        A PersistedEvent with the specified or default configuration.
+    """
+    return PersistedEvent(
+        team_id=team_id or uuid.uuid4(),
+        sequence=sequence,
+        event=event or UserMessage(content="test message"),
+        timestamp=datetime.now(UTC),
+    )
+
+
+def make_agent_state_snapshot(
+    team_id: uuid.UUID | None = None,
+    agent_id: str = "test-agent",
+    state: BaseState | None = None,
+) -> AgentStateSnapshot:
+    """Create an AgentStateSnapshot with sensible defaults for testing.
+
+    Args:
+        team_id: Optional team identifier.
+        agent_id: Agent identifier.
+        state: Optional BaseState subclass instance.
+
+    Returns:
+        An AgentStateSnapshot with the specified or default configuration.
+    """
+    return AgentStateSnapshot(
+        team_id=team_id or uuid.uuid4(),
+        agent_id=agent_id,
+        state=state or SampleAgentState(task_count=5),
+        updated_at=datetime.now(UTC),
     )

--- a/tests/models/test_process.py
+++ b/tests/models/test_process.py
@@ -42,13 +42,13 @@ class TestTeamStatus:
             assert isinstance(status, str)
 
     def test_string_comparison_running(self) -> None:
-        assert TeamStatus.RUNNING == "running"
+        assert TeamStatus.RUNNING.value == "running"
 
     def test_string_comparison_stopped(self) -> None:
-        assert TeamStatus.STOPPED == "stopped"
+        assert TeamStatus.STOPPED.value == "stopped"
 
     def test_string_comparison_deleted(self) -> None:
-        assert TeamStatus.DELETED == "deleted"
+        assert TeamStatus.DELETED.value == "deleted"
 
 
 class TestProcess:
@@ -127,7 +127,7 @@ class TestPersistedEvent:
         data = event.model_dump()
         restored = PersistedEvent.model_validate(data)
         assert type(restored.event) is UserMessage
-        assert restored.event.content == "hello world"  # type: ignore[attr-defined]
+        assert restored.event.content == "hello world"
 
     def test_polymorphic_event_is_not_base_message(self) -> None:
         user_msg = UserMessage(content="specific")
@@ -137,7 +137,7 @@ class TestPersistedEvent:
         assert type(restored.event) is not Message
 
 
-class SampleAgentStateSnapshot:
+class TestAgentStateSnapshot:
     """Tests for AgentStateSnapshot model."""
 
     def test_construction(self) -> None:
@@ -159,7 +159,7 @@ class SampleAgentStateSnapshot:
         data = snapshot.model_dump()
         restored = AgentStateSnapshot.model_validate(data)
         assert type(restored.state) is SampleAgentState
-        assert restored.state.task_count == 10  # type: ignore[attr-defined]
+        assert restored.state.task_count == 10
 
     def test_polymorphic_state_is_not_base_state(self) -> None:
         state = SampleAgentState(task_count=3)

--- a/tests/models/test_process.py
+++ b/tests/models/test_process.py
@@ -1,0 +1,169 @@
+"""Tests for persistence models: TeamStatus, Process, PersistedEvent, AgentStateSnapshot."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from akgentic.core.agent_state import BaseState
+from akgentic.core.messages.message import Message, UserMessage
+
+from akgentic.team.models import (
+    AgentStateSnapshot,
+    PersistedEvent,
+    Process,
+    TeamStatus,
+)
+
+from .conftest import (
+    SampleAgentState,
+    make_agent_state_snapshot,
+    make_persisted_event,
+    make_process,
+    make_team_card,
+)
+
+
+class TestTeamStatus:
+    """Tests for TeamStatus enum."""
+
+    def test_has_exactly_three_values(self) -> None:
+        assert len(TeamStatus) == 3
+
+    def test_values_are_running_stopped_deleted(self) -> None:
+        assert set(TeamStatus) == {
+            TeamStatus.RUNNING,
+            TeamStatus.STOPPED,
+            TeamStatus.DELETED,
+        }
+
+    def test_each_value_is_str(self) -> None:
+        for status in TeamStatus:
+            assert isinstance(status, str)
+
+    def test_string_comparison_running(self) -> None:
+        assert TeamStatus.RUNNING == "running"
+
+    def test_string_comparison_stopped(self) -> None:
+        assert TeamStatus.STOPPED == "stopped"
+
+    def test_string_comparison_deleted(self) -> None:
+        assert TeamStatus.DELETED == "deleted"
+
+
+class TestProcess:
+    """Tests for Process model."""
+
+    def test_construction_with_all_fields(self) -> None:
+        tid = uuid.uuid4()
+        tc = make_team_card()
+        now = datetime.now(UTC)
+        process = Process(
+            team_id=tid,
+            team_card=tc,
+            status=TeamStatus.RUNNING,
+            user_id="admin",
+            user_email="admin@example.com",
+            created_at=now,
+            updated_at=now,
+        )
+        assert process.team_id == tid
+        assert process.team_card.name == tc.name
+        assert process.status == TeamStatus.RUNNING
+        assert process.user_id == "admin"
+        assert process.user_email == "admin@example.com"
+        assert process.created_at == now
+        assert process.updated_at == now
+
+    def test_construction_with_defaults(self) -> None:
+        process = make_process()
+        assert process.user_id == "cli"
+        assert process.user_email == ""
+
+    def test_serialization_round_trip(self) -> None:
+        process = make_process()
+        data = process.model_dump()
+        restored = Process.model_validate(data)
+        assert restored.team_id == process.team_id
+        assert restored.team_card.name == process.team_card.name
+        assert restored.status == process.status
+        assert restored.user_id == process.user_id
+        assert restored.user_email == process.user_email
+        assert restored.created_at == process.created_at
+        assert restored.updated_at == process.updated_at
+
+    def test_round_trip_with_stopped_status(self) -> None:
+        process = make_process(status=TeamStatus.STOPPED)
+        data = process.model_dump()
+        restored = Process.model_validate(data)
+        assert restored.status == TeamStatus.STOPPED
+
+    def test_round_trip_with_deleted_status(self) -> None:
+        process = make_process(status=TeamStatus.DELETED)
+        data = process.model_dump()
+        restored = Process.model_validate(data)
+        assert restored.status == TeamStatus.DELETED
+
+
+class TestPersistedEvent:
+    """Tests for PersistedEvent model."""
+
+    def test_construction(self) -> None:
+        event = make_persisted_event()
+        assert event.sequence == 0
+        assert isinstance(event.event, UserMessage)
+
+    def test_serialization_round_trip(self) -> None:
+        event = make_persisted_event(sequence=42)
+        data = event.model_dump()
+        restored = PersistedEvent.model_validate(data)
+        assert restored.team_id == event.team_id
+        assert restored.sequence == 42
+        assert restored.timestamp == event.timestamp
+
+    def test_polymorphic_deserialization_preserves_message_type(self) -> None:
+        user_msg = UserMessage(content="hello world")
+        event = make_persisted_event(event=user_msg)
+        data = event.model_dump()
+        restored = PersistedEvent.model_validate(data)
+        assert type(restored.event) is UserMessage
+        assert restored.event.content == "hello world"  # type: ignore[attr-defined]
+
+    def test_polymorphic_event_is_not_base_message(self) -> None:
+        user_msg = UserMessage(content="specific")
+        event = make_persisted_event(event=user_msg)
+        data = event.model_dump()
+        restored = PersistedEvent.model_validate(data)
+        assert type(restored.event) is not Message
+
+
+class SampleAgentStateSnapshot:
+    """Tests for AgentStateSnapshot model."""
+
+    def test_construction(self) -> None:
+        snapshot = make_agent_state_snapshot()
+        assert snapshot.agent_id == "test-agent"
+        assert isinstance(snapshot.state, SampleAgentState)
+
+    def test_serialization_round_trip(self) -> None:
+        snapshot = make_agent_state_snapshot(agent_id="worker-1")
+        data = snapshot.model_dump()
+        restored = AgentStateSnapshot.model_validate(data)
+        assert restored.team_id == snapshot.team_id
+        assert restored.agent_id == "worker-1"
+        assert restored.updated_at == snapshot.updated_at
+
+    def test_polymorphic_deserialization_preserves_state_type(self) -> None:
+        state = SampleAgentState(task_count=10)
+        snapshot = make_agent_state_snapshot(state=state)
+        data = snapshot.model_dump()
+        restored = AgentStateSnapshot.model_validate(data)
+        assert type(restored.state) is SampleAgentState
+        assert restored.state.task_count == 10  # type: ignore[attr-defined]
+
+    def test_polymorphic_state_is_not_base_state(self) -> None:
+        state = SampleAgentState(task_count=3)
+        snapshot = make_agent_state_snapshot(state=state)
+        data = snapshot.model_dump()
+        restored = AgentStateSnapshot.model_validate(data)
+        assert type(restored.state) is not BaseState


### PR DESCRIPTION
## Summary

Implements persistence domain models for crash recovery and event-sourced persistence:

- **TeamStatus** (StrEnum): Lifecycle states — RUNNING, STOPPED, DELETED
- **Process**: Team metadata for rebuild on resume (TeamCard blueprint, status, audit fields)
- **PersistedEvent**: Append-only event log entry with polymorphic Message field
- **AgentStateSnapshot**: Overwrite-strategy agent state with polymorphic BaseState field

All models extend SerializableBaseModel with `__model__` polymorphic metadata for correct subclass reconstruction on deserialization.

## Code Review Fixes

- Renamed `SampleAgentStateSnapshot` to `TestAgentStateSnapshot` so pytest collects the 4 AgentStateSnapshot tests (were silently skipped)
- Widened `make_persisted_event` event param type from `UserMessage` to `Message`
- Fixed mypy comparison-overlap warnings by using `.value` for StrEnum comparisons
- Removed unused `type: ignore` comments on polymorphic attribute access

## Verification

- 57 tests passing (19 new for persistence models)
- ruff: clean
- mypy: clean (source + new tests)

Closes #7