### PR TITLE
TeamManager with create, get, and state machine

### DIFF
--- a/src/akgentic/team/__init__.py
+++ b/src/akgentic/team/__init__.py
@@ -7,6 +7,7 @@ re-exported here via explicit __all__.
 from __future__ import annotations
 
 from akgentic.team.factory import TeamFactory
+from akgentic.team.manager import TeamManager
 from akgentic.team.models import (
     AgentStateSnapshot,
     PersistedEvent,
@@ -38,6 +39,7 @@ __all__: list[str] = [
     "TeamCard",
     "TeamCardMember",
     "TeamFactory",
+    "TeamManager",
     "TeamRuntime",
     "TeamStatus",
     "YamlEventStore",

--- a/src/akgentic/team/factory.py
+++ b/src/akgentic/team/factory.py
@@ -29,6 +29,7 @@ class TeamFactory:
         team_card: TeamCard,
         actor_system: ActorSystem,
         subscribers: list[EventSubscriber] | None = None,
+        team_id: uuid.UUID | None = None,
     ) -> TeamRuntime:
         """Build a running team from a declarative TeamCard.
 
@@ -40,6 +41,9 @@ class TeamFactory:
             team_card: Declarative team definition with entry point and members.
             actor_system: The actor system to host the team's actors.
             subscribers: Optional event subscribers to register with the orchestrator.
+            team_id: Optional pre-generated team identifier. If None, a new UUID
+                is generated. Allows callers (e.g. TeamManager) to know the team_id
+                before build completes.
 
         Returns:
             A TeamRuntime with all actor addresses populated and proxies rebuilt.
@@ -48,7 +52,7 @@ class TeamFactory:
             Exception: If any agent spawn fails, all already-spawned actors are
                 torn down and the original exception is re-raised.
         """
-        team_id = uuid.uuid4()
+        team_id = team_id or uuid.uuid4()
         spawned_addrs: list[ActorAddress] = []
 
         if team_card.entry_point.headcount != 1:

--- a/src/akgentic/team/manager.py
+++ b/src/akgentic/team/manager.py
@@ -1,3 +1,177 @@
 """TeamManager: lifecycle facade for create, resume, stop, delete operations."""
 
 from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.orchestrator import EventSubscriber
+from akgentic.team.factory import TeamFactory
+from akgentic.team.models import Process, TeamCard, TeamRuntime, TeamStatus
+from akgentic.team.ports import EventStore, NullServiceRegistry, ServiceRegistry
+from akgentic.team.subscriber import PersistenceSubscriber
+
+logger = logging.getLogger(__name__)
+
+
+class TeamManager:
+    """Single facade for team lifecycle: create, get, resume, stop, delete.
+
+    Coordinates TeamFactory, PersistenceSubscriber, EventStore, and
+    ServiceRegistry to provide a unified API for managing team instances
+    with consistent state machine enforcement.
+
+    The state machine enforces: RUNNING -> STOPPED -> DELETED.
+    Operations that violate this flow raise ValueError.
+    """
+
+    def __init__(
+        self,
+        actor_system: ActorSystem,
+        event_store: EventStore,
+        service_registry: ServiceRegistry = NullServiceRegistry(),
+        subscriber_factory: Callable[[uuid.UUID], list[EventSubscriber]] | None = None,
+        instance_id: uuid.UUID | None = None,
+    ) -> None:
+        """Initialize TeamManager with injected dependencies.
+
+        Args:
+            actor_system: The actor system to host team actors.
+            event_store: Persistence backend for team state and events.
+            service_registry: Service discovery registry. Defaults to
+                NullServiceRegistry for single-process mode.
+            subscriber_factory: Optional callable that receives a team_id
+                and returns additional EventSubscribers to register.
+            instance_id: Worker instance identifier. Auto-generated if None.
+        """
+        self._actor_system = actor_system
+        self._event_store = event_store
+        self._service_registry = service_registry
+        self._subscriber_factory = subscriber_factory
+        self._instance_id = instance_id or uuid.uuid4()
+
+    def create_team(
+        self,
+        team_card: TeamCard,
+        user_id: str = "cli",
+        user_email: str = "",
+    ) -> TeamRuntime:
+        """Create and start a new team from a TeamCard.
+
+        Pre-generates a team_id, creates a PersistenceSubscriber (always first),
+        appends any subscriber_factory results, then delegates to TeamFactory.build.
+        On successful build, persists a Process with RUNNING status and registers
+        the team with the ServiceRegistry.
+
+        If build fails, the exception propagates without persisting any Process.
+
+        Args:
+            team_card: Declarative team definition.
+            user_id: Identifier of the user creating the team.
+            user_email: Email of the user creating the team.
+
+        Returns:
+            A TeamRuntime handle to the running team.
+
+        Raises:
+            ValueError: If the TeamCard is invalid (e.g. entry_point headcount != 1).
+            Exception: Any exception from TeamFactory.build propagates unchanged.
+        """
+        team_id = uuid.uuid4()
+        logger.info("Creating team '%s' with id %s", team_card.name, team_id)
+
+        # Build subscriber list: PersistenceSubscriber always first
+        persistence_sub = PersistenceSubscriber(team_id, self._event_store)
+        subscribers: list[EventSubscriber] = [persistence_sub]
+        if self._subscriber_factory is not None:
+            subscribers.extend(self._subscriber_factory(team_id))
+
+        # Build the team — if this raises, no Process is persisted
+        runtime = TeamFactory.build(
+            team_card, self._actor_system, subscribers, team_id=team_id
+        )
+
+        # Persist Process metadata
+        now = datetime.now(UTC)
+        process = Process(
+            team_id=team_id,
+            team_card=team_card,
+            status=TeamStatus.RUNNING,
+            user_id=user_id,
+            user_email=user_email,
+            created_at=now,
+            updated_at=now,
+        )
+        self._event_store.save_team(process)
+
+        # Register with service discovery
+        self._service_registry.register_team(self._instance_id, team_id)
+
+        logger.info("Team '%s' (%s) created successfully", team_card.name, team_id)
+        return runtime
+
+    def get_team(self, team_id: uuid.UUID) -> Process | None:
+        """Retrieve Process metadata for a team.
+
+        Args:
+            team_id: The team identifier to look up.
+
+        Returns:
+            The Process if found, None otherwise.
+        """
+        return self._event_store.load_team(team_id)
+
+    def delete_team(self, team_id: uuid.UUID) -> None:
+        """Delete a stopped team, purging all persisted data.
+
+        Enforces the state machine: only STOPPED teams can be deleted.
+
+        Args:
+            team_id: The team identifier to delete.
+
+        Raises:
+            ValueError: If the team is not found, is currently RUNNING,
+                or is already DELETED.
+        """
+        process = self._event_store.load_team(team_id)
+        if process is None:
+            msg = f"Team {team_id} not found"
+            raise ValueError(msg)
+        if process.status == TeamStatus.RUNNING:
+            msg = (
+                f"Cannot delete team {team_id}: "
+                f"team is currently running. Stop it first."
+            )
+            raise ValueError(msg)
+        if process.status == TeamStatus.DELETED:
+            msg = f"Team {team_id} is already deleted"
+            raise ValueError(msg)
+
+        # STOPPED — purge all data
+        logger.info("Deleting team %s", team_id)
+        self._event_store.delete_team(team_id)
+
+    def resume_team(self, team_id: uuid.UUID) -> TeamRuntime:
+        """Resume a stopped team. Implemented in story 3.2.
+
+        Args:
+            team_id: The team identifier to resume.
+
+        Raises:
+            NotImplementedError: Always — this is a stub for story 3.2.
+        """
+        raise NotImplementedError("Implemented in story 3.2")
+
+    def stop_team(self, team_id: uuid.UUID) -> None:
+        """Gracefully stop a running team. Implemented in story 4.2.
+
+        Args:
+            team_id: The team identifier to stop.
+
+        Raises:
+            NotImplementedError: Always — this is a stub for story 4.2.
+        """
+        raise NotImplementedError("Implemented in story 4.2")

--- a/src/akgentic/team/manager.py
+++ b/src/akgentic/team/manager.py
@@ -32,7 +32,7 @@ class TeamManager:
         self,
         actor_system: ActorSystem,
         event_store: EventStore,
-        service_registry: ServiceRegistry = NullServiceRegistry(),
+        service_registry: ServiceRegistry | None = None,
         subscriber_factory: Callable[[uuid.UUID], list[EventSubscriber]] | None = None,
         instance_id: uuid.UUID | None = None,
     ) -> None:
@@ -49,7 +49,7 @@ class TeamManager:
         """
         self._actor_system = actor_system
         self._event_store = event_store
-        self._service_registry = service_registry
+        self._service_registry = service_registry or NullServiceRegistry()
         self._subscriber_factory = subscriber_factory
         self._instance_id = instance_id or uuid.uuid4()
 
@@ -138,40 +138,44 @@ class TeamManager:
         """
         process = self._event_store.load_team(team_id)
         if process is None:
+            logger.warning("Delete rejected: team %s not found", team_id)
             msg = f"Team {team_id} not found"
             raise ValueError(msg)
         if process.status == TeamStatus.RUNNING:
+            logger.warning("Delete rejected: team %s is currently running", team_id)
             msg = (
                 f"Cannot delete team {team_id}: "
                 f"team is currently running. Stop it first."
             )
             raise ValueError(msg)
         if process.status == TeamStatus.DELETED:
+            logger.warning("Delete rejected: team %s is already deleted", team_id)
             msg = f"Team {team_id} is already deleted"
             raise ValueError(msg)
 
-        # STOPPED — purge all data
+        # STOPPED — purge all data and deregister from service discovery
         logger.info("Deleting team %s", team_id)
         self._event_store.delete_team(team_id)
+        self._service_registry.deregister_team(self._instance_id, team_id)
 
     def resume_team(self, team_id: uuid.UUID) -> TeamRuntime:
-        """Resume a stopped team. Implemented in story 3.2.
+        """Resume a stopped team. Stub for story 3.2.
 
         Args:
             team_id: The team identifier to resume.
 
         Raises:
-            NotImplementedError: Always — this is a stub for story 3.2.
+            NotImplementedError: Always — to be implemented in story 3.2.
         """
-        raise NotImplementedError("Implemented in story 3.2")
+        raise NotImplementedError("To be implemented in story 3.2")
 
     def stop_team(self, team_id: uuid.UUID) -> None:
-        """Gracefully stop a running team. Implemented in story 4.2.
+        """Gracefully stop a running team. Stub for story 4.2.
 
         Args:
             team_id: The team identifier to stop.
 
         Raises:
-            NotImplementedError: Always — this is a stub for story 4.2.
+            NotImplementedError: Always — to be implemented in story 4.2.
         """
-        raise NotImplementedError("Implemented in story 4.2")
+        raise NotImplementedError("To be implemented in story 4.2")

--- a/tests/services/test_manager.py
+++ b/tests/services/test_manager.py
@@ -145,8 +145,12 @@ class TestTeamManagerCreate:
         event_store: InMemoryEventStore,
     ) -> None:
         """AC 2,4,5,7: create_team returns TeamRuntime and persists RUNNING Process."""
+        from datetime import UTC, datetime, timedelta
+
+        before = datetime.now(UTC)
         tc = _make_team_card()
         runtime = manager.create_team(tc, user_id="test-user", user_email="u@test.com")
+        after = datetime.now(UTC)
 
         assert isinstance(runtime, TeamRuntime)
         assert runtime.orchestrator_addr.is_alive()
@@ -158,6 +162,10 @@ class TestTeamManagerCreate:
         assert process.user_id == "test-user"
         assert process.user_email == "u@test.com"
         assert process.team_card.name == "test-team"
+
+        # Timestamps are set to reasonable values
+        assert before - timedelta(seconds=1) <= process.created_at <= after + timedelta(seconds=1)
+        assert process.created_at == process.updated_at
 
     def test_create_team_with_subscriber_factory(
         self,
@@ -345,3 +353,35 @@ class TestTeamManagerServiceRegistry:
         runtime = mgr.create_team(tc)
 
         mock_registry.register_team.assert_called_once_with(instance_id, runtime.id)
+
+    def test_deregister_team_called_on_delete(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """deregister_team is called with instance_id and team_id on delete."""
+        from datetime import UTC, datetime
+
+        mock_registry = MagicMock(spec=NullServiceRegistry)
+        instance_id = uuid.uuid4()
+        mgr = TeamManager(
+            actor_system=actor_system,
+            event_store=event_store,
+            service_registry=mock_registry,
+            instance_id=instance_id,
+        )
+        team_id = uuid.uuid4()
+        process = Process(
+            team_id=team_id,
+            team_card=_make_team_card(),
+            status=TeamStatus.STOPPED,
+            user_id="cli",
+            user_email="",
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        event_store.save_team(process)
+
+        mgr.delete_team(team_id)
+
+        mock_registry.deregister_team.assert_called_once_with(instance_id, team_id)

--- a/tests/services/test_manager.py
+++ b/tests/services/test_manager.py
@@ -1,0 +1,347 @@
+"""Tests for TeamManager — AC 1-13."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_card import AgentCard
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.agent_state import BaseState
+from akgentic.core.messages.message import Message
+from akgentic.core.orchestrator import EventSubscriber
+
+from akgentic.team.manager import TeamManager
+from akgentic.team.models import (
+    Process,
+    TeamCard,
+    TeamCardMember,
+    TeamRuntime,
+    TeamStatus,
+)
+from akgentic.team.ports import NullServiceRegistry
+from tests.services.conftest import InMemoryEventStore
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class StubAgent(Akgent[BaseConfig, BaseState]):
+    """Minimal agent for manager tests."""
+
+    pass
+
+
+class FailingAgent(Akgent[BaseConfig, BaseState]):
+    """Agent that raises during __init__ for rollback tests."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        msg = "FailingAgent intentional error"
+        raise RuntimeError(msg)
+
+
+class RecordingSubscriber(EventSubscriber):
+    """Subscriber that records received messages."""
+
+    def __init__(self) -> None:
+        self.messages: list[Message] = []
+        self.stopped: bool = False
+
+    def on_message(self, msg: Message) -> None:
+        """Record received message."""
+        self.messages.append(msg)
+
+    def on_stop(self) -> None:
+        """Record stop."""
+        self.stopped = True
+
+
+def _make_card(
+    name: str,
+    role: str = "TestRole",
+    agent_class: type[Akgent[Any, Any]] = StubAgent,
+) -> AgentCard:
+    return AgentCard(
+        role=role,
+        description=f"Test: {role}",
+        skills=["testing"],
+        agent_class=agent_class,
+        config=BaseConfig(name=name, role=role),
+        routes_to=[],
+    )
+
+
+def _make_member(
+    name: str,
+    role: str = "TestRole",
+    agent_class: type[Akgent[Any, Any]] = StubAgent,
+    headcount: int = 1,
+    members: list[TeamCardMember] | None = None,
+) -> TeamCardMember:
+    return TeamCardMember(
+        card=_make_card(name, role, agent_class),
+        headcount=headcount,
+        members=members or [],
+    )
+
+
+def _make_team_card(
+    entry_point: TeamCardMember | None = None,
+    members: list[TeamCardMember] | None = None,
+    name: str = "test-team",
+) -> TeamCard:
+    ep = entry_point or _make_member("lead", "Lead")
+    return TeamCard(
+        name=name,
+        description="Test team",
+        entry_point=ep,
+        members=members or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def actor_system() -> ActorSystem:  # type: ignore[misc]
+    """Provide an ActorSystem that shuts down after each test."""
+    system = ActorSystem()
+    yield system  # type: ignore[misc]
+    system.shutdown()
+
+
+@pytest.fixture()
+def event_store() -> InMemoryEventStore:
+    """Provide a fresh InMemoryEventStore per test."""
+    return InMemoryEventStore()
+
+
+@pytest.fixture()
+def manager(
+    actor_system: ActorSystem, event_store: InMemoryEventStore
+) -> TeamManager:
+    """Provide a TeamManager with default NullServiceRegistry."""
+    return TeamManager(actor_system=actor_system, event_store=event_store)
+
+
+# ---------------------------------------------------------------------------
+# Tests: create_team
+# ---------------------------------------------------------------------------
+
+
+class TestTeamManagerCreate:
+    """AC 1-8: TeamManager.create_team creates teams via TeamFactory."""
+
+    def test_create_team_happy_path(
+        self,
+        manager: TeamManager,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 2,4,5,7: create_team returns TeamRuntime and persists RUNNING Process."""
+        tc = _make_team_card()
+        runtime = manager.create_team(tc, user_id="test-user", user_email="u@test.com")
+
+        assert isinstance(runtime, TeamRuntime)
+        assert runtime.orchestrator_addr.is_alive()
+
+        # Process persisted with RUNNING status
+        process = event_store.load_team(runtime.id)
+        assert process is not None
+        assert process.status == TeamStatus.RUNNING
+        assert process.user_id == "test-user"
+        assert process.user_email == "u@test.com"
+        assert process.team_card.name == "test-team"
+
+    def test_create_team_with_subscriber_factory(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 2,3: subscriber_factory results appended after PersistenceSubscriber."""
+        recording = RecordingSubscriber()
+
+        def factory(team_id: uuid.UUID) -> list[EventSubscriber]:
+            return [recording]
+
+        mgr = TeamManager(
+            actor_system=actor_system,
+            event_store=event_store,
+            subscriber_factory=factory,
+        )
+        tc = _make_team_card()
+        runtime = mgr.create_team(tc)
+
+        # Verify recording subscriber is registered by stopping orchestrator
+        runtime.orchestrator_addr.stop()
+        assert recording.stopped is True
+
+    def test_create_team_rollback_on_build_failure(
+        self,
+        manager: TeamManager,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 8: If build fails, no Process is persisted."""
+        failing = _make_member("failing", "Failing", agent_class=FailingAgent)
+        tc = _make_team_card(members=[failing])
+
+        with pytest.raises(RuntimeError, match="intentional error"):
+            manager.create_team(tc)
+
+        # No Process should be in event store
+        assert len(event_store.teams) == 0
+
+    def test_create_team_uses_pre_generated_team_id(
+        self,
+        manager: TeamManager,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 4: TeamManager pre-generates team_id and passes to TeamFactory.build."""
+        tc = _make_team_card()
+        runtime = manager.create_team(tc)
+
+        # The team_id in Process must match the runtime id
+        process = event_store.load_team(runtime.id)
+        assert process is not None
+        assert process.team_id == runtime.id
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_team
+# ---------------------------------------------------------------------------
+
+
+class TestTeamManagerGet:
+    """AC 9: TeamManager.get_team retrieves Process metadata."""
+
+    def test_get_team_found(
+        self,
+        manager: TeamManager,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 9: get_team returns Process when team exists."""
+        tc = _make_team_card()
+        runtime = manager.create_team(tc)
+
+        result = manager.get_team(runtime.id)
+        assert result is not None
+        assert result.team_id == runtime.id
+        assert result.status == TeamStatus.RUNNING
+
+    def test_get_team_not_found(self, manager: TeamManager) -> None:
+        """AC 9: get_team returns None when team does not exist."""
+        result = manager.get_team(uuid.uuid4())
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: State machine enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestTeamManagerStateMachine:
+    """AC 10-11: State machine enforcement for delete_team."""
+
+    def test_delete_running_team_raises(
+        self,
+        manager: TeamManager,
+    ) -> None:
+        """AC 10: delete_team on RUNNING team raises ValueError."""
+        tc = _make_team_card()
+        runtime = manager.create_team(tc)
+
+        with pytest.raises(ValueError, match="currently running"):
+            manager.delete_team(runtime.id)
+
+    def test_delete_stopped_team_succeeds(
+        self,
+        manager: TeamManager,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 11: delete_team on STOPPED team purges data."""
+        tc = _make_team_card()
+        runtime = manager.create_team(tc)
+
+        # Manually transition to STOPPED
+        process = event_store.load_team(runtime.id)
+        assert process is not None
+        stopped_process = Process(
+            team_id=process.team_id,
+            team_card=process.team_card,
+            status=TeamStatus.STOPPED,
+            user_id=process.user_id,
+            user_email=process.user_email,
+            created_at=process.created_at,
+            updated_at=process.updated_at,
+        )
+        event_store.save_team(stopped_process)
+
+        manager.delete_team(runtime.id)
+
+        # Data should be purged
+        assert event_store.load_team(runtime.id) is None
+
+    def test_delete_nonexistent_team_raises(
+        self,
+        manager: TeamManager,
+    ) -> None:
+        """AC 11: delete_team on non-existent team raises ValueError."""
+        with pytest.raises(ValueError, match="not found"):
+            manager.delete_team(uuid.uuid4())
+
+    def test_delete_already_deleted_team_raises(
+        self,
+        manager: TeamManager,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 11: delete_team on DELETED team raises ValueError."""
+        from datetime import UTC, datetime
+
+        team_id = uuid.uuid4()
+        process = Process(
+            team_id=team_id,
+            team_card=_make_team_card(),
+            status=TeamStatus.DELETED,
+            user_id="cli",
+            user_email="",
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        event_store.save_team(process)
+
+        with pytest.raises(ValueError, match="already deleted"):
+            manager.delete_team(team_id)
+
+
+# ---------------------------------------------------------------------------
+# Tests: ServiceRegistry integration
+# ---------------------------------------------------------------------------
+
+
+class TestTeamManagerServiceRegistry:
+    """AC 6: ServiceRegistry.register_team called on create."""
+
+    def test_register_team_called_on_create(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 6: register_team is called with instance_id and team_id."""
+        mock_registry = MagicMock(spec=NullServiceRegistry)
+        instance_id = uuid.uuid4()
+        mgr = TeamManager(
+            actor_system=actor_system,
+            event_store=event_store,
+            service_registry=mock_registry,
+            instance_id=instance_id,
+        )
+        tc = _make_team_card()
+        runtime = mgr.create_team(tc)
+
+        mock_registry.register_team.assert_called_once_with(instance_id, runtime.id)


### PR DESCRIPTION
## Summary

- Implement `TeamManager` as the lifecycle facade for create, get, resume (stub), stop (stub), delete operations
- Modify `TeamFactory.build()` to accept optional `team_id` parameter for pre-generation by TeamManager
- Export `TeamManager` from package `__init__.py`
- 12 comprehensive tests covering all acceptance criteria (create happy path, subscriber_factory, rollback, get found/not-found, state machine enforcement, service registry integration)
- Code review fixes: mutable default argument, deregister_team on delete, warning logging on error paths, stub docstrings

Closes #19