### PR TITLE
MongoEventStore Implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
     "pytest-cov>=4.1.0",
     "mypy>=1.8.0",
     "ruff>=0.1.0",
+    "mongomock>=4.0.0",
 ]
 
 [build-system]

--- a/src/akgentic/team/__init__.py
+++ b/src/akgentic/team/__init__.py
@@ -46,3 +46,12 @@ __all__: list[str] = [
     "TeamStatus",
     "YamlEventStore",
 ]
+
+_mongo_available = False
+try:
+    from akgentic.team.repositories import MongoEventStore  # noqa: F401
+
+    __all__.append("MongoEventStore")
+    _mongo_available = True
+except ImportError:
+    pass

--- a/src/akgentic/team/repositories/__init__.py
+++ b/src/akgentic/team/repositories/__init__.py
@@ -7,3 +7,10 @@ from akgentic.team.repositories.yaml import YamlEventStore
 __all__: list[str] = [
     "YamlEventStore",
 ]
+
+try:
+    from akgentic.team.repositories.mongo import MongoEventStore  # noqa: F401
+
+    __all__.append("MongoEventStore")
+except ImportError:
+    pass

--- a/src/akgentic/team/repositories/mongo.py
+++ b/src/akgentic/team/repositories/mongo.py
@@ -1,3 +1,182 @@
-"""MongoEventStore: MongoDB-backed EventStore via [mongo] optional extra."""
+"""MongoEventStore: MongoDB-backed EventStore via [mongo] optional extra.
+
+Persists team data to MongoDB collections using pymongo. Satisfies the
+EventStore protocol via structural subtyping (no explicit inheritance).
+
+Collection layout::
+
+    teams              # One document per team (Process metadata) -- upsert by team_id
+    events             # One document per event -- append-only, indexed by (team_id, sequence)
+    agent_states       # One document per agent per team -- upsert by (team_id, agent_id)
+"""
 
 from __future__ import annotations
+
+import logging
+import uuid
+from typing import TYPE_CHECKING
+
+try:
+    import pymongo  # noqa: F401
+except ImportError as exc:
+    raise ImportError(
+        "pymongo is required for MongoEventStore. "
+        "Install with: pip install akgentic-team[mongo]"
+    ) from exc
+
+from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process
+
+if TYPE_CHECKING:
+    import pymongo.collection
+    import pymongo.database
+
+logger = logging.getLogger(__name__)
+
+
+class MongoEventStore:
+    """MongoDB-backed EventStore using pymongo collections.
+
+    Satisfies the ``EventStore`` protocol via structural subtyping without
+    inheriting from it. Uses three collections: ``teams`` (upsert by team_id),
+    ``events`` (append-only, indexed by team_id + sequence), and
+    ``agent_states`` (upsert by team_id + agent_id).
+
+    Args:
+        db: A pymongo Database instance connected to the target MongoDB server.
+    """
+
+    def __init__(self, db: pymongo.database.Database) -> None:  # type: ignore[type-arg]
+        self._db = db
+        self._teams: pymongo.collection.Collection = db["teams"]  # type: ignore[type-arg]
+        self._events: pymongo.collection.Collection = db["events"]  # type: ignore[type-arg]
+        self._agent_states: pymongo.collection.Collection = db["agent_states"]  # type: ignore[type-arg]
+
+        # Create indexes for efficient queries
+        self._events.create_index([("team_id", 1), ("sequence", 1)])
+        self._agent_states.create_index(
+            [("team_id", 1), ("agent_id", 1)], unique=True
+        )
+        logger.debug("Initialized MongoEventStore with database '%s'", db.name)
+
+    def save_team(self, process: Process) -> None:
+        """Persist a team process snapshot via upsert.
+
+        Serializes the Process with ``model_dump()`` and upserts into the
+        ``teams`` collection keyed by ``team_id``.
+
+        Args:
+            process: The team process snapshot to persist.
+        """
+        doc = process.model_dump()
+        self._teams.replace_one(
+            {"team_id": str(process.team_id)},
+            doc,
+            upsert=True,
+        )
+        logger.debug("Saved team %s", process.team_id)
+
+    def load_team(self, team_id: uuid.UUID) -> Process | None:
+        """Load a team process snapshot by ID.
+
+        Queries the ``teams`` collection by ``team_id``. Returns None if no
+        document is found.
+
+        Args:
+            team_id: Unique identifier of the team.
+
+        Returns:
+            The deserialized Process, or None if not found.
+        """
+        doc = self._teams.find_one({"team_id": str(team_id)})
+        if doc is None:
+            return None
+        doc.pop("_id", None)
+        process = Process.model_validate(doc)
+        logger.debug("Loaded team %s", team_id)
+        return process
+
+    def save_event(self, event: PersistedEvent) -> None:
+        """Persist a single domain event (append-only).
+
+        Serializes the PersistedEvent with ``model_dump()`` and inserts into
+        the ``events`` collection. Never upserts -- events are immutable.
+
+        Args:
+            event: The event to persist.
+        """
+        doc = event.model_dump()
+        self._events.insert_one(doc)
+        logger.debug("Saved event seq=%d for team %s", event.sequence, event.team_id)
+
+    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
+        """Load all persisted events for a team, ordered by sequence.
+
+        Queries the ``events`` collection by ``team_id`` and sorts by
+        ``sequence`` ascending.
+
+        Args:
+            team_id: Unique identifier of the team.
+
+        Returns:
+            List of PersistedEvent ordered by sequence, or empty list if none.
+        """
+        cursor = self._events.find({"team_id": str(team_id)}).sort("sequence", 1)
+        events: list[PersistedEvent] = []
+        for doc in cursor:
+            doc.pop("_id", None)
+            events.append(PersistedEvent.model_validate(doc))
+        logger.debug("Loaded %d events for team %s", len(events), team_id)
+        return events
+
+    def save_agent_state(self, snapshot: AgentStateSnapshot) -> None:
+        """Persist an agent state snapshot via upsert.
+
+        Serializes the AgentStateSnapshot with ``model_dump()`` and upserts
+        into the ``agent_states`` collection keyed by ``team_id`` + ``agent_id``.
+
+        Args:
+            snapshot: The agent state snapshot to persist.
+        """
+        doc = snapshot.model_dump()
+        self._agent_states.replace_one(
+            {"team_id": str(snapshot.team_id), "agent_id": snapshot.agent_id},
+            doc,
+            upsert=True,
+        )
+        logger.debug(
+            "Saved agent state %s for team %s", snapshot.agent_id, snapshot.team_id
+        )
+
+    def load_agent_states(self, team_id: uuid.UUID) -> list[AgentStateSnapshot]:
+        """Load all agent state snapshots for a team.
+
+        Queries the ``agent_states`` collection by ``team_id``.
+
+        Args:
+            team_id: Unique identifier of the team.
+
+        Returns:
+            List of AgentStateSnapshot, or empty list if none.
+        """
+        cursor = self._agent_states.find({"team_id": str(team_id)})
+        snapshots: list[AgentStateSnapshot] = []
+        for doc in cursor:
+            doc.pop("_id", None)
+            snapshots.append(AgentStateSnapshot.model_validate(doc))
+        logger.debug("Loaded %d agent states for team %s", len(snapshots), team_id)
+        return snapshots
+
+    def delete_team(self, team_id: uuid.UUID) -> None:
+        """Delete all persisted data for a team from all three collections.
+
+        Removes documents from ``teams``, ``events``, and ``agent_states``
+        matching the given ``team_id``. If no documents exist, this is a no-op.
+
+        Args:
+            team_id: Unique identifier of the team to delete.
+        """
+        team_id_str = str(team_id)
+        self._teams.delete_many({"team_id": team_id_str})
+        self._events.delete_many({"team_id": team_id_str})
+        self._agent_states.delete_many({"team_id": team_id_str})
+        logger.debug("Deleted all data for team %s", team_id)

--- a/src/akgentic/team/repositories/mongo.py
+++ b/src/akgentic/team/repositories/mongo.py
@@ -79,7 +79,7 @@ class MongoEventStore:
         """Load a team process snapshot by ID.
 
         Queries the ``teams`` collection by ``team_id``. Returns None if no
-        document is found.
+        document is found or if the stored document is corrupted.
 
         Args:
             team_id: Unique identifier of the team.
@@ -91,7 +91,11 @@ class MongoEventStore:
         if doc is None:
             return None
         doc.pop("_id", None)
-        process = Process.model_validate(doc)
+        try:
+            process = Process.model_validate(doc)
+        except (ValueError, TypeError) as exc:
+            logger.error("Corrupted team document for team %s: %s", team_id, exc)
+            return None
         logger.debug("Loaded team %s", team_id)
         return process
 
@@ -124,7 +128,12 @@ class MongoEventStore:
         events: list[PersistedEvent] = []
         for doc in cursor:
             doc.pop("_id", None)
-            events.append(PersistedEvent.model_validate(doc))
+            try:
+                events.append(PersistedEvent.model_validate(doc))
+            except (ValueError, TypeError) as exc:
+                logger.warning(
+                    "Skipping corrupted event for team %s: %s", team_id, exc
+                )
         logger.debug("Loaded %d events for team %s", len(events), team_id)
         return events
 
@@ -162,7 +171,12 @@ class MongoEventStore:
         snapshots: list[AgentStateSnapshot] = []
         for doc in cursor:
             doc.pop("_id", None)
-            snapshots.append(AgentStateSnapshot.model_validate(doc))
+            try:
+                snapshots.append(AgentStateSnapshot.model_validate(doc))
+            except (ValueError, TypeError) as exc:
+                logger.warning(
+                    "Skipping corrupted agent state for team %s: %s", team_id, exc
+                )
         logger.debug("Loaded %d agent states for team %s", len(snapshots), team_id)
         return snapshots
 

--- a/tests/repositories/mongo/conftest.py
+++ b/tests/repositories/mongo/conftest.py
@@ -1,3 +1,31 @@
 """Test fixtures for MongoDB repository tests."""
 
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import mongomock
+import pytest
+
+if TYPE_CHECKING:
+    from akgentic.team.repositories.mongo import MongoEventStore
+
+
+@pytest.fixture
+def mongo_client() -> mongomock.MongoClient:
+    """Create a mongomock client for testing."""
+    return mongomock.MongoClient()
+
+
+@pytest.fixture
+def mongo_db(mongo_client: mongomock.MongoClient) -> mongomock.Database:
+    """Create a test database from the mongomock client."""
+    return mongo_client["test_akgentic_team"]
+
+
+@pytest.fixture
+def mongo_store(mongo_db: mongomock.Database) -> MongoEventStore:
+    """Create a MongoEventStore backed by a mongomock database."""
+    from akgentic.team.repositories.mongo import MongoEventStore
+
+    return MongoEventStore(mongo_db)

--- a/tests/repositories/mongo/test_mongo.py
+++ b/tests/repositories/mongo/test_mongo.py
@@ -12,7 +12,6 @@ import uuid
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
-import pytest
 from akgentic.core.messages.message import UserMessage
 
 from akgentic.team.models import TeamStatus
@@ -196,6 +195,70 @@ class TestMongoEventStore:
         assert isinstance(loaded[0].state, SampleAgentState)
         assert loaded[0].state.task_count == 5
 
+    # --- Corrupted data resilience ---
+
+    def test_load_team_returns_none_for_corrupted_document(
+        self, mongo_store: MongoEventStore, mongo_db: object
+    ) -> None:
+        """Corrupted team document returns None instead of raising."""
+        from mongomock import Database as MockDB
+
+        db: MockDB = mongo_db  # type: ignore[assignment]
+        db["teams"].insert_one({"team_id": "bad-uuid", "status": "INVALID", "_bogus": True})
+        result = mongo_store.load_team(uuid.UUID("00000000-0000-0000-0000-000000000000"))
+        # No document matches, so None
+        assert result is None
+
+        # Insert a document with a valid team_id but corrupted fields
+        team_id = uuid.uuid4()
+        db["teams"].insert_one({"team_id": str(team_id), "not_a_valid_field": 123})
+        result = mongo_store.load_team(team_id)
+        assert result is None
+
+    def test_load_events_skips_corrupted_documents(
+        self, mongo_store: MongoEventStore, mongo_db: object
+    ) -> None:
+        """Corrupted event documents are skipped; valid ones still loaded."""
+        from mongomock import Database as MockDB
+
+        db: MockDB = mongo_db  # type: ignore[assignment]
+        team_id = uuid.uuid4()
+
+        # Insert a valid event
+        valid_event = make_persisted_event(team_id=team_id, sequence=1)
+        mongo_store.save_event(valid_event)
+
+        # Insert a corrupted event document directly
+        db["events"].insert_one(
+            {"team_id": str(team_id), "sequence": 2, "corrupted": True}
+        )
+
+        loaded = mongo_store.load_events(team_id)
+        assert len(loaded) == 1
+        assert loaded[0].sequence == 1
+
+    def test_load_agent_states_skips_corrupted_documents(
+        self, mongo_store: MongoEventStore, mongo_db: object
+    ) -> None:
+        """Corrupted agent state documents are skipped; valid ones still loaded."""
+        from mongomock import Database as MockDB
+
+        db: MockDB = mongo_db  # type: ignore[assignment]
+        team_id = uuid.uuid4()
+
+        # Save a valid snapshot
+        snap = make_agent_state_snapshot(team_id=team_id, agent_id="good-agent")
+        mongo_store.save_agent_state(snap)
+
+        # Insert a corrupted agent state document directly
+        db["agent_states"].insert_one(
+            {"team_id": str(team_id), "agent_id": "bad-agent", "corrupted": True}
+        )
+
+        loaded = mongo_store.load_agent_states(team_id)
+        assert len(loaded) == 1
+        assert loaded[0].agent_id == "good-agent"
+
     # --- Protocol compliance (AC9) ---
 
     def test_satisfies_event_store_protocol(
@@ -220,20 +283,37 @@ class TestMongoEventStore:
 
         import akgentic.team.repositories as repos_module
 
-        # Remove cached mongo module so reload actually re-imports
+        # Save and remove cached mongo and pymongo modules
         mongo_module_key = "akgentic.team.repositories.mongo"
-        saved_mongo = sys.modules.pop(mongo_module_key, None)
+        saved: dict[str, object] = {}
+        for key in list(sys.modules):
+            if key.startswith(mongo_module_key):
+                saved[key] = sys.modules.pop(key)
+        pymongo_saved: dict[str, object] = {}
+        for key in list(sys.modules):
+            if key.startswith("pymongo"):
+                pymongo_saved[key] = sys.modules.pop(key)
 
         try:
             # Simulate pymongo being unavailable
             with patch.dict(
-                "sys.modules",
+                sys.modules,
                 {"pymongo": None, "pymongo.database": None, "pymongo.collection": None},
             ):
+                # Verify repositories __init__ removes MongoEventStore from __all__
                 importlib.reload(repos_module)
                 assert "MongoEventStore" not in repos_module.__all__
+
+                # Verify direct import of mongo module raises helpful ImportError
+                try:
+                    importlib.import_module(mongo_module_key)
+                    msg = "Expected ImportError was not raised"
+                    raise AssertionError(msg)
+                except ImportError as exc:
+                    assert "pymongo is required" in str(exc)
+                    assert "akgentic-team[mongo]" in str(exc)
         finally:
-            # Restore cached module and reload to normal state
-            if saved_mongo is not None:
-                sys.modules[mongo_module_key] = saved_mongo
+            # Restore all saved modules
+            sys.modules.update(saved)  # type: ignore[arg-type]
+            sys.modules.update(pymongo_saved)  # type: ignore[arg-type]
             importlib.reload(repos_module)

--- a/tests/repositories/mongo/test_mongo.py
+++ b/tests/repositories/mongo/test_mongo.py
@@ -1,0 +1,239 @@
+"""Tests for MongoEventStore -- MongoDB-backed EventStore implementation.
+
+Validates all seven EventStore protocol methods including round-trip
+serialization of polymorphic Message and BaseState fields.
+
+Acceptance Criteria: AC1-AC13 from Story 5.1.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from akgentic.core.messages.message import UserMessage
+
+from akgentic.team.models import TeamStatus
+from akgentic.team.repositories.mongo import MongoEventStore
+
+if TYPE_CHECKING:
+    from akgentic.team.ports import EventStore
+
+from tests.models.conftest import (
+    SampleAgentState,
+    make_agent_state_snapshot,
+    make_persisted_event,
+    make_process,
+)
+
+
+class TestMongoEventStore:
+    """Tests for MongoEventStore covering all EventStore protocol methods (AC1-AC13)."""
+
+    # --- save_team / load_team (AC2, AC3) ---
+
+    def test_save_and_load_team_round_trip(self, mongo_store: MongoEventStore) -> None:
+        """AC2: save_team upserts into teams collection; load_team deserializes it back."""
+        process = make_process()
+        mongo_store.save_team(process)
+        loaded = mongo_store.load_team(process.team_id)
+
+        assert loaded is not None
+        assert loaded.team_id == process.team_id
+        assert loaded.status == process.status
+        assert loaded.team_card.name == process.team_card.name
+        assert loaded.created_at == process.created_at
+
+    def test_load_team_returns_none_for_nonexistent(
+        self, mongo_store: MongoEventStore
+    ) -> None:
+        """AC3: load_team returns None when no document exists."""
+        result = mongo_store.load_team(uuid.uuid4())
+        assert result is None
+
+    def test_save_team_upserts_on_second_call(
+        self, mongo_store: MongoEventStore
+    ) -> None:
+        """AC2: save_team upserts on subsequent calls for the same team_id."""
+        process = make_process(status=TeamStatus.RUNNING)
+        mongo_store.save_team(process)
+
+        updated = make_process(team_id=process.team_id, status=TeamStatus.STOPPED)
+        mongo_store.save_team(updated)
+
+        loaded = mongo_store.load_team(process.team_id)
+        assert loaded is not None
+        assert loaded.status == TeamStatus.STOPPED
+
+    # --- save_event / load_events (AC4, AC5) ---
+
+    def test_save_and_load_events_round_trip(
+        self, mongo_store: MongoEventStore
+    ) -> None:
+        """AC4, AC5: save_event inserts; load_events returns ordered by sequence."""
+        team_id = uuid.uuid4()
+        events = [
+            make_persisted_event(team_id=team_id, sequence=3),
+            make_persisted_event(team_id=team_id, sequence=1),
+            make_persisted_event(team_id=team_id, sequence=2),
+        ]
+        for event in events:
+            mongo_store.save_event(event)
+
+        loaded = mongo_store.load_events(team_id)
+        assert len(loaded) == 3
+        assert [e.sequence for e in loaded] == [1, 2, 3]
+
+    def test_load_events_returns_empty_for_nonexistent(
+        self, mongo_store: MongoEventStore
+    ) -> None:
+        """AC5: load_events returns [] for a team with no events."""
+        result = mongo_store.load_events(uuid.uuid4())
+        assert result == []
+
+    # --- save_agent_state / load_agent_states (AC6, AC7) ---
+
+    def test_save_and_load_agent_states_round_trip(
+        self, mongo_store: MongoEventStore
+    ) -> None:
+        """AC6, AC7: save_agent_state writes; load_agent_states reads all."""
+        team_id = uuid.uuid4()
+        snap1 = make_agent_state_snapshot(team_id=team_id, agent_id="agent-a")
+        snap2 = make_agent_state_snapshot(team_id=team_id, agent_id="agent-b")
+        mongo_store.save_agent_state(snap1)
+        mongo_store.save_agent_state(snap2)
+
+        loaded = mongo_store.load_agent_states(team_id)
+        assert len(loaded) == 2
+        agent_ids = {s.agent_id for s in loaded}
+        assert agent_ids == {"agent-a", "agent-b"}
+
+    def test_save_agent_state_upserts_for_same_agent(
+        self, mongo_store: MongoEventStore
+    ) -> None:
+        """AC6: save_agent_state upserts for the same agent_id."""
+        team_id = uuid.uuid4()
+        snap1 = make_agent_state_snapshot(
+            team_id=team_id, agent_id="agent-a", state=SampleAgentState(task_count=1)
+        )
+        mongo_store.save_agent_state(snap1)
+
+        snap2 = make_agent_state_snapshot(
+            team_id=team_id, agent_id="agent-a", state=SampleAgentState(task_count=99)
+        )
+        mongo_store.save_agent_state(snap2)
+
+        loaded = mongo_store.load_agent_states(team_id)
+        assert len(loaded) == 1
+        assert isinstance(loaded[0].state, SampleAgentState)
+        assert loaded[0].state.task_count == 99
+
+    def test_load_agent_states_returns_empty_for_nonexistent(
+        self, mongo_store: MongoEventStore
+    ) -> None:
+        """AC7: load_agent_states returns [] for a team with no agent states."""
+        result = mongo_store.load_agent_states(uuid.uuid4())
+        assert result == []
+
+    # --- delete_team (AC8) ---
+
+    def test_delete_team_removes_all_documents(
+        self, mongo_store: MongoEventStore
+    ) -> None:
+        """AC8: delete_team removes documents from all three collections."""
+        process = make_process()
+        mongo_store.save_team(process)
+        mongo_store.save_event(
+            make_persisted_event(team_id=process.team_id, sequence=1)
+        )
+        mongo_store.save_agent_state(
+            make_agent_state_snapshot(team_id=process.team_id, agent_id="a")
+        )
+
+        mongo_store.delete_team(process.team_id)
+
+        assert mongo_store.load_team(process.team_id) is None
+        assert mongo_store.load_events(process.team_id) == []
+        assert mongo_store.load_agent_states(process.team_id) == []
+
+    def test_delete_team_noop_for_nonexistent(
+        self, mongo_store: MongoEventStore
+    ) -> None:
+        """AC8: delete_team is a no-op for non-existent team (no error)."""
+        mongo_store.delete_team(uuid.uuid4())  # should not raise
+
+    # --- Polymorphic round-trip (AC11) ---
+
+    def test_polymorphic_event_round_trip(
+        self, mongo_store: MongoEventStore
+    ) -> None:
+        """AC11: PersistedEvent with UserMessage survives MongoDB round-trip."""
+        team_id = uuid.uuid4()
+        msg = UserMessage(content="hello from polymorphic test")
+        event = make_persisted_event(team_id=team_id, sequence=1, event=msg)
+        mongo_store.save_event(event)
+
+        loaded = mongo_store.load_events(team_id)
+        assert len(loaded) == 1
+        assert isinstance(loaded[0].event, UserMessage)
+        assert loaded[0].event.content == "hello from polymorphic test"
+
+    def test_polymorphic_agent_state_round_trip(
+        self, mongo_store: MongoEventStore
+    ) -> None:
+        """AC11: AgentStateSnapshot with SampleAgentState survives MongoDB round-trip."""
+        team_id = uuid.uuid4()
+        state = SampleAgentState(task_count=5)
+        snap = make_agent_state_snapshot(
+            team_id=team_id, agent_id="poly-agent", state=state
+        )
+        mongo_store.save_agent_state(snap)
+
+        loaded = mongo_store.load_agent_states(team_id)
+        assert len(loaded) == 1
+        assert isinstance(loaded[0].state, SampleAgentState)
+        assert loaded[0].state.task_count == 5
+
+    # --- Protocol compliance (AC9) ---
+
+    def test_satisfies_event_store_protocol(
+        self, mongo_store: MongoEventStore
+    ) -> None:
+        """AC9: MongoEventStore satisfies EventStore Protocol via structural subtyping."""
+        store: EventStore = mongo_store
+        assert store is not None
+
+    # --- Import guard (AC10) ---
+
+    def test_import_succeeds_when_pymongo_installed(self) -> None:
+        """AC10: MongoEventStore is importable when pymongo is available."""
+        from akgentic.team.repositories.mongo import MongoEventStore as Imported
+
+        assert Imported is MongoEventStore
+
+    def test_import_guard_when_pymongo_missing(self) -> None:
+        """AC10: Conditional import fails gracefully when pymongo is unavailable."""
+        import importlib
+        import sys
+
+        import akgentic.team.repositories as repos_module
+
+        # Remove cached mongo module so reload actually re-imports
+        mongo_module_key = "akgentic.team.repositories.mongo"
+        saved_mongo = sys.modules.pop(mongo_module_key, None)
+
+        try:
+            # Simulate pymongo being unavailable
+            with patch.dict(
+                "sys.modules",
+                {"pymongo": None, "pymongo.database": None, "pymongo.collection": None},
+            ):
+                importlib.reload(repos_module)
+                assert "MongoEventStore" not in repos_module.__all__
+        finally:
+            # Restore cached module and reload to normal state
+            if saved_mongo is not None:
+                sys.modules[mongo_module_key] = saved_mongo
+            importlib.reload(repos_module)


### PR DESCRIPTION
## Summary

- Implement `MongoEventStore` with all 7 `EventStore` protocol methods using pymongo
- Three MongoDB collections: `teams` (upsert), `events` (append-only), `agent_states` (upsert by team_id + agent_id)
- Structural subtyping (no inheritance from EventStore Protocol)
- Conditional import guard: pymongo gated behind `[mongo]` optional extra
- Error handling for corrupted documents in all load methods
- 18 tests covering protocol methods, polymorphic round-trips, upserts, delete purge, corrupted data resilience, protocol compliance, and import guard

Closes #27