### PR TITLE
PersistenceSubscriber with Live Event Sourcing

### DIFF
--- a/src/akgentic/team/__init__.py
+++ b/src/akgentic/team/__init__.py
@@ -21,6 +21,7 @@ from akgentic.team.ports import (
     NullServiceRegistry,
     ServiceRegistry,
 )
+from akgentic.team.subscriber import PersistenceSubscriber
 
 __version__ = "1.0.0-alpha.1"
 
@@ -29,6 +30,7 @@ __all__: list[str] = [
     "AgentStateSnapshot",
     "EventStore",
     "NullServiceRegistry",
+    "PersistenceSubscriber",
     "PersistedEvent",
     "Process",
     "ServiceRegistry",

--- a/src/akgentic/team/subscriber.py
+++ b/src/akgentic/team/subscriber.py
@@ -51,21 +51,21 @@ class PersistenceSubscriber(EventSubscriber):
             return
 
         self._sequence += 1
+        now = datetime.now(UTC)
         event = PersistedEvent(
             team_id=self._team_id,
             sequence=self._sequence,
             event=msg,
-            timestamp=datetime.now(UTC),
+            timestamp=now,
         )
         self._event_store.save_event(event)
 
-        if isinstance(msg, StateChangedMessage):
-            agent_id = msg.sender.name  # type: ignore[union-attr]
+        if isinstance(msg, StateChangedMessage) and msg.sender is not None:
             snapshot = AgentStateSnapshot(
                 team_id=self._team_id,
-                agent_id=agent_id,
+                agent_id=msg.sender.name,
                 state=msg.state.serializable_copy(),
-                updated_at=datetime.now(UTC),
+                updated_at=now,
             )
             self._event_store.save_agent_state(snapshot)
 

--- a/src/akgentic/team/subscriber.py
+++ b/src/akgentic/team/subscriber.py
@@ -1,3 +1,82 @@
 """PersistenceSubscriber: EventSubscriber to EventStore bridge for live event sourcing."""
 
 from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from akgentic.core.messages.message import Message
+from akgentic.core.messages.orchestrator import StateChangedMessage
+from akgentic.core.orchestrator import EventSubscriber
+from akgentic.team.models import AgentStateSnapshot, PersistedEvent
+from akgentic.team.ports import EventStore
+
+
+class PersistenceSubscriber(EventSubscriber):
+    """Bridges EventSubscriber (akgentic-core) with EventStore (akgentic-team).
+
+    Receives all messages from the orchestrator and persists:
+    1. Every message as an append-only event (for replay on resume)
+    2. Agent state snapshots on StateChangedMessage (for fast restore)
+
+    LLM conversation history is NOT persisted separately -- it is
+    reconstructed from the event log during restore.
+
+    All types used here come from akgentic-core (Message, StateChangedMessage,
+    BaseState) -- no imports from akgentic-llm or akgentic-agent needed.
+    """
+
+    def __init__(self, team_id: uuid.UUID, event_store: EventStore) -> None:
+        """Initialize the persistence subscriber.
+
+        Args:
+            team_id: Unique identifier of the team whose events are persisted.
+            event_store: Storage backend for events and agent state snapshots.
+        """
+        self._team_id = team_id
+        self._event_store = event_store
+        self._sequence = 0
+        self._restoring = False
+
+    def on_message(self, msg: Message) -> None:
+        """Persist a message as a PersistedEvent and optionally save agent state.
+
+        If the restoring flag is True, skips all persistence to avoid duplicate
+        writes during event replay.
+
+        Args:
+            msg: The message flowing through the orchestrator.
+        """
+        if self._restoring:
+            return
+
+        self._sequence += 1
+        event = PersistedEvent(
+            team_id=self._team_id,
+            sequence=self._sequence,
+            event=msg,
+            timestamp=datetime.now(UTC),
+        )
+        self._event_store.save_event(event)
+
+        if isinstance(msg, StateChangedMessage):
+            agent_id = msg.sender.name  # type: ignore[union-attr]
+            snapshot = AgentStateSnapshot(
+                team_id=self._team_id,
+                agent_id=agent_id,
+                state=msg.state.serializable_copy(),
+                updated_at=datetime.now(UTC),
+            )
+            self._event_store.save_agent_state(snapshot)
+
+    def set_restoring(self, restoring: bool) -> None:
+        """Set the restoring flag to skip or resume persistence.
+
+        Args:
+            restoring: If True, on_message will skip all persistence.
+        """
+        self._restoring = restoring
+
+    def on_stop(self) -> None:
+        """No-op: required by EventSubscriber protocol."""
+        pass

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -1,3 +1,51 @@
 """Test fixtures for team service tests."""
 
 from __future__ import annotations
+
+import uuid
+
+from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process
+
+
+class InMemoryEventStore:
+    """Dict-backed EventStore for test isolation.
+
+    Satisfies the EventStore protocol via structural subtyping.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[PersistedEvent] = []
+        self.teams: dict[uuid.UUID, Process] = {}
+        self.agent_states: dict[tuple[uuid.UUID, str], AgentStateSnapshot] = {}
+
+    def save_event(self, event: PersistedEvent) -> None:
+        """Persist a single domain event."""
+        self.events.append(event)
+
+    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
+        """Load all persisted events for a team."""
+        return [e for e in self.events if e.team_id == team_id]
+
+    def save_team(self, process: Process) -> None:
+        """Persist team process snapshot."""
+        self.teams[process.team_id] = process
+
+    def load_team(self, team_id: uuid.UUID) -> Process | None:
+        """Load a team process snapshot by ID."""
+        return self.teams.get(team_id)
+
+    def delete_team(self, team_id: uuid.UUID) -> None:
+        """Delete all persisted data for a team."""
+        self.teams.pop(team_id, None)
+        self.events = [e for e in self.events if e.team_id != team_id]
+        self.agent_states = {
+            k: v for k, v in self.agent_states.items() if k[0] != team_id
+        }
+
+    def save_agent_state(self, snapshot: AgentStateSnapshot) -> None:
+        """Persist an agent state snapshot."""
+        self.agent_states[(snapshot.team_id, snapshot.agent_id)] = snapshot
+
+    def load_agent_states(self, team_id: uuid.UUID) -> list[AgentStateSnapshot]:
+        """Load all agent state snapshots for a team."""
+        return [v for k, v in self.agent_states.items() if k[0] == team_id]

--- a/tests/services/test_subscriber.py
+++ b/tests/services/test_subscriber.py
@@ -1,0 +1,131 @@
+"""Tests for PersistenceSubscriber — AC 1-7."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.messages.message import UserMessage
+from akgentic.core.messages.orchestrator import StateChangedMessage
+from akgentic.core.orchestrator import EventSubscriber
+
+from akgentic.team.models import AgentStateSnapshot, PersistedEvent
+from akgentic.team.subscriber import PersistenceSubscriber
+
+from tests.models.conftest import SampleAgentState
+from tests.services.conftest import InMemoryEventStore
+
+
+class TestPersistenceSubscriber:
+    """AC 1-7: PersistenceSubscriber persists events and state snapshots."""
+
+    def _make_subscriber(
+        self,
+    ) -> tuple[PersistenceSubscriber, InMemoryEventStore, uuid.UUID]:
+        """Create a PersistenceSubscriber with an InMemoryEventStore."""
+        team_id = uuid.uuid4()
+        store = InMemoryEventStore()
+        sub = PersistenceSubscriber(team_id=team_id, event_store=store)
+        return sub, store, team_id
+
+    # -- 3.2: Event persistence on normal message --------------------------
+
+    def test_event_persistence_on_user_message(self) -> None:
+        """AC 1: UserMessage produces one PersistedEvent with correct fields."""
+        sub, store, team_id = self._make_subscriber()
+        msg = UserMessage(content="hello")
+
+        sub.on_message(msg)
+
+        assert len(store.events) == 1
+        event = store.events[0]
+        assert isinstance(event, PersistedEvent)
+        assert event.team_id == team_id
+        assert event.sequence == 1
+        assert event.event == msg
+        assert event.timestamp is not None
+
+    # -- 3.3: Sequence numbering -------------------------------------------
+
+    def test_sequence_increments_monotonically(self) -> None:
+        """AC 1: Sequence numbers increment 1, 2, 3 across messages."""
+        sub, store, _team_id = self._make_subscriber()
+
+        sub.on_message(UserMessage(content="first"))
+        sub.on_message(UserMessage(content="second"))
+        sub.on_message(UserMessage(content="third"))
+
+        sequences = [e.sequence for e in store.events]
+        assert sequences == [1, 2, 3]
+
+    # -- 3.4: Agent state snapshot on StateChangedMessage ------------------
+
+    def test_state_snapshot_on_state_changed_message(self) -> None:
+        """AC 2: StateChangedMessage triggers both save_event and save_agent_state."""
+        sub, store, team_id = self._make_subscriber()
+
+        sender = MagicMock(spec=ActorAddress)
+        sender.name = "worker-agent"
+        state = SampleAgentState(task_count=5)
+        msg = StateChangedMessage(sender=sender, state=state)
+
+        sub.on_message(msg)
+
+        # Event saved
+        assert len(store.events) == 1
+        assert store.events[0].event == msg
+
+        # Agent state snapshot saved
+        key = (team_id, "worker-agent")
+        assert key in store.agent_states
+        snapshot = store.agent_states[key]
+        assert isinstance(snapshot, AgentStateSnapshot)
+        assert snapshot.team_id == team_id
+        assert snapshot.agent_id == "worker-agent"
+        assert snapshot.updated_at is not None
+
+    # -- 3.5: Restoring flag -----------------------------------------------
+
+    def test_restoring_flag_skips_persistence(self) -> None:
+        """AC 4: set_restoring(True) skips all persistence."""
+        sub, store, _team_id = self._make_subscriber()
+
+        sub.set_restoring(True)
+        sub.on_message(UserMessage(content="ignored"))
+        sub.on_message(UserMessage(content="also ignored"))
+
+        assert len(store.events) == 0
+        assert len(store.agent_states) == 0
+
+    def test_restoring_flag_resumes_with_correct_sequence(self) -> None:
+        """AC 4: After set_restoring(False), persistence resumes with correct sequence."""
+        sub, store, _team_id = self._make_subscriber()
+
+        # Send one message normally
+        sub.on_message(UserMessage(content="first"))
+        assert store.events[0].sequence == 1
+
+        # Enable restoring, send messages
+        sub.set_restoring(True)
+        sub.on_message(UserMessage(content="skipped"))
+
+        # Disable restoring, send message — sequence continues
+        sub.set_restoring(False)
+        sub.on_message(UserMessage(content="resumed"))
+
+        assert len(store.events) == 2
+        assert store.events[1].sequence == 2
+
+    # -- 3.6: on_stop is callable (no-op) ----------------------------------
+
+    def test_on_stop_is_callable(self) -> None:
+        """AC 3: on_stop exists and does not raise."""
+        sub, _store, _team_id = self._make_subscriber()
+        sub.on_stop()  # Should not raise
+
+    # -- 3.7: Explicit inheritance from EventSubscriber --------------------
+
+    def test_is_instance_of_event_subscriber(self) -> None:
+        """AC 3: PersistenceSubscriber explicitly inherits from EventSubscriber."""
+        assert EventSubscriber in PersistenceSubscriber.__mro__

--- a/tests/services/test_subscriber.py
+++ b/tests/services/test_subscriber.py
@@ -12,7 +12,6 @@ from akgentic.core.orchestrator import EventSubscriber
 
 from akgentic.team.models import AgentStateSnapshot, PersistedEvent
 from akgentic.team.subscriber import PersistenceSubscriber
-
 from tests.models.conftest import SampleAgentState
 from tests.services.conftest import InMemoryEventStore
 
@@ -84,6 +83,20 @@ class TestPersistenceSubscriber:
         assert snapshot.team_id == team_id
         assert snapshot.agent_id == "worker-agent"
         assert snapshot.updated_at is not None
+        assert isinstance(snapshot.state, SampleAgentState)
+        assert snapshot.state.task_count == 5
+
+    def test_state_changed_message_with_none_sender_skips_snapshot(self) -> None:
+        """AC 2: StateChangedMessage with sender=None saves event but no snapshot."""
+        sub, store, _team_id = self._make_subscriber()
+
+        state = SampleAgentState(task_count=3)
+        msg = StateChangedMessage(sender=None, state=state)
+
+        sub.on_message(msg)
+
+        assert len(store.events) == 1
+        assert len(store.agent_states) == 0
 
     # -- 3.5: Restoring flag -----------------------------------------------
 
@@ -120,7 +133,7 @@ class TestPersistenceSubscriber:
     # -- 3.6: on_stop is callable (no-op) ----------------------------------
 
     def test_on_stop_is_callable(self) -> None:
-        """AC 3: on_stop exists and does not raise."""
+        """Task 1.5: on_stop exists and does not raise."""
         sub, _store, _team_id = self._make_subscriber()
         sub.on_stop()  # Should not raise
 


### PR DESCRIPTION
## Summary

- Implements `PersistenceSubscriber` that bridges `EventSubscriber` (akgentic-core) with `EventStore` (akgentic-team) for real-time event sourcing
- Persists every orchestrator message as a `PersistedEvent` with incrementing sequence numbers and UTC timestamps
- Additionally saves `AgentStateSnapshot` on `StateChangedMessage` for fast agent state recovery
- Supports `set_restoring(bool)` to skip persistence during event replay (crash recovery)
- Exports `PersistenceSubscriber` from package `__init__.py` and `__all__`
- 8 tests covering all acceptance criteria including null sender edge case

## Code Review Fixes Applied

| Severity | Issue | Fix |
|----------|-------|-----|
| HIGH | `msg.sender.name` crashes when sender is None | Added null guard: `if msg.sender is not None` |
| MEDIUM | Two `datetime.now(UTC)` calls per StateChangedMessage | Single `now` variable reused for event and snapshot |
| MEDIUM | Test missing assertion on snapshot state content | Added `snapshot.state.task_count == 5` assertion |
| MEDIUM | No test for None sender edge case | Added `test_state_changed_message_with_none_sender_skips_snapshot` |
| LOW | Test docstring references wrong AC | Fixed `on_stop` test to reference Task 1.5 |

Closes #15