### PR TITLE
YamlEventStore — file-based persistence

### DIFF
--- a/src/akgentic/team/__init__.py
+++ b/src/akgentic/team/__init__.py
@@ -21,6 +21,7 @@ from akgentic.team.ports import (
     NullServiceRegistry,
     ServiceRegistry,
 )
+from akgentic.team.repositories import YamlEventStore
 from akgentic.team.subscriber import PersistenceSubscriber
 
 __version__ = "1.0.0-alpha.1"
@@ -39,4 +40,5 @@ __all__: list[str] = [
     "TeamFactory",
     "TeamRuntime",
     "TeamStatus",
+    "YamlEventStore",
 ]

--- a/src/akgentic/team/repositories/__init__.py
+++ b/src/akgentic/team/repositories/__init__.py
@@ -1,3 +1,9 @@
 """EventStore implementations: YAML (default) and MongoDB (optional)."""
 
 from __future__ import annotations
+
+from akgentic.team.repositories.yaml import YamlEventStore
+
+__all__: list[str] = [
+    "YamlEventStore",
+]

--- a/src/akgentic/team/repositories/yaml.py
+++ b/src/akgentic/team/repositories/yaml.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import shutil
+import tempfile
 import uuid
 from pathlib import Path
 
@@ -42,6 +43,25 @@ class YamlEventStore:
     def __init__(self, data_dir: Path) -> None:
         self._data_dir = data_dir
 
+    @staticmethod
+    def _atomic_write(path: Path, data: dict[str, object]) -> None:
+        """Write YAML data atomically using write-to-temp-then-rename.
+
+        Prevents corrupted partial files if the process crashes mid-write.
+
+        Args:
+            path: Destination file path.
+            data: Dictionary to serialize as YAML.
+        """
+        fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+        try:
+            with open(fd, "w") as f:
+                yaml.dump(data, f, default_flow_style=False)
+            Path(tmp).replace(path)
+        except BaseException:
+            Path(tmp).unlink(missing_ok=True)
+            raise
+
     def _team_dir(self, team_id: uuid.UUID) -> Path:
         """Return the directory path for a specific team.
 
@@ -65,9 +85,7 @@ class YamlEventStore:
         team_dir = self._team_dir(process.team_id)
         team_dir.mkdir(parents=True, exist_ok=True)
         team_path = team_dir / "team.yaml"
-        data = process.model_dump()
-        with open(team_path, "w") as f:
-            yaml.dump(data, f, default_flow_style=False)
+        self._atomic_write(team_path, process.model_dump())
         logger.debug("Saved team %s to %s", process.team_id, team_path)
 
     def load_team(self, team_id: uuid.UUID) -> Process | None:
@@ -82,9 +100,15 @@ class YamlEventStore:
         team_path = self._team_dir(team_id) / "team.yaml"
         if not team_path.exists():
             return None
-        with open(team_path) as f:
-            data = yaml.safe_load(f)
-        return Process.model_validate(data)
+        try:
+            with open(team_path) as f:
+                data = yaml.safe_load(f)
+            process = Process.model_validate(data)
+        except (yaml.YAMLError, ValueError) as exc:
+            logger.error("Corrupted team.yaml for team %s: %s", team_id, exc)
+            return None
+        logger.debug("Loaded team %s from %s", team_id, team_path)
+        return process
 
     def save_event(self, event: PersistedEvent) -> None:
         """Append a persisted event to events.yaml.
@@ -120,9 +144,23 @@ class YamlEventStore:
         events_path = self._team_dir(team_id) / "events.yaml"
         if not events_path.exists():
             return []
-        with open(events_path) as f:
-            docs = list(yaml.safe_load_all(f))
-        events = [PersistedEvent.model_validate(doc) for doc in docs if doc is not None]
+        try:
+            with open(events_path) as f:
+                docs = list(yaml.safe_load_all(f))
+        except yaml.YAMLError as exc:
+            logger.error("Corrupted events.yaml for team %s: %s", team_id, exc)
+            return []
+        events: list[PersistedEvent] = []
+        for doc in docs:
+            if doc is None:
+                continue
+            try:
+                events.append(PersistedEvent.model_validate(doc))
+            except ValueError as exc:
+                logger.warning(
+                    "Skipping corrupted event for team %s: %s", team_id, exc
+                )
+        logger.debug("Loaded %d events for team %s", len(events), team_id)
         return sorted(events, key=lambda e: e.sequence)
 
     def save_agent_state(self, snapshot: AgentStateSnapshot) -> None:
@@ -137,9 +175,7 @@ class YamlEventStore:
         states_dir = self._team_dir(snapshot.team_id) / "states"
         states_dir.mkdir(parents=True, exist_ok=True)
         state_path = states_dir / f"{snapshot.agent_id}.yaml"
-        data = snapshot.model_dump()
-        with open(state_path, "w") as f:
-            yaml.dump(data, f, default_flow_style=False)
+        self._atomic_write(state_path, snapshot.model_dump())
         logger.debug(
             "Saved agent state %s for team %s", snapshot.agent_id, snapshot.team_id
         )
@@ -159,9 +195,18 @@ class YamlEventStore:
             return []
         snapshots: list[AgentStateSnapshot] = []
         for state_path in sorted(states_dir.glob("*.yaml")):
-            with open(state_path) as f:
-                data = yaml.safe_load(f)
-            snapshots.append(AgentStateSnapshot.model_validate(data))
+            try:
+                with open(state_path) as f:
+                    data = yaml.safe_load(f)
+                snapshots.append(AgentStateSnapshot.model_validate(data))
+            except (yaml.YAMLError, ValueError) as exc:
+                logger.warning(
+                    "Skipping corrupted state file %s for team %s: %s",
+                    state_path.name,
+                    team_id,
+                    exc,
+                )
+        logger.debug("Loaded %d agent states for team %s", len(snapshots), team_id)
         return snapshots
 
     def delete_team(self, team_id: uuid.UUID) -> None:

--- a/src/akgentic/team/repositories/yaml.py
+++ b/src/akgentic/team/repositories/yaml.py
@@ -1,3 +1,179 @@
-"""YamlEventStore: file-based EventStore with per-team directory layout."""
+"""YamlEventStore: file-based EventStore with per-team directory layout.
+
+Persists team data to YAML files in a per-team directory structure using
+PyYAML for serialization and pathlib for filesystem operations. Satisfies
+the EventStore protocol via structural subtyping (no explicit inheritance).
+
+File layout per team::
+
+    {data_dir}/
+      {team_uuid}/
+        team.yaml           # Process metadata (overwrite)
+        events.yaml         # Append-only event log (multi-document YAML)
+        states/
+          {agent_id}.yaml   # Latest agent state snapshot (overwrite)
+"""
 
 from __future__ import annotations
+
+import logging
+import shutil
+import uuid
+from pathlib import Path
+
+import yaml
+
+from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process
+
+logger = logging.getLogger(__name__)
+
+
+class YamlEventStore:
+    """File-based EventStore using YAML serialization with per-team directories.
+
+    Satisfies the ``EventStore`` protocol via structural subtyping without
+    inheriting from it. All filesystem directories are created on demand
+    (not eagerly at instantiation time).
+
+    Args:
+        data_dir: Root directory for all persisted team data.
+    """
+
+    def __init__(self, data_dir: Path) -> None:
+        self._data_dir = data_dir
+
+    def _team_dir(self, team_id: uuid.UUID) -> Path:
+        """Return the directory path for a specific team.
+
+        Args:
+            team_id: Unique identifier of the team.
+
+        Returns:
+            Path to the team's directory under the data root.
+        """
+        return self._data_dir / str(team_id)
+
+    def save_team(self, process: Process) -> None:
+        """Persist a team process snapshot to team.yaml.
+
+        Creates the team directory if it does not exist, then writes
+        (or overwrites) the serialized Process to ``team.yaml``.
+
+        Args:
+            process: The team process snapshot to persist.
+        """
+        team_dir = self._team_dir(process.team_id)
+        team_dir.mkdir(parents=True, exist_ok=True)
+        team_path = team_dir / "team.yaml"
+        data = process.model_dump()
+        with open(team_path, "w") as f:
+            yaml.dump(data, f, default_flow_style=False)
+        logger.debug("Saved team %s to %s", process.team_id, team_path)
+
+    def load_team(self, team_id: uuid.UUID) -> Process | None:
+        """Load a team process snapshot from team.yaml.
+
+        Args:
+            team_id: Unique identifier of the team.
+
+        Returns:
+            The deserialized Process, or None if no team.yaml exists.
+        """
+        team_path = self._team_dir(team_id) / "team.yaml"
+        if not team_path.exists():
+            return None
+        with open(team_path) as f:
+            data = yaml.safe_load(f)
+        return Process.model_validate(data)
+
+    def save_event(self, event: PersistedEvent) -> None:
+        """Append a persisted event to events.yaml.
+
+        Uses multi-document YAML format (documents separated by ``---``)
+        for append-only semantics. Creates the team directory if needed.
+
+        Args:
+            event: The event to append.
+        """
+        team_dir = self._team_dir(event.team_id)
+        team_dir.mkdir(parents=True, exist_ok=True)
+        events_path = team_dir / "events.yaml"
+        data = event.model_dump()
+        with open(events_path, "a") as f:
+            f.write("---\n")
+            yaml.dump(data, f, default_flow_style=False)
+        logger.debug("Appended event seq=%d for team %s", event.sequence, event.team_id)
+
+    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
+        """Load all persisted events for a team from events.yaml.
+
+        Reads multi-document YAML and reconstructs each document as a
+        PersistedEvent, returned sorted by sequence number.
+
+        Args:
+            team_id: Unique identifier of the team.
+
+        Returns:
+            List of PersistedEvent ordered by sequence, or empty list if
+            no events file exists.
+        """
+        events_path = self._team_dir(team_id) / "events.yaml"
+        if not events_path.exists():
+            return []
+        with open(events_path) as f:
+            docs = list(yaml.safe_load_all(f))
+        events = [PersistedEvent.model_validate(doc) for doc in docs if doc is not None]
+        return sorted(events, key=lambda e: e.sequence)
+
+    def save_agent_state(self, snapshot: AgentStateSnapshot) -> None:
+        """Persist an agent state snapshot to states/{agent_id}.yaml.
+
+        Creates the states directory if it does not exist, then writes
+        (or overwrites) the serialized snapshot.
+
+        Args:
+            snapshot: The agent state snapshot to persist.
+        """
+        states_dir = self._team_dir(snapshot.team_id) / "states"
+        states_dir.mkdir(parents=True, exist_ok=True)
+        state_path = states_dir / f"{snapshot.agent_id}.yaml"
+        data = snapshot.model_dump()
+        with open(state_path, "w") as f:
+            yaml.dump(data, f, default_flow_style=False)
+        logger.debug(
+            "Saved agent state %s for team %s", snapshot.agent_id, snapshot.team_id
+        )
+
+    def load_agent_states(self, team_id: uuid.UUID) -> list[AgentStateSnapshot]:
+        """Load all agent state snapshots for a team from states/ directory.
+
+        Args:
+            team_id: Unique identifier of the team.
+
+        Returns:
+            List of AgentStateSnapshot, or empty list if no states
+            directory exists.
+        """
+        states_dir = self._team_dir(team_id) / "states"
+        if not states_dir.exists():
+            return []
+        snapshots: list[AgentStateSnapshot] = []
+        for state_path in sorted(states_dir.glob("*.yaml")):
+            with open(state_path) as f:
+                data = yaml.safe_load(f)
+            snapshots.append(AgentStateSnapshot.model_validate(data))
+        return snapshots
+
+    def delete_team(self, team_id: uuid.UUID) -> None:
+        """Delete all persisted data for a team.
+
+        Removes the entire team directory and all contents. If the directory
+        does not exist, this is a no-op (no error raised).
+
+        Args:
+            team_id: Unique identifier of the team to delete.
+        """
+        team_dir = self._team_dir(team_id)
+        if team_dir.exists():
+            shutil.rmtree(team_dir)
+            logger.debug("Deleted team directory %s", team_dir)

--- a/tests/repositories/test_yaml.py
+++ b/tests/repositories/test_yaml.py
@@ -10,12 +10,16 @@ from __future__ import annotations
 
 import uuid
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
-
 from akgentic.core.messages.message import UserMessage
+
 from akgentic.team.models import TeamStatus
 from akgentic.team.repositories.yaml import YamlEventStore
+
+if TYPE_CHECKING:
+    from akgentic.team.ports import EventStore
 
 from tests.models.conftest import (
     SampleAgentState,
@@ -201,6 +205,13 @@ class TestYamlEventStore:
         assert isinstance(loaded[0].state, SampleAgentState)
         assert loaded[0].state.task_count == 5
 
+    # --- Protocol compliance ---
+
+    def test_satisfies_event_store_protocol(self, tmp_path: Path) -> None:
+        """AC9: YamlEventStore satisfies EventStore Protocol via structural subtyping."""
+        store: EventStore = YamlEventStore(tmp_path)
+        assert store is not None
+
     # --- Directory creation ---
 
     def test_directory_creation_is_automatic(
@@ -214,3 +225,37 @@ class TestYamlEventStore:
 
         loaded = yaml_store.load_events(team_id)
         assert len(loaded) == 1
+
+    # --- Corrupted data resilience ---
+
+    def test_load_team_returns_none_for_corrupted_yaml(self, tmp_path: Path) -> None:
+        """Corrupted team.yaml returns None instead of raising."""
+        store = YamlEventStore(tmp_path)
+        team_id = uuid.uuid4()
+        team_dir = tmp_path / str(team_id)
+        team_dir.mkdir()
+        (team_dir / "team.yaml").write_text("{{invalid: yaml: [}")
+        assert store.load_team(team_id) is None
+
+    def test_load_events_returns_empty_for_corrupted_yaml(self, tmp_path: Path) -> None:
+        """Corrupted events.yaml returns empty list instead of raising."""
+        store = YamlEventStore(tmp_path)
+        team_id = uuid.uuid4()
+        team_dir = tmp_path / str(team_id)
+        team_dir.mkdir()
+        (team_dir / "events.yaml").write_text("{{invalid: yaml: [}")
+        assert store.load_events(team_id) == []
+
+    def test_load_agent_states_skips_corrupted_files(self, tmp_path: Path) -> None:
+        """Corrupted state file is skipped; valid ones are still loaded."""
+        store = YamlEventStore(tmp_path)
+        team_id = uuid.uuid4()
+        # Save a valid state first
+        snap = make_agent_state_snapshot(team_id=team_id, agent_id="good-agent")
+        store.save_agent_state(snap)
+        # Write a corrupted state file
+        states_dir = tmp_path / str(team_id) / "states"
+        (states_dir / "bad-agent.yaml").write_text("{{invalid: yaml: [}")
+        loaded = store.load_agent_states(team_id)
+        assert len(loaded) == 1
+        assert loaded[0].agent_id == "good-agent"

--- a/tests/repositories/test_yaml.py
+++ b/tests/repositories/test_yaml.py
@@ -1,0 +1,216 @@
+"""Tests for YamlEventStore — file-based EventStore implementation.
+
+Validates all seven EventStore protocol methods including round-trip
+serialization of polymorphic Message and BaseState fields.
+
+Acceptance Criteria: AC1-AC12 from Story 2.3.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+from akgentic.core.messages.message import UserMessage
+from akgentic.team.models import TeamStatus
+from akgentic.team.repositories.yaml import YamlEventStore
+
+from tests.models.conftest import (
+    SampleAgentState,
+    make_agent_state_snapshot,
+    make_persisted_event,
+    make_process,
+)
+
+
+@pytest.fixture
+def yaml_store(tmp_path: Path) -> YamlEventStore:
+    """Create a YamlEventStore backed by a temporary directory."""
+    return YamlEventStore(tmp_path)
+
+
+class TestYamlEventStore:
+    """Tests for YamlEventStore covering all EventStore protocol methods (AC1-AC12)."""
+
+    # --- save_team / load_team ---
+
+    def test_save_and_load_team_round_trip(self, yaml_store: YamlEventStore) -> None:
+        """AC2, AC3: save_team writes team.yaml; load_team deserializes it back."""
+        process = make_process()
+        yaml_store.save_team(process)
+        loaded = yaml_store.load_team(process.team_id)
+
+        assert loaded is not None
+        assert loaded.team_id == process.team_id
+        assert loaded.status == process.status
+        assert loaded.team_card.name == process.team_card.name
+        assert loaded.created_at == process.created_at
+
+    def test_load_team_returns_none_for_nonexistent(
+        self, yaml_store: YamlEventStore
+    ) -> None:
+        """AC3: load_team returns None when no team.yaml exists."""
+        result = yaml_store.load_team(uuid.uuid4())
+        assert result is None
+
+    def test_save_team_overwrites_on_second_call(
+        self, yaml_store: YamlEventStore
+    ) -> None:
+        """AC2: save_team overwrites existing team.yaml on subsequent calls."""
+        process = make_process(status=TeamStatus.RUNNING)
+        yaml_store.save_team(process)
+
+        updated = make_process(team_id=process.team_id, status=TeamStatus.STOPPED)
+        yaml_store.save_team(updated)
+
+        loaded = yaml_store.load_team(process.team_id)
+        assert loaded is not None
+        assert loaded.status == TeamStatus.STOPPED
+
+    # --- save_event / load_events ---
+
+    def test_save_and_load_events_round_trip(
+        self, yaml_store: YamlEventStore
+    ) -> None:
+        """AC4, AC5: save_event appends; load_events returns ordered by sequence."""
+        team_id = uuid.uuid4()
+        events = [
+            make_persisted_event(team_id=team_id, sequence=3),
+            make_persisted_event(team_id=team_id, sequence=1),
+            make_persisted_event(team_id=team_id, sequence=2),
+        ]
+        for event in events:
+            yaml_store.save_event(event)
+
+        loaded = yaml_store.load_events(team_id)
+        assert len(loaded) == 3
+        assert [e.sequence for e in loaded] == [1, 2, 3]
+
+    def test_save_event_append_only(self, yaml_store: YamlEventStore) -> None:
+        """AC4: save_event appends without overwriting previous events."""
+        team_id = uuid.uuid4()
+        yaml_store.save_event(make_persisted_event(team_id=team_id, sequence=1))
+        yaml_store.save_event(make_persisted_event(team_id=team_id, sequence=2))
+
+        loaded = yaml_store.load_events(team_id)
+        assert len(loaded) == 2
+
+    def test_load_events_returns_empty_for_nonexistent(
+        self, yaml_store: YamlEventStore
+    ) -> None:
+        """AC5: load_events returns [] when no events.yaml exists."""
+        result = yaml_store.load_events(uuid.uuid4())
+        assert result == []
+
+    # --- save_agent_state / load_agent_states ---
+
+    def test_save_and_load_agent_states_round_trip(
+        self, yaml_store: YamlEventStore
+    ) -> None:
+        """AC6, AC7: save_agent_state writes; load_agent_states reads all."""
+        team_id = uuid.uuid4()
+        snap1 = make_agent_state_snapshot(team_id=team_id, agent_id="agent-a")
+        snap2 = make_agent_state_snapshot(team_id=team_id, agent_id="agent-b")
+        yaml_store.save_agent_state(snap1)
+        yaml_store.save_agent_state(snap2)
+
+        loaded = yaml_store.load_agent_states(team_id)
+        assert len(loaded) == 2
+        agent_ids = {s.agent_id for s in loaded}
+        assert agent_ids == {"agent-a", "agent-b"}
+
+    def test_save_agent_state_overwrites_for_same_agent(
+        self, yaml_store: YamlEventStore
+    ) -> None:
+        """AC6: save_agent_state overwrites for the same agent_id."""
+        team_id = uuid.uuid4()
+        snap1 = make_agent_state_snapshot(
+            team_id=team_id, agent_id="agent-a", state=SampleAgentState(task_count=1)
+        )
+        yaml_store.save_agent_state(snap1)
+
+        snap2 = make_agent_state_snapshot(
+            team_id=team_id, agent_id="agent-a", state=SampleAgentState(task_count=99)
+        )
+        yaml_store.save_agent_state(snap2)
+
+        loaded = yaml_store.load_agent_states(team_id)
+        assert len(loaded) == 1
+        assert isinstance(loaded[0].state, SampleAgentState)
+        assert loaded[0].state.task_count == 99
+
+    def test_load_agent_states_returns_empty_for_nonexistent(
+        self, yaml_store: YamlEventStore
+    ) -> None:
+        """AC7: load_agent_states returns [] when no states/ dir exists."""
+        result = yaml_store.load_agent_states(uuid.uuid4())
+        assert result == []
+
+    # --- delete_team ---
+
+    def test_delete_team_removes_directory_tree(
+        self, yaml_store: YamlEventStore
+    ) -> None:
+        """AC8: delete_team removes the entire team directory and all contents."""
+        process = make_process()
+        yaml_store.save_team(process)
+        yaml_store.save_event(make_persisted_event(team_id=process.team_id, sequence=1))
+        yaml_store.save_agent_state(
+            make_agent_state_snapshot(team_id=process.team_id, agent_id="a")
+        )
+
+        yaml_store.delete_team(process.team_id)
+
+        assert yaml_store.load_team(process.team_id) is None
+        assert yaml_store.load_events(process.team_id) == []
+        assert yaml_store.load_agent_states(process.team_id) == []
+
+    def test_delete_team_noop_for_nonexistent(
+        self, yaml_store: YamlEventStore
+    ) -> None:
+        """AC8: delete_team is a no-op for non-existent team (no error)."""
+        yaml_store.delete_team(uuid.uuid4())  # should not raise
+
+    # --- Polymorphic round-trip ---
+
+    def test_polymorphic_event_round_trip(self, yaml_store: YamlEventStore) -> None:
+        """AC11: PersistedEvent with UserMessage survives YAML round-trip."""
+        team_id = uuid.uuid4()
+        msg = UserMessage(content="hello from polymorphic test")
+        event = make_persisted_event(team_id=team_id, sequence=1, event=msg)
+        yaml_store.save_event(event)
+
+        loaded = yaml_store.load_events(team_id)
+        assert len(loaded) == 1
+        assert isinstance(loaded[0].event, UserMessage)
+        assert loaded[0].event.content == "hello from polymorphic test"
+
+    def test_polymorphic_agent_state_round_trip(
+        self, yaml_store: YamlEventStore
+    ) -> None:
+        """AC11: AgentStateSnapshot with SampleAgentState survives YAML round-trip."""
+        team_id = uuid.uuid4()
+        state = SampleAgentState(task_count=5)
+        snap = make_agent_state_snapshot(team_id=team_id, agent_id="poly-agent", state=state)
+        yaml_store.save_agent_state(snap)
+
+        loaded = yaml_store.load_agent_states(team_id)
+        assert len(loaded) == 1
+        assert isinstance(loaded[0].state, SampleAgentState)
+        assert loaded[0].state.task_count == 5
+
+    # --- Directory creation ---
+
+    def test_directory_creation_is_automatic(
+        self, yaml_store: YamlEventStore
+    ) -> None:
+        """AC10: Directories are created on demand, not eagerly."""
+        team_id = uuid.uuid4()
+        # Save event without pre-creating any dirs
+        event = make_persisted_event(team_id=team_id, sequence=1)
+        yaml_store.save_event(event)  # should not raise
+
+        loaded = yaml_store.load_events(team_id)
+        assert len(loaded) == 1


### PR DESCRIPTION
## Summary

- Implements `YamlEventStore` with all 7 `EventStore` protocol methods via structural subtyping (no inheritance)
- Per-team directory layout: `team.yaml` (overwrite), `events.yaml` (append-only multi-document YAML), `states/{agent_id}.yaml` (overwrite)
- Atomic writes for overwrite-strategy files prevent corruption on crash
- Error handling for corrupted YAML: graceful degradation with logging instead of exceptions
- 18 tests covering all protocol methods, polymorphic round-trips, edge cases, and corruption resilience

Closes #17