### PR TITLE
TeamFactory Builds Running Teams

### DIFF
--- a/src/akgentic/team/__init__.py
+++ b/src/akgentic/team/__init__.py
@@ -6,6 +6,7 @@ re-exported here via explicit __all__.
 
 from __future__ import annotations
 
+from akgentic.team.factory import TeamFactory
 from akgentic.team.models import (
     AgentStateSnapshot,
     PersistedEvent,
@@ -33,6 +34,7 @@ __all__: list[str] = [
     "ServiceRegistry",
     "TeamCard",
     "TeamCardMember",
+    "TeamFactory",
     "TeamRuntime",
     "TeamStatus",
 ]

--- a/src/akgentic/team/factory.py
+++ b/src/akgentic/team/factory.py
@@ -51,6 +51,13 @@ class TeamFactory:
         team_id = uuid.uuid4()
         spawned_addrs: list[ActorAddress] = []
 
+        if team_card.entry_point.headcount != 1:
+            msg = (
+                f"Entry point '{team_card.entry_point.card.config.name}' "
+                f"must have headcount=1, got {team_card.entry_point.headcount}"
+            )
+            raise ValueError(msg)
+
         try:
             # 1. Create Orchestrator
             orchestrator_addr = actor_system.createActor(

--- a/src/akgentic/team/factory.py
+++ b/src/akgentic/team/factory.py
@@ -1,3 +1,171 @@
 """TeamFactory: build running teams from TeamCard + ActorSystem."""
 
 from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.orchestrator import EventSubscriber, Orchestrator
+from akgentic.team.models import TeamCard, TeamCardMember, TeamRuntime
+
+logger = logging.getLogger(__name__)
+
+
+class TeamFactory:
+    """Build running teams from TeamCard + ActorSystem.
+
+    Static builder: TeamFactory.build(team_card, actor_system, subscribers) -> TeamRuntime.
+    Creates Orchestrator, spawns agents, wires routes_to, registers subscribers.
+    Rollback on partial failure (tear down spawned actors if build fails).
+    """
+
+    @staticmethod
+    def build(
+        team_card: TeamCard,
+        actor_system: ActorSystem,
+        subscribers: list[EventSubscriber] | None = None,
+    ) -> TeamRuntime:
+        """Build a running team from a declarative TeamCard.
+
+        Creates an Orchestrator actor, spawns all agents defined in the TeamCard
+        member tree, registers subscribers and agent profiles, and returns a
+        TeamRuntime handle to the running team.
+
+        Args:
+            team_card: Declarative team definition with entry point and members.
+            actor_system: The actor system to host the team's actors.
+            subscribers: Optional event subscribers to register with the orchestrator.
+
+        Returns:
+            A TeamRuntime with all actor addresses populated and proxies rebuilt.
+
+        Raises:
+            Exception: If any agent spawn fails, all already-spawned actors are
+                torn down and the original exception is re-raised.
+        """
+        team_id = uuid.uuid4()
+        spawned_addrs: list[ActorAddress] = []
+
+        try:
+            # 1. Create Orchestrator
+            orchestrator_addr = actor_system.createActor(
+                Orchestrator,
+                config=BaseConfig(name="orchestrator", role="Orchestrator"),
+                team_id=team_id,
+            )
+            spawned_addrs.append(orchestrator_addr)
+
+            # 2. Get orchestrator proxy and register subscribers
+            orchestrator_proxy: Orchestrator = actor_system.proxy_ask(
+                orchestrator_addr, Orchestrator
+            )
+            for sub in subscribers or []:
+                orchestrator_proxy.subscribe(sub)
+
+            # 3. Walk TeamCard tree and spawn all agents
+            addrs: dict[str, ActorAddress] = {}
+            entry_addr: ActorAddress | None = None
+
+            # Spawn entry point
+            entry_addrs = TeamFactory._spawn_member(
+                team_card.entry_point, actor_system, team_id, spawned_addrs
+            )
+            addrs.update(entry_addrs)
+            # Entry point always has headcount=1, so use the card name
+            entry_addr = entry_addrs[team_card.entry_point.card.config.name]
+
+            # Spawn top-level members
+            for member in team_card.members:
+                member_addrs = TeamFactory._spawn_member(
+                    member, actor_system, team_id, spawned_addrs
+                )
+                addrs.update(member_addrs)
+
+            # 4. Register agent profiles with orchestrator
+            orchestrator_proxy.register_agent_profiles(
+                list(team_card.agent_cards.values())
+            )
+
+            # 5. Build supervisor_addrs
+            supervisor_addrs: dict[str, ActorAddress] = {}
+            for card in team_card.supervisors:
+                name = card.config.name
+                if name in addrs:
+                    supervisor_addrs[name] = addrs[name]
+
+            # 6. Build and return TeamRuntime
+            return TeamRuntime(
+                id=team_id,
+                team=team_card,
+                actor_system=actor_system,
+                orchestrator_addr=orchestrator_addr,
+                entry_addr=entry_addr,
+                supervisor_addrs=supervisor_addrs,
+                addrs=addrs,
+            )
+
+        except Exception:
+            # Rollback: stop all already-spawned actors
+            for addr in reversed(spawned_addrs):
+                try:
+                    addr.stop()
+                except Exception:
+                    logger.warning("Failed to stop actor during rollback: %s", addr)
+            raise
+
+    @staticmethod
+    def _spawn_member(
+        member: TeamCardMember,
+        actor_system: ActorSystem,
+        team_id: uuid.UUID,
+        spawned_addrs: list[ActorAddress],
+    ) -> dict[str, ActorAddress]:
+        """Spawn a member and its subordinates recursively.
+
+        Args:
+            member: The TeamCardMember to spawn.
+            actor_system: The actor system to host the actors.
+            team_id: Team identifier for all spawned actors.
+            spawned_addrs: Accumulator for rollback tracking.
+
+        Returns:
+            Dictionary mapping agent names to their spawned ActorAddresses.
+        """
+        result: dict[str, ActorAddress] = {}
+        agent_class: type[Akgent[Any, Any]] = member.card.get_agent_class()
+        name = member.card.config.name
+
+        if member.headcount == 1:
+            addr = actor_system.createActor(
+                agent_class,
+                config=member.card.get_config_copy(),
+                team_id=team_id,
+            )
+            spawned_addrs.append(addr)
+            result[name] = addr
+        else:
+            for i in range(member.headcount):
+                indexed_name = f"{name}_{i}"
+                config = member.card.get_config_copy()
+                config.name = indexed_name
+                addr = actor_system.createActor(
+                    agent_class,
+                    config=config,
+                    team_id=team_id,
+                )
+                spawned_addrs.append(addr)
+                result[indexed_name] = addr
+
+        # Recurse into subordinates
+        for child in member.members:
+            child_addrs = TeamFactory._spawn_member(
+                child, actor_system, team_id, spawned_addrs
+            )
+            result.update(child_addrs)
+
+        return result

--- a/tests/services/test_factory.py
+++ b/tests/services/test_factory.py
@@ -4,20 +4,19 @@ from __future__ import annotations
 
 import uuid
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
+from akgentic.core.actor_address import ActorAddress
 from akgentic.core.actor_system_impl import ActorSystem
 from akgentic.core.agent import Akgent
 from akgentic.core.agent_card import AgentCard
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.agent_state import BaseState
 from akgentic.core.messages.message import Message
-from akgentic.core.orchestrator import EventSubscriber, Orchestrator
 
 from akgentic.team.factory import TeamFactory
 from akgentic.team.models import TeamCard, TeamCardMember, TeamRuntime
-
 
 # ---------------------------------------------------------------------------
 # Test helpers
@@ -255,3 +254,20 @@ class TestTeamFactoryBuild:
         # lead has subordinates, so it's a supervisor
         assert "lead" in runtime.supervisor_addrs
         assert runtime.supervisor_addrs["lead"] == runtime.addrs["lead"]
+
+    def test_entry_point_headcount_gt1_raises(self, actor_system: ActorSystem) -> None:
+        """Entry point with headcount > 1 raises ValueError."""
+        ep = _make_member("lead", "Lead", headcount=2)
+        tc = _make_team_card(entry_point=ep)
+
+        with pytest.raises(ValueError, match="must have headcount=1"):
+            TeamFactory.build(tc, actor_system)
+
+    def test_rollback_handles_stop_failure(self, actor_system: ActorSystem) -> None:
+        """Rollback continues even if stopping an actor raises."""
+        failing = _make_member("failing", "Failing", agent_class=FailingAgent)
+        tc = _make_team_card(members=[failing])
+
+        with patch.object(ActorAddress, "stop", side_effect=RuntimeError("stop failed")):
+            with pytest.raises(RuntimeError, match="intentional error"):
+                TeamFactory.build(tc, actor_system)

--- a/tests/services/test_factory.py
+++ b/tests/services/test_factory.py
@@ -1,0 +1,257 @@
+"""Tests for TeamFactory.build — AC 1-10."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_card import AgentCard
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.agent_state import BaseState
+from akgentic.core.messages.message import Message
+from akgentic.core.orchestrator import EventSubscriber, Orchestrator
+
+from akgentic.team.factory import TeamFactory
+from akgentic.team.models import TeamCard, TeamCardMember, TeamRuntime
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class StubAgent(Akgent[BaseConfig, BaseState]):
+    """Minimal agent for factory tests."""
+
+    pass
+
+
+class FailingAgent(Akgent[BaseConfig, BaseState]):
+    """Agent that raises during __init__ for rollback tests."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        msg = "FailingAgent intentional error"
+        raise RuntimeError(msg)
+
+
+class StubSubscriber:
+    """Minimal EventSubscriber for testing."""
+
+    def __init__(self) -> None:
+        self.messages: list[Message] = []
+        self.stopped: bool = False
+
+    def on_stop(self) -> None:
+        self.stopped = True
+
+    def on_message(self, msg: Message) -> None:
+        self.messages.append(msg)
+
+
+def _make_card(
+    name: str,
+    role: str = "TestRole",
+    agent_class: type[Akgent[Any, Any]] = StubAgent,
+    routes_to: list[str] | None = None,
+) -> AgentCard:
+    return AgentCard(
+        role=role,
+        description=f"Test: {role}",
+        skills=["testing"],
+        agent_class=agent_class,
+        config=BaseConfig(name=name, role=role),
+        routes_to=routes_to or [],
+    )
+
+
+def _make_member(
+    name: str,
+    role: str = "TestRole",
+    agent_class: type[Akgent[Any, Any]] = StubAgent,
+    headcount: int = 1,
+    members: list[TeamCardMember] | None = None,
+    routes_to: list[str] | None = None,
+) -> TeamCardMember:
+    return TeamCardMember(
+        card=_make_card(name, role, agent_class, routes_to),
+        headcount=headcount,
+        members=members or [],
+    )
+
+
+def _make_team_card(
+    entry_point: TeamCardMember | None = None,
+    members: list[TeamCardMember] | None = None,
+    name: str = "test-team",
+) -> TeamCard:
+    ep = entry_point or _make_member("lead", "Lead")
+    return TeamCard(
+        name=name,
+        description="Test team",
+        entry_point=ep,
+        members=members or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def actor_system() -> ActorSystem:  # type: ignore[misc]
+    system = ActorSystem()
+    yield system  # type: ignore[misc]
+    system.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTeamFactoryBuild:
+    """AC 1-8: TeamFactory.build creates a running team from a TeamCard."""
+
+    # -- 3.1: Successful build with single agent -------------------------
+
+    def test_build_single_agent(self, actor_system: ActorSystem) -> None:
+        """AC 1,7: Build returns TeamRuntime with orchestrator, entry, addrs."""
+        tc = _make_team_card()
+        runtime = TeamFactory.build(tc, actor_system)
+
+        assert isinstance(runtime, TeamRuntime)
+        assert isinstance(runtime.id, uuid.UUID)
+        assert runtime.orchestrator_addr is not None
+        assert runtime.entry_addr is not None
+        assert "lead" in runtime.addrs
+        assert runtime.orchestrator_addr.is_alive()
+        assert runtime.entry_addr.is_alive()
+
+    # -- 3.2: Successful build with multiple agents (hierarchical) -------
+
+    def test_build_hierarchical_team(self, actor_system: ActorSystem) -> None:
+        """AC 2: All agents in TeamCard member tree are spawned."""
+        worker = _make_member("worker", "Worker")
+        supervisor = _make_member("supervisor", "Supervisor", members=[worker])
+        tc = _make_team_card(members=[supervisor])
+
+        runtime = TeamFactory.build(tc, actor_system)
+
+        assert "lead" in runtime.addrs
+        assert "supervisor" in runtime.addrs
+        assert "worker" in runtime.addrs
+        assert len(runtime.addrs) == 3
+        for addr in runtime.addrs.values():
+            assert addr.is_alive()
+
+    # -- 3.3: Headcount > 1 spawns multiple instances --------------------
+
+    def test_headcount_multiple_instances(self, actor_system: ActorSystem) -> None:
+        """AC 3: Headcount > 1 spawns multiple actor instances."""
+        multi = _make_member("worker", "Worker", headcount=3)
+        tc = _make_team_card(members=[multi])
+
+        runtime = TeamFactory.build(tc, actor_system)
+
+        assert "worker_0" in runtime.addrs
+        assert "worker_1" in runtime.addrs
+        assert "worker_2" in runtime.addrs
+        assert "worker" not in runtime.addrs
+        # lead + 3 workers = 4
+        assert len(runtime.addrs) == 4
+
+    # -- 3.4: Subscriber registration -----------------------------------
+
+    def test_subscriber_registration(self, actor_system: ActorSystem) -> None:
+        """AC 5: Provided subscribers are registered with the orchestrator."""
+        sub = StubSubscriber()
+        tc = _make_team_card()
+
+        runtime = TeamFactory.build(tc, actor_system, subscribers=[sub])
+
+        # Verify subscriber is registered by stopping the orchestrator,
+        # which calls on_stop on all subscribers.
+        runtime.orchestrator_addr.stop()
+        assert sub.stopped is True
+
+    # -- 3.5: routes_to wiring ------------------------------------------
+
+    def test_routes_to_registered(self, actor_system: ActorSystem) -> None:
+        """AC 4,6: Agent profiles with routes_to are registered with orchestrator."""
+        worker = _make_member("worker", "Worker")
+        ep = _make_member("lead", "Lead", routes_to=["Worker"])
+        tc = _make_team_card(entry_point=ep, members=[worker])
+
+        runtime = TeamFactory.build(tc, actor_system)
+
+        # Verify agent profiles are registered
+        catalog = runtime.orchestrator_proxy.get_agent_catalog()
+        roles = {c.role for c in catalog}
+        assert "Lead" in roles
+        assert "Worker" in roles
+
+        # Verify routes_to is preserved
+        lead_card = next(c for c in catalog if c.role == "Lead")
+        assert "Worker" in lead_card.routes_to
+
+    # -- 3.6: Partial failure rollback -----------------------------------
+
+    def test_partial_failure_rollback(self, actor_system: ActorSystem) -> None:
+        """AC 8: Partial failure tears down already-spawned actors."""
+        # FailingAgent will raise on start -- this should trigger rollback
+        failing = _make_member("failing", "Failing", agent_class=FailingAgent)
+        tc = _make_team_card(members=[failing])
+
+        with pytest.raises(Exception):
+            TeamFactory.build(tc, actor_system)
+
+    # -- 3.7: TeamRuntime.id equals orchestrator's team_id ---------------
+
+    def test_runtime_id_is_team_id(self, actor_system: ActorSystem) -> None:
+        """AC 7: TeamRuntime.id is the team_id assigned to all actors."""
+        tc = _make_team_card()
+        runtime = TeamFactory.build(tc, actor_system)
+
+        # The orchestrator's team_id should match runtime.id
+        assert runtime.orchestrator_addr.team_id == runtime.id
+        assert runtime.entry_addr.team_id == runtime.id
+
+    # -- 3.8: Agent profiles registered with orchestrator ----------------
+
+    def test_agent_profiles_registered(self, actor_system: ActorSystem) -> None:
+        """AC 6: orchestrator.get_agent_catalog() returns all agent cards."""
+        worker = _make_member("worker", "Worker")
+        tc = _make_team_card(members=[worker])
+
+        runtime = TeamFactory.build(tc, actor_system)
+
+        catalog = runtime.orchestrator_proxy.get_agent_catalog()
+        roles = {c.role for c in catalog}
+        assert "Lead" in roles
+        assert "Worker" in roles
+        assert len(catalog) == 2
+
+    # -- Additional edge-case tests --------------------------------------
+
+    def test_build_with_no_subscribers(self, actor_system: ActorSystem) -> None:
+        """Build works when subscribers is None."""
+        tc = _make_team_card()
+        runtime = TeamFactory.build(tc, actor_system, subscribers=None)
+        assert runtime.orchestrator_addr.is_alive()
+
+    def test_supervisor_addrs_populated(self, actor_system: ActorSystem) -> None:
+        """Supervisor addresses are populated for members with subordinates."""
+        worker = _make_member("worker", "Worker")
+        ep = _make_member("lead", "Lead", members=[worker])
+        tc = _make_team_card(entry_point=ep)
+
+        runtime = TeamFactory.build(tc, actor_system)
+
+        # lead has subordinates, so it's a supervisor
+        assert "lead" in runtime.supervisor_addrs
+        assert runtime.supervisor_addrs["lead"] == runtime.addrs["lead"]


### PR DESCRIPTION
## Summary

- Implement `TeamFactory.build()` static method that creates an Orchestrator, spawns all agents from a TeamCard member tree, registers subscribers and agent profiles, and returns a running `TeamRuntime`
- Rollback on partial failure tears down all already-spawned actors
- Entry point headcount validated to be exactly 1
- 12 tests covering all acceptance criteria including edge cases

Closes #13