### PR TITLE
Port Protocols & NullServiceRegistry

### DIFF
--- a/src/akgentic/team/__init__.py
+++ b/src/akgentic/team/__init__.py
@@ -15,14 +15,22 @@ from akgentic.team.models import (
     TeamRuntime,
     TeamStatus,
 )
+from akgentic.team.ports import (
+    EventStore,
+    NullServiceRegistry,
+    ServiceRegistry,
+)
 
 __version__ = "1.0.0-alpha.1"
 
 __all__: list[str] = [
     "__version__",
     "AgentStateSnapshot",
+    "EventStore",
+    "NullServiceRegistry",
     "PersistedEvent",
     "Process",
+    "ServiceRegistry",
     "TeamCard",
     "TeamCardMember",
     "TeamRuntime",

--- a/src/akgentic/team/ports.py
+++ b/src/akgentic/team/ports.py
@@ -1,3 +1,141 @@
 """Port protocols: EventStore, ServiceRegistry, and NullServiceRegistry default."""
 
 from __future__ import annotations
+
+import uuid
+from typing import Protocol, runtime_checkable
+
+from akgentic.team.models import (
+    AgentStateSnapshot,
+    PersistedEvent,
+    Process,
+)
+
+
+class EventStore(Protocol):
+    """Typed persistence surface for team event sourcing.
+
+    Implementations provide durable storage for events, team process state,
+    and agent state snapshots. Concrete implementations (e.g. YamlEventStore,
+    MongoEventStore) satisfy this protocol via structural subtyping.
+    """
+
+    def save_event(self, event: PersistedEvent) -> None:
+        """Persist a single domain event.
+
+        Called by PersistenceSubscriber on each event received from the orchestrator.
+        """
+        ...
+
+    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
+        """Load all persisted events for a team.
+
+        Called by TeamRestorer to replay events during team resumption.
+        """
+        ...
+
+    def save_team(self, process: Process) -> None:
+        """Persist the current team process snapshot.
+
+        Called by PersistenceSubscriber to checkpoint team state.
+        """
+        ...
+
+    def load_team(self, team_id: uuid.UUID) -> Process | None:
+        """Load a team process snapshot by ID.
+
+        Called by TeamManager to retrieve team state. Returns None if no
+        snapshot exists for the given team ID.
+        """
+        ...
+
+    def delete_team(self, team_id: uuid.UUID) -> None:
+        """Delete all persisted data for a team.
+
+        Called by TeamManager during team deletion to purge stored state.
+        """
+        ...
+
+    def save_agent_state(self, snapshot: AgentStateSnapshot) -> None:
+        """Persist an agent state snapshot.
+
+        Called by PersistenceSubscriber to checkpoint individual agent state.
+        """
+        ...
+
+    def load_agent_states(self, team_id: uuid.UUID) -> list[AgentStateSnapshot]:
+        """Load all agent state snapshots for a team.
+
+        Called by TeamRestorer to restore agent states during team resumption.
+        """
+        ...
+
+
+@runtime_checkable
+class ServiceRegistry(Protocol):
+    """Service discovery port for multi-worker deployments.
+
+    Tracks which worker instances are active and which teams are hosted
+    on each instance. Implementations satisfy this protocol via structural
+    subtyping. In single-process mode, use NullServiceRegistry.
+    """
+
+    def register_instance(self, instance_id: uuid.UUID) -> None:
+        """Register a worker instance as active."""
+        ...
+
+    def deregister_instance(self, instance_id: uuid.UUID) -> None:
+        """Remove a worker instance from the active set."""
+        ...
+
+    def register_team(self, instance_id: uuid.UUID, team_id: uuid.UUID) -> None:
+        """Associate a team with a worker instance."""
+        ...
+
+    def deregister_team(self, instance_id: uuid.UUID, team_id: uuid.UUID) -> None:
+        """Disassociate a team from a worker instance."""
+        ...
+
+    def find_team(self, team_id: uuid.UUID) -> uuid.UUID | None:
+        """Find the worker instance hosting a team.
+
+        Returns the instance UUID if found, None otherwise.
+        """
+        ...
+
+    def get_active_instances(self) -> list[uuid.UUID]:
+        """Return all currently active worker instance IDs."""
+        ...
+
+
+class NullServiceRegistry:
+    """No-op service registry for single-process mode.
+
+    Satisfies the ServiceRegistry protocol via structural subtyping without
+    inheriting from it. All mutating methods are no-ops; queries return
+    empty results.
+    """
+
+    def register_instance(self, instance_id: uuid.UUID) -> None:
+        """No-op: single-process mode has no instance tracking."""
+        pass
+
+    def deregister_instance(self, instance_id: uuid.UUID) -> None:
+        """No-op: single-process mode has no instance tracking."""
+        pass
+
+    def register_team(self, instance_id: uuid.UUID, team_id: uuid.UUID) -> None:
+        """No-op: single-process mode has no team-to-instance mapping."""
+        pass
+
+    def deregister_team(self, instance_id: uuid.UUID, team_id: uuid.UUID) -> None:
+        """No-op: single-process mode has no team-to-instance mapping."""
+        pass
+
+    def find_team(self, team_id: uuid.UUID) -> uuid.UUID | None:
+        """Always returns None: no team routing in single-process mode."""
+        return None
+
+    def get_active_instances(self) -> list[uuid.UUID]:
+        """Always returns empty list: no instance tracking in single-process mode."""
+        return []

--- a/tests/models/test_ports.py
+++ b/tests/models/test_ports.py
@@ -1,0 +1,54 @@
+"""Tests for port protocols: NullServiceRegistry conformance and behavior.
+
+AC: 3, 5 — NullServiceRegistry satisfies ServiceRegistry via structural subtyping,
+with all no-op implementations verified.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from akgentic.team.ports import NullServiceRegistry, ServiceRegistry
+
+
+class TestNullServiceRegistry:
+    """Verify NullServiceRegistry satisfies ServiceRegistry protocol (AC: 3, 5)."""
+
+    def test_satisfies_service_registry_protocol(self) -> None:
+        """NullServiceRegistry is recognized as a ServiceRegistry instance."""
+        registry = NullServiceRegistry()
+        assert isinstance(registry, ServiceRegistry)
+
+    def test_find_team_returns_none(self) -> None:
+        """find_team always returns None in single-process mode."""
+        registry = NullServiceRegistry()
+        assert registry.find_team(uuid.uuid4()) is None
+
+    def test_get_active_instances_returns_empty_list(self) -> None:
+        """get_active_instances always returns empty list in single-process mode."""
+        registry = NullServiceRegistry()
+        assert registry.get_active_instances() == []
+
+    def test_register_instance_is_noop(self) -> None:
+        """register_instance executes without error."""
+        registry = NullServiceRegistry()
+        result = registry.register_instance(uuid.uuid4())
+        assert result is None
+
+    def test_deregister_instance_is_noop(self) -> None:
+        """deregister_instance executes without error."""
+        registry = NullServiceRegistry()
+        result = registry.deregister_instance(uuid.uuid4())
+        assert result is None
+
+    def test_register_team_is_noop(self) -> None:
+        """register_team executes without error."""
+        registry = NullServiceRegistry()
+        result = registry.register_team(uuid.uuid4(), uuid.uuid4())
+        assert result is None
+
+    def test_deregister_team_is_noop(self) -> None:
+        """deregister_team executes without error."""
+        registry = NullServiceRegistry()
+        result = registry.deregister_team(uuid.uuid4(), uuid.uuid4())
+        assert result is None

--- a/tests/models/test_ports.py
+++ b/tests/models/test_ports.py
@@ -8,47 +8,62 @@ from __future__ import annotations
 
 import uuid
 
+import pytest
+
 from akgentic.team.ports import NullServiceRegistry, ServiceRegistry
+
+
+@pytest.fixture()
+def registry() -> NullServiceRegistry:
+    """Shared NullServiceRegistry instance for tests."""
+    return NullServiceRegistry()
 
 
 class TestNullServiceRegistry:
     """Verify NullServiceRegistry satisfies ServiceRegistry protocol (AC: 3, 5)."""
 
-    def test_satisfies_service_registry_protocol(self) -> None:
+    def test_satisfies_service_registry_protocol(self, registry: NullServiceRegistry) -> None:
         """NullServiceRegistry is recognized as a ServiceRegistry instance."""
-        registry = NullServiceRegistry()
         assert isinstance(registry, ServiceRegistry)
 
-    def test_find_team_returns_none(self) -> None:
+    def test_non_conforming_object_is_not_service_registry(self) -> None:
+        """An object without the required methods is NOT a ServiceRegistry."""
+
+        class NotARegistry:
+            pass
+
+        assert not isinstance(NotARegistry(), ServiceRegistry)
+
+    def test_find_team_returns_none(self, registry: NullServiceRegistry) -> None:
         """find_team always returns None in single-process mode."""
-        registry = NullServiceRegistry()
         assert registry.find_team(uuid.uuid4()) is None
 
-    def test_get_active_instances_returns_empty_list(self) -> None:
+    def test_get_active_instances_returns_empty_list(self, registry: NullServiceRegistry) -> None:
         """get_active_instances always returns empty list in single-process mode."""
-        registry = NullServiceRegistry()
         assert registry.get_active_instances() == []
 
-    def test_register_instance_is_noop(self) -> None:
+    def test_get_active_instances_returns_fresh_list(self, registry: NullServiceRegistry) -> None:
+        """Each call returns a new list object, not shared mutable state."""
+        first = registry.get_active_instances()
+        second = registry.get_active_instances()
+        assert first is not second
+
+    def test_register_instance_is_noop(self, registry: NullServiceRegistry) -> None:
         """register_instance executes without error."""
-        registry = NullServiceRegistry()
         result = registry.register_instance(uuid.uuid4())
         assert result is None
 
-    def test_deregister_instance_is_noop(self) -> None:
+    def test_deregister_instance_is_noop(self, registry: NullServiceRegistry) -> None:
         """deregister_instance executes without error."""
-        registry = NullServiceRegistry()
         result = registry.deregister_instance(uuid.uuid4())
         assert result is None
 
-    def test_register_team_is_noop(self) -> None:
+    def test_register_team_is_noop(self, registry: NullServiceRegistry) -> None:
         """register_team executes without error."""
-        registry = NullServiceRegistry()
         result = registry.register_team(uuid.uuid4(), uuid.uuid4())
         assert result is None
 
-    def test_deregister_team_is_noop(self) -> None:
+    def test_deregister_team_is_noop(self, registry: NullServiceRegistry) -> None:
         """deregister_team executes without error."""
-        registry = NullServiceRegistry()
         result = registry.deregister_team(uuid.uuid4(), uuid.uuid4())
         assert result is None


### PR DESCRIPTION
## Summary

- Implement `EventStore` Protocol with 7 methods matching architecture spec (save/load events, teams, agent state)
- Implement `ServiceRegistry` Protocol with 6 methods for multi-worker service discovery
- Implement `NullServiceRegistry` no-op default for single-process mode (structural subtyping, no Protocol inheritance)
- Update `__init__.py` exports and `__all__`
- Add 9 tests: protocol conformance (isinstance), negative conformance, return values, no-op behavior, fresh-list identity

## Validation

- ruff: clean
- mypy: clean (13 source files)
- pytest: 66 tests pass, 94.76% coverage (ports.py at 100%)

Closes #9