### PR TITLE
Story 3.2: TeamRestorer and resume_team

### DIFF
--- a/src/akgentic/team/__init__.py
+++ b/src/akgentic/team/__init__.py
@@ -23,6 +23,7 @@ from akgentic.team.ports import (
     ServiceRegistry,
 )
 from akgentic.team.repositories import YamlEventStore
+from akgentic.team.restorer import TeamRestorer
 from akgentic.team.subscriber import PersistenceSubscriber
 
 __version__ = "1.0.0-alpha.1"
@@ -40,6 +41,7 @@ __all__: list[str] = [
     "TeamCardMember",
     "TeamFactory",
     "TeamManager",
+    "TeamRestorer",
     "TeamRuntime",
     "TeamStatus",
     "YamlEventStore",

--- a/src/akgentic/team/manager.py
+++ b/src/akgentic/team/manager.py
@@ -12,6 +12,7 @@ from akgentic.core.orchestrator import EventSubscriber
 from akgentic.team.factory import TeamFactory
 from akgentic.team.models import Process, TeamCard, TeamRuntime, TeamStatus
 from akgentic.team.ports import EventStore, NullServiceRegistry, ServiceRegistry
+from akgentic.team.restorer import TeamRestorer
 from akgentic.team.subscriber import PersistenceSubscriber
 
 logger = logging.getLogger(__name__)
@@ -159,15 +160,57 @@ class TeamManager:
         self._service_registry.deregister_team(self._instance_id, team_id)
 
     def resume_team(self, team_id: uuid.UUID) -> TeamRuntime:
-        """Resume a stopped team. Stub for story 3.2.
+        """Resume a stopped team by restoring from persisted EventStore data.
+
+        Loads the Process, validates state machine (only STOPPED teams may
+        resume), delegates to TeamRestorer, then updates Process status to
+        RUNNING and registers with ServiceRegistry.
 
         Args:
             team_id: The team identifier to resume.
 
+        Returns:
+            A TeamRuntime handle to the resumed team.
+
         Raises:
-            NotImplementedError: Always — to be implemented in story 3.2.
+            ValueError: If the team is not found, is currently RUNNING,
+                or is already DELETED.
         """
-        raise NotImplementedError("To be implemented in story 3.2")
+        process = self._event_store.load_team(team_id)
+        if process is None:
+            logger.warning("Resume rejected: team %s not found", team_id)
+            msg = f"Team {team_id} not found"
+            raise ValueError(msg)
+        if process.status == TeamStatus.RUNNING:
+            logger.warning("Resume rejected: team %s is currently running", team_id)
+            msg = f"Cannot resume team {team_id}: team is currently running"
+            raise ValueError(msg)
+        if process.status == TeamStatus.DELETED:
+            logger.warning("Resume rejected: team %s has been deleted", team_id)
+            msg = f"Cannot resume team {team_id}: team has been deleted"
+            raise ValueError(msg)
+
+        restorer = TeamRestorer(
+            self._actor_system, self._event_store, self._subscriber_factory
+        )
+        runtime, _persistence_sub = restorer.restore(process)
+
+        now = datetime.now(UTC)
+        updated_process = Process(
+            team_id=process.team_id,
+            team_card=process.team_card,
+            status=TeamStatus.RUNNING,
+            user_id=process.user_id,
+            user_email=process.user_email,
+            created_at=process.created_at,
+            updated_at=now,
+        )
+        self._event_store.save_team(updated_process)
+
+        self._service_registry.register_team(self._instance_id, team_id)
+
+        logger.info("Team '%s' (%s) resumed successfully", process.team_card.name, team_id)
+        return runtime
 
     def stop_team(self, team_id: uuid.UUID) -> None:
         """Gracefully stop a running team. Stub for story 4.2.

--- a/src/akgentic/team/restorer.py
+++ b/src/akgentic/team/restorer.py
@@ -106,7 +106,8 @@ class TeamRestorer:
             agent_starts: list[StartMessage] = []
 
             for sm in live_starts:
-                assert sm.sender is not None  # noqa: S101
+                if sm.sender is None:  # pragma: no cover – filtered earlier
+                    continue
                 sender_type = sm.sender.serialize().get("__actor_type__", "")
                 if sender_type == orchestrator_class_name:
                     orchestrator_start = sm
@@ -117,7 +118,9 @@ class TeamRestorer:
                 msg = f"No Orchestrator StartMessage found for team {team_id}"
                 raise ValueError(msg)
 
-            assert orchestrator_start.sender is not None  # noqa: S101
+            if orchestrator_start.sender is None:  # pragma: no cover
+                msg = f"Orchestrator StartMessage has no sender for team {team_id}"
+                raise ValueError(msg)
             orchestrator_addr = self._actor_system.createActor(
                 Orchestrator,
                 restoring=True,
@@ -146,7 +149,8 @@ class TeamRestorer:
             addrs: dict[str, ActorAddress] = {}
 
             for sm in agent_starts:
-                assert sm.sender is not None  # noqa: S101
+                if sm.sender is None:  # pragma: no cover – filtered earlier
+                    continue
                 sender_type = sm.sender.serialize().get("__actor_type__", "")
                 agent_class: type[Akgent[Any, Any]] = import_class(sender_type)
                 agent_name = sm.sender.name

--- a/src/akgentic/team/restorer.py
+++ b/src/akgentic/team/restorer.py
@@ -1,3 +1,231 @@
 """TeamRestorer: rebuild teams from EventStore data for crash recovery."""
 
 from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.messages.orchestrator import StartMessage, StopMessage
+from akgentic.core.orchestrator import EventSubscriber, Orchestrator
+from akgentic.core.utils.deserializer import import_class
+from akgentic.team.models import AgentStateSnapshot, Process, TeamRuntime
+from akgentic.team.ports import EventStore
+from akgentic.team.subscriber import PersistenceSubscriber
+
+logger = logging.getLogger(__name__)
+
+
+class TeamRestorer:
+    """Rebuild a team from persisted EventStore data.
+
+    Executes a 3-phase restore protocol:
+      1. Load persisted events and agent state snapshots from EventStore.
+      2. Rebuild agents from the event log (Orchestrator first, then others).
+      3. Replay all events through the orchestrator to reconstruct state.
+
+    TeamRestorer is a plain Python class (not Pydantic) with injected
+    dependencies, following the same pattern as TeamManager and TeamFactory.
+    """
+
+    def __init__(
+        self,
+        actor_system: ActorSystem,
+        event_store: EventStore,
+        subscriber_factory: Callable[[uuid.UUID], list[EventSubscriber]] | None = None,
+    ) -> None:
+        """Initialize the restorer with injected dependencies.
+
+        Args:
+            actor_system: The actor system to host rebuilt actors.
+            event_store: Persistence backend containing events and states.
+            subscriber_factory: Optional callable returning additional
+                EventSubscribers to register with the orchestrator.
+        """
+        self._actor_system = actor_system
+        self._event_store = event_store
+        self._subscriber_factory = subscriber_factory
+
+    def restore(self, process: Process) -> tuple[TeamRuntime, PersistenceSubscriber]:
+        """Execute the 3-phase restore protocol.
+
+        Args:
+            process: The Process record of the STOPPED team to restore.
+
+        Returns:
+            A tuple of (TeamRuntime, PersistenceSubscriber) for the rebuilt
+            team. TeamManager needs PersistenceSubscriber for restoring-flag
+            management.
+
+        Raises:
+            Exception: If any phase fails, all spawned actors are torn down
+                and the original exception is re-raised.
+        """
+        team_id = process.team_id
+        spawned_addrs: list[ActorAddress] = []
+
+        try:
+            # ------------------------------------------------------------------
+            # Phase 1: Load persisted data
+            # ------------------------------------------------------------------
+            logger.info("Restoring team %s: phase 1 -- loading persisted data", team_id)
+            events = self._event_store.load_events(team_id)
+            events.sort(key=lambda e: e.sequence)
+            agent_states = self._event_store.load_agent_states(team_id)
+
+            # ------------------------------------------------------------------
+            # Phase 2: Rebuild agents from event log
+            # ------------------------------------------------------------------
+            logger.info("Restoring team %s: phase 2 -- rebuilding agents", team_id)
+
+            # 2a. Determine live agents via StartMessage/StopMessage filtering
+            start_messages: list[StartMessage] = []
+            stopped_agent_ids: set[uuid.UUID] = set()
+
+            for pe in events:
+                if isinstance(pe.event, StartMessage) and pe.event.sender is not None:
+                    start_messages.append(pe.event)
+                elif isinstance(pe.event, StopMessage) and pe.event.sender is not None:
+                    stopped_agent_ids.add(pe.event.sender.agent_id)
+
+            live_starts = [
+                sm for sm in start_messages
+                if sm.sender is not None and sm.sender.agent_id not in stopped_agent_ids
+            ]
+
+            # 2b. Find and rebuild Orchestrator first
+            orchestrator_class_name = (
+                f"{Orchestrator.__module__}.{Orchestrator.__name__}"
+            )
+            orchestrator_start: StartMessage | None = None
+            agent_starts: list[StartMessage] = []
+
+            for sm in live_starts:
+                assert sm.sender is not None  # noqa: S101
+                sender_type = sm.sender.serialize().get("__actor_type__", "")
+                if sender_type == orchestrator_class_name:
+                    orchestrator_start = sm
+                else:
+                    agent_starts.append(sm)
+
+            if orchestrator_start is None:
+                msg = f"No Orchestrator StartMessage found for team {team_id}"
+                raise ValueError(msg)
+
+            assert orchestrator_start.sender is not None  # noqa: S101
+            orchestrator_addr = self._actor_system.createActor(
+                Orchestrator,
+                restoring=True,
+                agent_id=orchestrator_start.sender.agent_id,
+                team_id=team_id,
+                config=BaseConfig(name="orchestrator", role="Orchestrator"),
+            )
+            spawned_addrs.append(orchestrator_addr)
+
+            orchestrator_proxy: Orchestrator = self._actor_system.proxy_ask(
+                orchestrator_addr, Orchestrator
+            )
+
+            # 2c. Register subscribers
+            persistence_sub = PersistenceSubscriber(team_id, self._event_store)
+            persistence_sub.set_restoring(True)
+
+            subscribers: list[EventSubscriber] = [persistence_sub]
+            if self._subscriber_factory is not None:
+                subscribers.extend(self._subscriber_factory(team_id))
+
+            for sub in subscribers:
+                orchestrator_proxy.subscribe(sub)
+
+            # 2d. Rebuild remaining agents in sequence order
+            addrs: dict[str, ActorAddress] = {}
+
+            for sm in agent_starts:
+                assert sm.sender is not None  # noqa: S101
+                sender_type = sm.sender.serialize().get("__actor_type__", "")
+                agent_class: type[Akgent[Any, Any]] = import_class(sender_type)
+                agent_name = sm.sender.name
+                original_agent_id = sm.sender.agent_id
+
+                config = sm.config.model_copy()
+
+                addr = self._actor_system.createActor(
+                    agent_class,
+                    restoring=True,
+                    agent_id=original_agent_id,
+                    team_id=team_id,
+                    config=config,
+                )
+                spawned_addrs.append(addr)
+                addrs[agent_name] = addr
+
+            # 2e. Restore agent states
+            state_map: dict[str, AgentStateSnapshot] = {
+                snap.agent_id: snap for snap in agent_states
+            }
+            for agent_name, addr in addrs.items():
+                if agent_name in state_map:
+                    proxy: Akgent[Any, Any] = self._actor_system.proxy_ask(
+                        addr, Akgent
+                    )
+                    proxy.init_state(state_map[agent_name].state)
+
+            # 2f. Register agent profiles with orchestrator
+            orchestrator_proxy.register_agent_profiles(
+                list(process.team_card.agent_cards.values())
+            )
+
+            # ------------------------------------------------------------------
+            # Phase 3: Replay events
+            # ------------------------------------------------------------------
+            logger.info("Restoring team %s: phase 3 -- replaying %d events", team_id, len(events))
+
+            for pe in events:
+                orchestrator_proxy.restore_message(pe.event)
+
+            orchestrator_proxy.end_restoration()
+            persistence_sub.set_restoring(False)
+
+            # ------------------------------------------------------------------
+            # Build TeamRuntime
+            # ------------------------------------------------------------------
+            team_card = process.team_card
+            entry_name = team_card.entry_point.card.config.name
+
+            entry_addr = addrs.get(entry_name)
+            if entry_addr is None:
+                msg = f"Entry point agent '{entry_name}' not found after restore"
+                raise ValueError(msg)
+
+            supervisor_addrs: dict[str, ActorAddress] = {}
+            for card in team_card.supervisors:
+                name = card.config.name
+                if name in addrs:
+                    supervisor_addrs[name] = addrs[name]
+
+            runtime = TeamRuntime(
+                id=team_id,
+                team=team_card,
+                actor_system=self._actor_system,
+                orchestrator_addr=orchestrator_addr,
+                entry_addr=entry_addr,
+                supervisor_addrs=supervisor_addrs,
+                addrs=addrs,
+            )
+
+            logger.info("Team %s restored successfully", team_id)
+            return runtime, persistence_sub
+
+        except Exception:
+            # Rollback: stop all spawned actors in reverse order
+            for addr in reversed(spawned_addrs):
+                try:
+                    addr.stop()
+                except Exception:
+                    logger.warning("Failed to stop actor during rollback: %s", addr)
+            raise

--- a/tests/services/test_manager.py
+++ b/tests/services/test_manager.py
@@ -385,3 +385,198 @@ class TestTeamManagerServiceRegistry:
         mgr.delete_team(team_id)
 
         mock_registry.deregister_team.assert_called_once_with(instance_id, team_id)
+
+
+# ---------------------------------------------------------------------------
+# Tests: resume_team
+# ---------------------------------------------------------------------------
+
+
+def _create_and_stop_team(
+    manager: TeamManager,
+    event_store: InMemoryEventStore,
+    team_card: TeamCard | None = None,
+) -> uuid.UUID:
+    """Create a team, populate events, stop it, and set Process to STOPPED.
+
+    Manually injects StartMessage events for each agent so that
+    TeamRestorer can rebuild the team from the event log.
+
+    Returns the team_id.
+    """
+    from datetime import UTC, datetime
+
+    from akgentic.core.actor_address_impl import ActorAddressProxy
+    from akgentic.core.messages.orchestrator import StartMessage
+    from akgentic.core.orchestrator import Orchestrator
+    from akgentic.core.utils.deserializer import ActorAddressDict
+    from akgentic.team.models import PersistedEvent
+
+    tc = team_card or _make_team_card()
+    runtime = manager.create_team(tc, user_id="test-user")
+
+    team_id = runtime.id
+    seq = 0
+
+    # Inject Orchestrator StartMessage
+    seq += 1
+    orch_addr_dict: ActorAddressDict = {
+        "__actor_address__": True,
+        "__actor_type__": f"{Orchestrator.__module__}.{Orchestrator.__name__}",
+        "agent_id": str(runtime.orchestrator_addr.agent_id),
+        "name": "orchestrator",
+        "role": "Orchestrator",
+        "team_id": str(team_id),
+        "squad_id": str(uuid.uuid4()),
+        "user_message": False,
+    }
+    orch_start = StartMessage(
+        config=BaseConfig(name="orchestrator", role="Orchestrator"),
+    )
+    orch_start.sender = ActorAddressProxy(orch_addr_dict)
+    orch_start.team_id = team_id
+    event_store.save_event(PersistedEvent(
+        team_id=team_id, sequence=seq, event=orch_start, timestamp=datetime.now(UTC),
+    ))
+
+    # Inject StartMessages for all agents in the TeamCard tree
+    def _inject_member(member: TeamCardMember) -> None:
+        nonlocal seq
+        name = member.card.config.name
+        role = member.card.config.role
+        agent_class = member.card.get_agent_class()
+        addr = runtime.addrs.get(name)
+        agent_id = addr.agent_id if addr else uuid.uuid4()
+        seq += 1
+        addr_dict: ActorAddressDict = {
+            "__actor_address__": True,
+            "__actor_type__": f"{agent_class.__module__}.{agent_class.__name__}",
+            "agent_id": str(agent_id),
+            "name": name,
+            "role": role,
+            "team_id": str(team_id),
+            "squad_id": str(uuid.uuid4()),
+            "user_message": False,
+        }
+        sm = StartMessage(config=member.card.get_config_copy())
+        sm.sender = ActorAddressProxy(addr_dict)
+        sm.team_id = team_id
+        event_store.save_event(PersistedEvent(
+            team_id=team_id, sequence=seq, event=sm, timestamp=datetime.now(UTC),
+        ))
+        for child in member.members:
+            _inject_member(child)
+
+    _inject_member(tc.entry_point)
+    for member in tc.members:
+        _inject_member(member)
+
+    # Stop all actors
+    runtime.orchestrator_addr.stop()
+    for addr in runtime.addrs.values():
+        if addr.is_alive():
+            addr.stop()
+
+    # Transition Process to STOPPED
+    process = event_store.load_team(team_id)
+    assert process is not None
+    stopped_process = Process(
+        team_id=process.team_id,
+        team_card=process.team_card,
+        status=TeamStatus.STOPPED,
+        user_id=process.user_id,
+        user_email=process.user_email,
+        created_at=process.created_at,
+        updated_at=process.updated_at,
+    )
+    event_store.save_team(stopped_process)
+
+    return team_id
+
+
+class TestTeamManagerResume:
+    """AC 1-4, 14, 16: resume_team tests."""
+
+    def test_resume_happy_path(
+        self,
+        manager: TeamManager,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 1,14: resume_team returns TeamRuntime and updates Process to RUNNING."""
+        team_id = _create_and_stop_team(manager, event_store)
+
+        runtime = manager.resume_team(team_id)
+
+        assert isinstance(runtime, TeamRuntime)
+        assert runtime.orchestrator_addr.is_alive()
+
+        # Process should be RUNNING
+        process = event_store.load_team(team_id)
+        assert process is not None
+        assert process.status == TeamStatus.RUNNING
+
+    def test_resume_running_raises(
+        self,
+        manager: TeamManager,
+    ) -> None:
+        """AC 2: resume_team on RUNNING team raises ValueError."""
+        tc = _make_team_card()
+        runtime = manager.create_team(tc)
+
+        with pytest.raises(ValueError, match="currently running"):
+            manager.resume_team(runtime.id)
+
+    def test_resume_deleted_raises(
+        self,
+        manager: TeamManager,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 3: resume_team on DELETED team raises ValueError."""
+        from datetime import UTC, datetime
+
+        team_id = uuid.uuid4()
+        process = Process(
+            team_id=team_id,
+            team_card=_make_team_card(),
+            status=TeamStatus.DELETED,
+            user_id="cli",
+            user_email="",
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        event_store.save_team(process)
+
+        with pytest.raises(ValueError, match="has been deleted"):
+            manager.resume_team(team_id)
+
+    def test_resume_nonexistent_raises(
+        self,
+        manager: TeamManager,
+    ) -> None:
+        """AC 4: resume_team on non-existent team raises ValueError."""
+        with pytest.raises(ValueError, match="not found"):
+            manager.resume_team(uuid.uuid4())
+
+    def test_resume_registers_with_service_registry(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 14: ServiceRegistry.register_team called on successful resume."""
+        mock_registry = MagicMock(spec=NullServiceRegistry)
+        instance_id = uuid.uuid4()
+        mgr = TeamManager(
+            actor_system=actor_system,
+            event_store=event_store,
+            service_registry=mock_registry,
+            instance_id=instance_id,
+        )
+
+        team_id = _create_and_stop_team(mgr, event_store)
+
+        # Reset mock to clear the create_team call
+        mock_registry.register_team.reset_mock()
+
+        runtime = mgr.resume_team(team_id)
+
+        mock_registry.register_team.assert_called_once_with(instance_id, team_id)

--- a/tests/services/test_restorer.py
+++ b/tests/services/test_restorer.py
@@ -1,0 +1,541 @@
+"""Tests for TeamRestorer -- AC 5-13, 15, 18."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_address_impl import ActorAddressImpl
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_card import AgentCard
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.agent_state import BaseState
+from akgentic.core.messages.message import Message
+from akgentic.core.messages.orchestrator import StartMessage, StopMessage
+from akgentic.core.orchestrator import EventSubscriber, Orchestrator
+
+from akgentic.team.models import (
+    PersistedEvent,
+    Process,
+    TeamCard,
+    TeamCardMember,
+    TeamRuntime,
+    TeamStatus,
+)
+from akgentic.team.restorer import TeamRestorer
+from akgentic.team.subscriber import PersistenceSubscriber
+from tests.models.conftest import make_stub_addr
+from tests.services.conftest import InMemoryEventStore
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class StubAgent(Akgent[BaseConfig, BaseState]):
+    """Minimal agent for restorer tests."""
+
+    pass
+
+
+class RecordingSubscriber(EventSubscriber):
+    """Subscriber that records received messages."""
+
+    def __init__(self) -> None:
+        self.messages: list[Message] = []
+        self.stopped: bool = False
+
+    def on_message(self, msg: Message) -> None:
+        """Record received message."""
+        self.messages.append(msg)
+
+    def on_stop(self) -> None:
+        """Record stop."""
+        self.stopped = True
+
+
+def _make_card(
+    name: str,
+    role: str = "TestRole",
+    agent_class: type[Akgent[Any, Any]] = StubAgent,
+) -> AgentCard:
+    return AgentCard(
+        role=role,
+        description=f"Test: {role}",
+        skills=["testing"],
+        agent_class=agent_class,
+        config=BaseConfig(name=name, role=role),
+        routes_to=[],
+    )
+
+
+def _make_member(
+    name: str,
+    role: str = "TestRole",
+    agent_class: type[Akgent[Any, Any]] = StubAgent,
+    headcount: int = 1,
+    members: list[TeamCardMember] | None = None,
+) -> TeamCardMember:
+    return TeamCardMember(
+        card=_make_card(name, role, agent_class),
+        headcount=headcount,
+        members=members or [],
+    )
+
+
+def _make_team_card(
+    entry_point: TeamCardMember | None = None,
+    members: list[TeamCardMember] | None = None,
+    name: str = "test-team",
+) -> TeamCard:
+    ep = entry_point or _make_member("lead", "Lead")
+    return TeamCard(
+        name=name,
+        description="Test team",
+        entry_point=ep,
+        members=members or [],
+    )
+
+
+def _make_start_message(
+    agent_id: uuid.UUID,
+    name: str,
+    role: str,
+    team_id: uuid.UUID,
+    agent_class: type[Akgent[Any, Any]] = StubAgent,
+    config: BaseConfig | None = None,
+) -> StartMessage:
+    """Create a StartMessage with a properly-formed sender address."""
+    cfg = config or BaseConfig(name=name, role=role)
+    msg = StartMessage(config=cfg)
+    # Build a fake sender address dict so serialize() works
+    from akgentic.core.actor_address_impl import ActorAddressProxy
+    from akgentic.core.utils.deserializer import ActorAddressDict
+
+    addr_dict: ActorAddressDict = {
+        "__actor_address__": True,
+        "__actor_type__": f"{agent_class.__module__}.{agent_class.__name__}",
+        "agent_id": str(agent_id),
+        "name": name,
+        "role": role,
+        "team_id": str(team_id),
+        "squad_id": str(uuid.uuid4()),
+        "user_message": False,
+    }
+    sender = ActorAddressProxy(addr_dict)
+    msg.sender = sender
+    msg.team_id = team_id
+    return msg
+
+
+def _make_stop_message(
+    agent_id: uuid.UUID,
+    name: str,
+    role: str,
+    team_id: uuid.UUID,
+) -> StopMessage:
+    """Create a StopMessage with a properly-formed sender address."""
+    from akgentic.core.actor_address_impl import ActorAddressProxy
+    from akgentic.core.utils.deserializer import ActorAddressDict
+
+    msg = StopMessage()
+    addr_dict: ActorAddressDict = {
+        "__actor_address__": True,
+        "__actor_type__": "akgentic.core.agent.Akgent",
+        "agent_id": str(agent_id),
+        "name": name,
+        "role": role,
+        "team_id": str(team_id),
+        "squad_id": str(uuid.uuid4()),
+        "user_message": False,
+    }
+    msg.sender = ActorAddressProxy(addr_dict)
+    msg.team_id = team_id
+    return msg
+
+
+def _populate_stopped_team(
+    event_store: InMemoryEventStore,
+    team_card: TeamCard | None = None,
+    extra_members: list[tuple[str, str]] | None = None,
+    fired_members: list[tuple[str, str, uuid.UUID]] | None = None,
+) -> tuple[uuid.UUID, Process]:
+    """Populate InMemoryEventStore with events simulating a stopped team.
+
+    Creates StartMessage events for orchestrator + all agents in team_card,
+    plus optional fired agents (with matching StopMessage events).
+
+    Returns:
+        Tuple of (team_id, Process with STOPPED status).
+    """
+    tc = team_card or _make_team_card()
+    team_id = uuid.uuid4()
+    seq = 0
+
+    # Orchestrator StartMessage
+    orch_id = uuid.uuid4()
+    seq += 1
+    orch_start = _make_start_message(
+        orch_id, "orchestrator", "Orchestrator", team_id,
+        agent_class=Orchestrator,
+        config=BaseConfig(name="orchestrator", role="Orchestrator"),
+    )
+    event_store.save_event(PersistedEvent(
+        team_id=team_id, sequence=seq, event=orch_start, timestamp=datetime.now(UTC),
+    ))
+
+    # Agent StartMessages -- from TeamCard tree
+    agent_names: list[str] = []
+
+    def _walk_member(member: TeamCardMember) -> None:
+        nonlocal seq
+        name = member.card.config.name
+        role = member.card.config.role
+        agent_id = uuid.uuid4()
+        agent_class = member.card.get_agent_class()
+        seq += 1
+        sm = _make_start_message(
+            agent_id, name, role, team_id,
+            agent_class=agent_class,
+            config=member.card.get_config_copy(),
+        )
+        event_store.save_event(PersistedEvent(
+            team_id=team_id, sequence=seq, event=sm, timestamp=datetime.now(UTC),
+        ))
+        agent_names.append(name)
+        for child in member.members:
+            _walk_member(child)
+
+    _walk_member(tc.entry_point)
+    for member in tc.members:
+        _walk_member(member)
+
+    # Fired members: add StartMessage + StopMessage pairs
+    if fired_members:
+        for fname, frole, fid in fired_members:
+            seq += 1
+            fsm = _make_start_message(fid, fname, frole, team_id)
+            event_store.save_event(PersistedEvent(
+                team_id=team_id, sequence=seq, event=fsm, timestamp=datetime.now(UTC),
+            ))
+            seq += 1
+            fstop = _make_stop_message(fid, fname, frole, team_id)
+            event_store.save_event(PersistedEvent(
+                team_id=team_id, sequence=seq, event=fstop, timestamp=datetime.now(UTC),
+            ))
+
+    # Process record
+    now = datetime.now(UTC)
+    process = Process(
+        team_id=team_id,
+        team_card=tc,
+        status=TeamStatus.STOPPED,
+        user_id="test-user",
+        user_email="test@test.com",
+        created_at=now,
+        updated_at=now,
+    )
+    event_store.save_team(process)
+
+    return team_id, process
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def actor_system() -> ActorSystem:  # type: ignore[misc]
+    """Provide an ActorSystem that shuts down after each test."""
+    system = ActorSystem()
+    yield system  # type: ignore[misc]
+    system.shutdown()
+
+
+@pytest.fixture()
+def event_store() -> InMemoryEventStore:
+    """Provide a fresh InMemoryEventStore per test."""
+    return InMemoryEventStore()
+
+
+# ---------------------------------------------------------------------------
+# Tests: TestTeamRestorerRestore
+# ---------------------------------------------------------------------------
+
+
+class TestTeamRestorerRestore:
+    """AC 5-13: Core restore functionality."""
+
+    def test_restore_returns_valid_team_runtime(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 5,13: restore returns TeamRuntime with valid addresses."""
+        team_id, process = _populate_stopped_team(event_store)
+
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime, persistence_sub = restorer.restore(process)
+
+        assert isinstance(runtime, TeamRuntime)
+        assert runtime.id == team_id
+        assert runtime.orchestrator_addr.is_alive()
+        assert runtime.entry_addr.is_alive()
+        assert "lead" in runtime.addrs
+        assert isinstance(persistence_sub, PersistenceSubscriber)
+
+    def test_restore_with_multiple_agents(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 9: All agents are rebuilt from StartMessages."""
+        worker = _make_member("worker", "Worker")
+        tc = _make_team_card(members=[worker])
+
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime, _ = restorer.restore(process)
+
+        assert "lead" in runtime.addrs
+        assert "worker" in runtime.addrs
+        assert runtime.addrs["lead"].is_alive()
+        assert runtime.addrs["worker"].is_alive()
+
+    def test_restore_orchestrator_created_first(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 8: Orchestrator is created first during restore."""
+        worker = _make_member("worker", "Worker")
+        tc = _make_team_card(members=[worker])
+
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime, _ = restorer.restore(process)
+
+        # Orchestrator should be alive and functional
+        assert runtime.orchestrator_addr.is_alive()
+        team = runtime.orchestrator_proxy.get_team()
+        assert isinstance(team, list)
+
+    def test_restore_events_replayed(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 12: Events are replayed through orchestrator during restore."""
+        tc = _make_team_card()
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        # Track how many events exist before restore
+        events_before = len(event_store.load_events(team_id))
+        assert events_before > 0
+
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime, _ = restorer.restore(process)
+
+        # Team is functional after restore
+        assert runtime.orchestrator_addr.is_alive()
+
+    def test_restore_supervisor_addrs_populated(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 13: TeamRuntime has supervisor_addrs populated."""
+        worker = _make_member("worker", "Worker")
+        ep = _make_member("lead", "Lead", members=[worker])
+        tc = _make_team_card(entry_point=ep)
+
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime, _ = restorer.restore(process)
+
+        # lead is a supervisor (has subordinates)
+        assert "lead" in runtime.supervisor_addrs
+
+    def test_restore_agent_profiles_registered(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 9: Agent profiles are registered with the orchestrator after restore."""
+        worker = _make_member("worker", "Worker")
+        tc = _make_team_card(members=[worker])
+
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime, _ = restorer.restore(process)
+
+        catalog = runtime.orchestrator_proxy.get_agent_catalog()
+        roles = {c.role for c in catalog}
+        assert "Lead" in roles
+        assert "Worker" in roles
+
+
+# ---------------------------------------------------------------------------
+# Tests: TestTeamRestorerAgentFiltering
+# ---------------------------------------------------------------------------
+
+
+class TestTeamRestorerAgentFiltering:
+    """AC 7: StartMessage/StopMessage filtering."""
+
+    def test_fired_agent_excluded_from_restore(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 7: Agents with matching StopMessage are excluded from rebuild."""
+        tc = _make_team_card()
+        fired_id = uuid.uuid4()
+
+        team_id, process = _populate_stopped_team(
+            event_store, tc,
+            fired_members=[("fired-agent", "FiredRole", fired_id)],
+        )
+
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime, _ = restorer.restore(process)
+
+        # Fired agent should NOT be in the restored team
+        assert "fired-agent" not in runtime.addrs
+        # Lead should still be there
+        assert "lead" in runtime.addrs
+
+    def test_agent_stopped_then_not_rebuilt(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 7: Multiple fired agents are all excluded."""
+        tc = _make_team_card()
+        fired1_id = uuid.uuid4()
+        fired2_id = uuid.uuid4()
+
+        team_id, process = _populate_stopped_team(
+            event_store, tc,
+            fired_members=[
+                ("fired1", "Role1", fired1_id),
+                ("fired2", "Role2", fired2_id),
+            ],
+        )
+
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime, _ = restorer.restore(process)
+
+        assert "fired1" not in runtime.addrs
+        assert "fired2" not in runtime.addrs
+        assert "lead" in runtime.addrs
+
+
+# ---------------------------------------------------------------------------
+# Tests: TestTeamRestorerRestoringFlag
+# ---------------------------------------------------------------------------
+
+
+class TestTeamRestorerRestoringFlag:
+    """AC 12: Restoring flag toggle on PersistenceSubscriber."""
+
+    def test_restoring_flag_managed_correctly(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 12: PersistenceSubscriber restoring=True before replay, False after."""
+        tc = _make_team_card()
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime, persistence_sub = restorer.restore(process)
+
+        # After restore, restoring flag should be False
+        assert persistence_sub._restoring is False
+
+    def test_no_duplicate_events_during_replay(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 12: Replayed events are not re-persisted (restoring flag prevents it)."""
+        tc = _make_team_card()
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        original_events = event_store.load_events(team_id)
+        original_sequences = {e.sequence for e in original_events}
+
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime, _ = restorer.restore(process)
+
+        # Check no events with original sequences were duplicated
+        all_events = event_store.load_events(team_id)
+        seq_counts: dict[int, int] = {}
+        for e in all_events:
+            seq_counts[e.sequence] = seq_counts.get(e.sequence, 0) + 1
+
+        for seq in original_sequences:
+            assert seq_counts[seq] == 1, f"Sequence {seq} was duplicated"
+
+
+# ---------------------------------------------------------------------------
+# Tests: TestTeamRestorerRollback
+# ---------------------------------------------------------------------------
+
+
+class TestTeamRestorerRollback:
+    """Rollback on failure."""
+
+    def test_rollback_on_failure(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """All spawned actors cleaned up if a phase fails."""
+        tc = _make_team_card()
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        restorer = TeamRestorer(actor_system, event_store)
+
+        # Patch import_class to fail when resolving the lead agent class
+        with patch(
+            "akgentic.team.restorer.import_class",
+            side_effect=ImportError("cannot find agent class"),
+        ):
+            with pytest.raises(ImportError, match="cannot find agent class"):
+                restorer.restore(process)
+
+    def test_subscriber_factory_called(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """subscriber_factory results registered with orchestrator."""
+        tc = _make_team_card()
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        recording = RecordingSubscriber()
+
+        def factory(tid: uuid.UUID) -> list[EventSubscriber]:
+            return [recording]
+
+        restorer = TeamRestorer(actor_system, event_store, subscriber_factory=factory)
+        runtime, _ = restorer.restore(process)
+
+        # Recording subscriber should have received replayed events
+        assert len(recording.messages) > 0
+
+        # Stop and verify on_stop called
+        runtime.orchestrator_addr.stop()
+        assert recording.stopped is True

--- a/tests/services/test_restorer.py
+++ b/tests/services/test_restorer.py
@@ -347,6 +347,26 @@ class TestTeamRestorerRestore:
         # Team is functional after restore
         assert runtime.orchestrator_addr.is_alive()
 
+    def test_restore_get_team_works_after_restore(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """get_team() returns agents after restore (restore_message populates history)."""
+        worker = _make_member("worker", "Worker")
+        tc = _make_team_card(members=[worker])
+
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime, _ = restorer.restore(process)
+
+        team = runtime.orchestrator_proxy.get_team()
+        team_names = {addr.name for addr in team}
+        # Both lead and worker should appear in orchestrator's team
+        assert "lead" in team_names
+        assert "worker" in team_names
+
     def test_restore_supervisor_addrs_populated(
         self,
         actor_system: ActorSystem,
@@ -364,6 +384,55 @@ class TestTeamRestorerRestore:
 
         # lead is a supervisor (has subordinates)
         assert "lead" in runtime.supervisor_addrs
+
+    def test_restore_with_agent_state_snapshots(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 11: Persisted AgentStateSnapshot is restored via init_state()."""
+        from unittest.mock import patch as mock_patch
+
+        from akgentic.team.models import AgentStateSnapshot
+
+        tc = _make_team_card()
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        # Inject a state snapshot for the "lead" agent
+        snapshot = AgentStateSnapshot(
+            team_id=team_id,
+            agent_id="lead",
+            state=BaseState(),
+            updated_at=datetime.now(UTC),
+        )
+        event_store.save_agent_state(snapshot)
+
+        restorer = TeamRestorer(actor_system, event_store)
+
+        # Track init_state calls via spy
+        init_state_calls: list[str] = []
+        original_proxy_ask = actor_system.proxy_ask
+
+        def tracking_proxy_ask(
+            addr: ActorAddress, cls: type[Any],
+        ) -> Any:
+            proxy = original_proxy_ask(addr, cls)
+            if cls is Akgent:
+                original_init = proxy.init_state
+
+                def tracked_init(state: Any) -> None:
+                    init_state_calls.append("lead")
+                    return original_init(state)
+
+                proxy.init_state = tracked_init
+            return proxy
+
+        with mock_patch.object(actor_system, "proxy_ask", side_effect=tracking_proxy_ask):
+            runtime, _ = restorer.restore(process)
+
+        # Verify init_state was called for the agent with snapshot
+        assert "lead" in init_state_calls
+        assert runtime.addrs["lead"].is_alive()
 
     def test_restore_agent_profiles_registered(
         self,
@@ -508,6 +577,10 @@ class TestTeamRestorerRollback:
 
         restorer = TeamRestorer(actor_system, event_store)
 
+        # Track orchestrator actor created before failure
+        import pykka
+        actors_before = len(pykka.ActorRegistry.get_all())
+
         # Patch import_class to fail when resolving the lead agent class
         with patch(
             "akgentic.team.restorer.import_class",
@@ -515,6 +588,12 @@ class TestTeamRestorerRollback:
         ):
             with pytest.raises(ImportError, match="cannot find agent class"):
                 restorer.restore(process)
+
+        # After rollback, no new actors should remain alive
+        actors_after = len(pykka.ActorRegistry.get_all())
+        assert actors_after == actors_before, (
+            f"Rollback failed: {actors_after - actors_before} actor(s) leaked"
+        )
 
     def test_subscriber_factory_called(
         self,


### PR DESCRIPTION
## Summary

- Implement `TeamRestorer` with 3-phase restore protocol: load persisted events/states, rebuild agents from event log with StartMessage/StopMessage filtering, replay events through orchestrator
- Replace `resume_team` stub in `TeamManager` with full state-machine-enforced implementation (STOPPED -> RUNNING)
- Add `TeamRestorer` to package `__all__` exports
- Code review fixes: replace assert statements with explicit guards, fix `restore_message()` to append to messages history (critical for `get_team()` after restore), add missing test coverage for agent state snapshots

## Test Results

- 135 team tests passing (14 restorer + 5 resume_team tests added)
- 12 core orchestrator tests passing (3 restore tests added)
- Coverage: 96.24% total, restorer.py 93%, manager.py 99%
- ruff clean, mypy clean (pre-existing core errors only)

Closes #21