### PR TITLE
CLI scaffold with list and inspect commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dev = [
     "mongomock>=4.0.0",
 ]
 
+[project.scripts]
+ak-team = "akgentic.team.cli.main:app"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/src/akgentic/team/cli/__init__.py
+++ b/src/akgentic/team/cli/__init__.py
@@ -1,3 +1,20 @@
-"""CLI interface for team lifecycle management."""
+"""CLI interface for team lifecycle management.
+
+Provides the ``ak-team`` command for managing team instances from the
+command line with list and inspect operations.
+
+Requires the ``cli`` extra: ``pip install akgentic-team[cli]``.
+"""
 
 from __future__ import annotations
+
+try:
+    import typer as _typer  # noqa: F401
+except ImportError as exc:
+    raise ImportError(
+        "Typer is required. Install with: pip install akgentic-team[cli]"
+    ) from exc
+
+from akgentic.team.cli.main import app
+
+__all__ = ["app"]

--- a/src/akgentic/team/cli/_output.py
+++ b/src/akgentic/team/cli/_output.py
@@ -1,0 +1,210 @@
+"""Output rendering for the team CLI.
+
+Supports three output formats: Rich table (default), JSON, and YAML.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+import yaml
+from pydantic import BaseModel
+from rich.console import Console
+from rich.table import Table
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = ["OutputFormat", "render"]
+
+logger = logging.getLogger(__name__)
+
+console = Console()
+
+# Column definitions for Process list view: (field_path, header_label)
+_TABLE_COLUMNS: list[tuple[str, str]] = [
+    ("team_id", "Team ID"),
+    ("team_card.name", "Name"),
+    ("status", "Status"),
+    ("created_at", "Created"),
+    ("updated_at", "Updated"),
+]
+
+
+class OutputFormat(StrEnum):
+    """CLI output format options."""
+
+    table = "table"
+    json = "json"
+    yaml = "yaml"
+
+
+def _get_field_value(model: BaseModel, dotted_path: str) -> str:
+    """Resolve a dotted field path on a Pydantic model to a string value.
+
+    Args:
+        model: The Pydantic model instance.
+        dotted_path: A dot-separated field path (e.g. ``"team_card.name"``).
+
+    Returns:
+        String representation of the resolved value.
+    """
+    obj: Any = model
+    for part in dotted_path.split("."):
+        if isinstance(obj, BaseModel):
+            obj = getattr(obj, part, None)
+        elif isinstance(obj, dict):
+            obj = obj.get(part)
+        else:
+            return ""
+    return str(obj) if obj is not None else ""
+
+
+def _render_list_table(entries: Sequence[BaseModel]) -> None:
+    """Render a list of Process entries as a Rich table.
+
+    Team IDs are truncated to 8 characters for display readability.
+
+    Args:
+        entries: Sequence of Process model instances.
+    """
+    if not entries:
+        console.print("[dim]No teams found.[/dim]")
+        return
+
+    table = Table(title="Teams")
+    for _, header in _TABLE_COLUMNS:
+        table.add_column(header)
+
+    for entry in entries:
+        row: list[str] = []
+        for field_path, _ in _TABLE_COLUMNS:
+            value = _get_field_value(entry, field_path)
+            if field_path == "team_id":
+                value = value[:8]
+            row.append(value)
+        table.add_row(*row)
+
+    console.print(table)
+
+
+def _render_detail_table(
+    entry: BaseModel,
+    *,
+    event_count: int = 0,
+    agent_state_count: int = 0,
+) -> None:
+    """Render a single Process entry as a Rich key-value detail table.
+
+    Args:
+        entry: A Process model instance.
+        event_count: Number of persisted events for the team.
+        agent_state_count: Number of agent state snapshots for the team.
+    """
+    table = Table(title="Team Detail", show_header=False)
+    table.add_column("Field", style="bold")
+    table.add_column("Value")
+
+    data = entry.model_dump(mode="json")
+    team_card = data.get("team_card", {})
+    agent_cards = team_card.get("agent_cards", {})
+
+    table.add_row("team_id", str(data.get("team_id", "")))
+    table.add_row("name", str(team_card.get("name", "")))
+    table.add_row("description", str(team_card.get("description", "")))
+    table.add_row("status", str(data.get("status", "")))
+    table.add_row("user_id", str(data.get("user_id", "")))
+    table.add_row("user_email", str(data.get("user_email", "")))
+    table.add_row("created_at", str(data.get("created_at", "")))
+    table.add_row("updated_at", str(data.get("updated_at", "")))
+    table.add_row("member_count", str(len(agent_cards)))
+    table.add_row("event_count", str(event_count))
+    table.add_row("agent_state_count", str(agent_state_count))
+
+    console.print(table)
+
+
+def _render_json(
+    entries: Sequence[BaseModel] | BaseModel,
+    *,
+    event_count: int | None = None,
+    agent_state_count: int | None = None,
+) -> None:
+    """Render entries as JSON to stdout.
+
+    Args:
+        entries: A single entry or sequence of entries to render.
+        event_count: Optional event count for detail view.
+        agent_state_count: Optional agent state count for detail view.
+    """
+    data: dict[str, Any] | list[dict[str, Any]]
+    if isinstance(entries, BaseModel):
+        data = entries.model_dump(mode="json")
+        if event_count is not None:
+            data["event_count"] = event_count
+        if agent_state_count is not None:
+            data["agent_state_count"] = agent_state_count
+    else:
+        data = [e.model_dump(mode="json") for e in entries]
+    console.print(json.dumps(data, indent=2))
+
+
+def _render_yaml(
+    entries: Sequence[BaseModel] | BaseModel,
+    *,
+    event_count: int | None = None,
+    agent_state_count: int | None = None,
+) -> None:
+    """Render entries as YAML to stdout.
+
+    Args:
+        entries: A single entry or sequence of entries to render.
+        event_count: Optional event count for detail view.
+        agent_state_count: Optional agent state count for detail view.
+    """
+    data: dict[str, Any] | list[dict[str, Any]]
+    if isinstance(entries, BaseModel):
+        data = entries.model_dump(mode="json")
+        if event_count is not None:
+            data["event_count"] = event_count
+        if agent_state_count is not None:
+            data["agent_state_count"] = agent_state_count
+    else:
+        data = [e.model_dump(mode="json") for e in entries]
+    console.print(yaml.dump(data, default_flow_style=False).rstrip())
+
+
+def render(
+    entries: Sequence[BaseModel] | BaseModel,
+    fmt: OutputFormat,
+    *,
+    event_count: int | None = None,
+    agent_state_count: int | None = None,
+) -> None:
+    """Render team entries in the requested format.
+
+    Args:
+        entries: A single entry or sequence of entries to render.
+        fmt: The output format (table, json, or yaml).
+        event_count: Optional event count for inspect detail view.
+        agent_state_count: Optional agent state count for inspect detail view.
+    """
+    if fmt == OutputFormat.json:
+        _render_json(
+            entries, event_count=event_count, agent_state_count=agent_state_count
+        )
+    elif fmt == OutputFormat.yaml:
+        _render_yaml(
+            entries, event_count=event_count, agent_state_count=agent_state_count
+        )
+    elif isinstance(entries, BaseModel):
+        _render_detail_table(
+            entries,
+            event_count=event_count or 0,
+            agent_state_count=agent_state_count or 0,
+        )
+    else:
+        _render_list_table(entries)

--- a/src/akgentic/team/cli/_output.py
+++ b/src/akgentic/team/cli/_output.py
@@ -203,8 +203,8 @@ def render(
     elif isinstance(entries, BaseModel):
         _render_detail_table(
             entries,
-            event_count=event_count or 0,
-            agent_state_count=agent_state_count or 0,
+            event_count=event_count if event_count is not None else 0,
+            agent_state_count=agent_state_count if agent_state_count is not None else 0,
         )
     else:
         _render_list_table(entries)

--- a/src/akgentic/team/cli/main.py
+++ b/src/akgentic/team/cli/main.py
@@ -1,3 +1,227 @@
-"""ak-team Typer CLI application via [cli] optional extra."""
+"""ak-team Typer CLI application via [cli] optional extra.
+
+Provides the ``ak-team`` entry point with global options and subcommands
+for managing team lifecycle instances.
+"""
 
 from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from akgentic.team.cli._output import OutputFormat, render
+from akgentic.team.ports import EventStore
+
+__all__ = ["app"]
+
+logger = logging.getLogger(__name__)
+err_console = Console(stderr=True)
+
+
+@dataclass
+class GlobalState:
+    """Shared state passed through Typer context.
+
+    Attributes:
+        data_dir: Root directory for team data files.
+        format: Output format for command results.
+        backend: Storage backend (yaml or mongodb).
+        mongo_uri: MongoDB connection URI.
+        mongo_db: MongoDB database name.
+    """
+
+    data_dir: Path = field(default_factory=lambda: Path("./data/"))
+    format: OutputFormat = OutputFormat.table
+    backend: str = "yaml"
+    mongo_uri: str | None = None
+    mongo_db: str | None = None
+
+
+app = typer.Typer(name="ak-team", help="Manage team instances.")
+
+
+@app.callback()
+def main(
+    ctx: typer.Context,
+    data_dir: Path = typer.Option(
+        Path("./data/"),
+        "--data-dir",
+        help="Root directory for team data files.",
+    ),
+    fmt: OutputFormat = typer.Option(
+        OutputFormat.table,
+        "--format",
+        help="Output format: table, json, or yaml.",
+    ),
+    backend: str = typer.Option(
+        "yaml",
+        "--backend",
+        help="Storage backend: yaml or mongodb.",
+    ),
+    mongo_uri: str | None = typer.Option(
+        None,
+        "--mongo-uri",
+        envvar="MONGO_URI",
+        help="MongoDB connection URI (required when --backend=mongodb).",
+    ),
+    mongo_db: str | None = typer.Option(
+        None,
+        "--mongo-db",
+        envvar="MONGO_DB",
+        help="MongoDB database name (required when --backend=mongodb).",
+    ),
+) -> None:
+    """Akgentic team CLI -- manage team lifecycle instances."""
+    valid_backends = ("yaml", "mongodb")
+    if backend not in valid_backends:
+        err_console.print(
+            f"[red]Error:[/red] Invalid backend '{backend}'. "
+            f"Must be one of: {', '.join(valid_backends)}"
+        )
+        raise typer.Exit(code=1)
+
+    if backend == "mongodb":
+        errors = _validate_mongodb_options(mongo_uri, mongo_db)
+        if errors:
+            for err in errors:
+                err_console.print(f"[red]Error:[/red] {err}")
+            raise typer.Exit(code=1)
+
+    ctx.ensure_object(dict)
+    ctx.obj = GlobalState(
+        data_dir=data_dir,
+        format=fmt,
+        backend=backend,
+        mongo_uri=mongo_uri,
+        mongo_db=mongo_db,
+    )
+
+
+def _validate_mongodb_options(
+    mongo_uri: str | None,
+    mongo_db: str | None,
+) -> list[str]:
+    """Validate MongoDB connection options and return error messages.
+
+    Args:
+        mongo_uri: MongoDB connection URI, or None if not provided.
+        mongo_db: MongoDB database name, or None if not provided.
+
+    Returns:
+        List of error message strings (empty if valid).
+    """
+    errors: list[str] = []
+    if not mongo_uri:
+        errors.append(
+            "--mongo-uri (or MONGO_URI env var) is required when --backend=mongodb"
+        )
+    if not mongo_db:
+        errors.append(
+            "--mongo-db (or MONGO_DB env var) is required when --backend=mongodb"
+        )
+    return errors
+
+
+def _build_event_store(state: GlobalState) -> EventStore:
+    """Construct an EventStore from the global CLI state.
+
+    Args:
+        state: The global state containing backend configuration.
+
+    Returns:
+        An EventStore implementation matching the configured backend.
+    """
+    if state.backend == "mongodb":
+        import pymongo
+
+        client: pymongo.MongoClient = pymongo.MongoClient(state.mongo_uri)  # type: ignore[type-arg]
+        db = client[state.mongo_db]  # type: ignore[index]
+        from akgentic.team.repositories.mongo import MongoEventStore
+
+        return MongoEventStore(db)
+
+    from akgentic.team.repositories.yaml import YamlEventStore
+
+    return YamlEventStore(state.data_dir)
+
+
+def _get_state(ctx: typer.Context) -> GlobalState:
+    """Retrieve the global state from the Typer context.
+
+    Args:
+        ctx: The current Typer command context.
+
+    Returns:
+        The GlobalState instance stored in ctx.obj, or a default.
+    """
+    state: GlobalState = ctx.obj
+    if state is None:
+        state = GlobalState()
+    return state
+
+
+@app.command(name="list")
+def list_teams_cmd(
+    ctx: typer.Context,
+    status: str | None = typer.Option(
+        None,
+        "--status",
+        help="Filter by team status: running, stopped, or deleted.",
+    ),
+) -> None:
+    """List all team instances."""
+    state = _get_state(ctx)
+    event_store = _build_event_store(state)
+    teams = event_store.list_teams()
+
+    if status is not None:
+        valid_statuses = ("running", "stopped", "deleted")
+        if status not in valid_statuses:
+            err_console.print(
+                f"[red]Error:[/red] Invalid status '{status}'. "
+                f"Must be one of: {', '.join(valid_statuses)}"
+            )
+            raise typer.Exit(code=1)
+        teams = [t for t in teams if t.status.value == status]
+
+    render(teams, state.format)
+
+
+@app.command(name="inspect")
+def inspect_cmd(
+    ctx: typer.Context,
+    team_id: str = typer.Argument(help="Team UUID to inspect."),
+) -> None:
+    """Inspect a team instance by ID."""
+    try:
+        parsed_id = uuid.UUID(team_id)
+    except ValueError:
+        err_console.print(
+            f"[red]Error:[/red] Invalid UUID format: '{team_id}'"
+        )
+        raise typer.Exit(code=1)  # noqa: B904
+
+    state = _get_state(ctx)
+    event_store = _build_event_store(state)
+    process = event_store.load_team(parsed_id)
+
+    if process is None:
+        err_console.print(
+            f"[red]Error:[/red] Team '{team_id}' not found."
+        )
+        raise typer.Exit(code=1)
+
+    event_count = len(event_store.load_events(parsed_id))
+    agent_state_count = len(event_store.load_agent_states(parsed_id))
+
+    render(
+        process,
+        state.format,
+        event_count=event_count,
+        agent_state_count=agent_state_count,
+    )

--- a/src/akgentic/team/cli/main.py
+++ b/src/akgentic/team/cli/main.py
@@ -139,8 +139,16 @@ def _build_event_store(state: GlobalState) -> EventStore:
     if state.backend == "mongodb":
         import pymongo
 
-        client: pymongo.MongoClient = pymongo.MongoClient(state.mongo_uri)  # type: ignore[type-arg]
-        db = client[state.mongo_db]  # type: ignore[index]
+        try:
+            client: pymongo.MongoClient = pymongo.MongoClient(  # type: ignore[type-arg]
+                state.mongo_uri, serverSelectionTimeoutMS=5000
+            )
+            db = client[state.mongo_db]  # type: ignore[index]
+        except Exception as exc:  # noqa: BLE001
+            err_console.print(
+                f"[red]Error:[/red] Failed to connect to MongoDB: {exc}"
+            )
+            raise typer.Exit(code=1) from exc
         from akgentic.team.repositories.mongo import MongoEventStore
 
         return MongoEventStore(db)

--- a/src/akgentic/team/ports.py
+++ b/src/akgentic/team/ports.py
@@ -63,6 +63,13 @@ class EventStore(Protocol):
         """
         ...
 
+    def list_teams(self) -> list[Process]:
+        """Load all team process snapshots.
+
+        Called by the CLI to enumerate all known teams.
+        """
+        ...
+
     def load_agent_states(self, team_id: uuid.UUID) -> list[AgentStateSnapshot]:
         """Load all agent state snapshots for a team.
 

--- a/src/akgentic/team/repositories/mongo.py
+++ b/src/akgentic/team/repositories/mongo.py
@@ -99,6 +99,26 @@ class MongoEventStore:
         logger.debug("Loaded team %s", team_id)
         return process
 
+    def list_teams(self) -> list[Process]:
+        """Load all team process snapshots from the teams collection.
+
+        Queries all documents in the ``teams`` collection and reconstructs
+        each as a Process via ``model_validate()``. Corrupted documents
+        are skipped with a warning.
+
+        Returns:
+            List of all loadable Process snapshots.
+        """
+        teams: list[Process] = []
+        for doc in self._teams.find({}):
+            doc.pop("_id", None)
+            try:
+                teams.append(Process.model_validate(doc))
+            except (ValueError, TypeError) as exc:
+                logger.warning("Skipping corrupted team document: %s", exc)
+        logger.debug("Listed %d teams", len(teams))
+        return teams
+
     def save_event(self, event: PersistedEvent) -> None:
         """Persist a single domain event (append-only).
 

--- a/src/akgentic/team/repositories/yaml.py
+++ b/src/akgentic/team/repositories/yaml.py
@@ -110,6 +110,32 @@ class YamlEventStore:
         logger.debug("Loaded team %s from %s", team_id, team_path)
         return process
 
+    def list_teams(self) -> list[Process]:
+        """Load all team process snapshots from the data directory.
+
+        Iterates subdirectories of ``data_dir``, attempts to parse each
+        directory name as a UUID, and loads the team snapshot for valid
+        team directories. Non-UUID directories are skipped with a warning.
+
+        Returns:
+            List of all loadable Process snapshots.
+        """
+        if not self._data_dir.exists():
+            return []
+        teams: list[Process] = []
+        for child in sorted(self._data_dir.iterdir()):
+            if not child.is_dir():
+                continue
+            try:
+                team_id = uuid.UUID(child.name)
+            except ValueError:
+                logger.warning("Skipping non-team directory: %s", child.name)
+                continue
+            process = self.load_team(team_id)
+            if process is not None:
+                teams.append(process)
+        return teams
+
     def save_event(self, event: PersistedEvent) -> None:
         """Append a persisted event to events.yaml.
 

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,3 +1,56 @@
 """Test fixtures for team CLI tests."""
 
 from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from akgentic.team.models import Process, TeamStatus
+from akgentic.team.repositories.yaml import YamlEventStore
+
+from tests.models.conftest import make_process
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """Create a Typer CliRunner for CLI tests."""
+    return CliRunner()
+
+
+@pytest.fixture
+def data_dir(tmp_path: Path) -> Path:
+    """Create a temporary data directory for CLI tests."""
+    d = tmp_path / "data"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def yaml_store(data_dir: Path) -> YamlEventStore:
+    """Create a YamlEventStore backed by a temporary directory."""
+    return YamlEventStore(data_dir)
+
+
+def populate_teams(
+    store: YamlEventStore,
+    count: int = 2,
+    status: TeamStatus = TeamStatus.RUNNING,
+) -> list[Process]:
+    """Pre-populate the store with team processes.
+
+    Args:
+        store: The YamlEventStore to populate.
+        count: Number of teams to create.
+        status: Status for all created teams.
+
+    Returns:
+        List of created Process instances.
+    """
+    teams: list[Process] = []
+    for _ in range(count):
+        p = make_process(status=status)
+        store.save_team(p)
+        teams.append(p)
+    return teams

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,0 +1,177 @@
+"""Tests for the ak-team CLI commands.
+
+Validates list, inspect, and global options using Typer CliRunner
+with YamlEventStore backed by temporary directories.
+
+Acceptance Criteria: AC1-AC11 from Story 6.1.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import yaml
+from typer.testing import CliRunner
+
+from akgentic.team.cli.main import app
+from akgentic.team.models import TeamStatus
+from akgentic.team.repositories.yaml import YamlEventStore
+
+from tests.cli.conftest import populate_teams
+from tests.models.conftest import (
+    make_agent_state_snapshot,
+    make_persisted_event,
+    make_process,
+)
+
+
+class TestListCommand:
+    """Tests for `ak-team list` command (AC2, AC3, AC4, AC5)."""
+
+    def test_list_with_no_teams_returns_empty(
+        self, cli_runner: CliRunner, data_dir: object
+    ) -> None:
+        """AC4: list with no teams shows empty output, exit code 0."""
+        result = cli_runner.invoke(app, ["--data-dir", str(data_dir), "list"])
+        assert result.exit_code == 0
+        assert "No teams found" in result.output
+
+    def test_list_with_teams_shows_all(
+        self, cli_runner: CliRunner, data_dir: object, yaml_store: YamlEventStore
+    ) -> None:
+        """AC2: list with teams shows all team names and IDs."""
+        teams = populate_teams(yaml_store, count=2)
+        result = cli_runner.invoke(app, ["--data-dir", str(data_dir), "list"])
+        assert result.exit_code == 0
+        for t in teams:
+            # Table truncates to 8 chars
+            assert str(t.team_id)[:8] in result.output
+            assert t.team_card.name in result.output
+
+    def test_list_status_filter_running(
+        self, cli_runner: CliRunner, data_dir: object, yaml_store: YamlEventStore
+    ) -> None:
+        """AC3: list --status running filters correctly."""
+        running = populate_teams(yaml_store, count=1, status=TeamStatus.RUNNING)
+        stopped = populate_teams(yaml_store, count=1, status=TeamStatus.STOPPED)
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "list", "--status", "running"]
+        )
+        assert result.exit_code == 0
+        assert str(running[0].team_id)[:8] in result.output
+        assert str(stopped[0].team_id)[:8] not in result.output
+
+    def test_list_format_json(
+        self, cli_runner: CliRunner, data_dir: object, yaml_store: YamlEventStore
+    ) -> None:
+        """AC5: list --format json produces valid JSON."""
+        populate_teams(yaml_store, count=1)
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "--format", "json", "list"]
+        )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+
+    def test_list_format_yaml(
+        self, cli_runner: CliRunner, data_dir: object, yaml_store: YamlEventStore
+    ) -> None:
+        """AC5: list --format yaml produces valid YAML."""
+        populate_teams(yaml_store, count=1)
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "--format", "yaml", "list"]
+        )
+        assert result.exit_code == 0
+        parsed = yaml.safe_load(result.output)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+
+
+class TestInspectCommand:
+    """Tests for `ak-team inspect` command (AC6, AC7)."""
+
+    def test_inspect_existing_team(
+        self, cli_runner: CliRunner, data_dir: object, yaml_store: YamlEventStore
+    ) -> None:
+        """AC6: inspect shows full metadata for existing team."""
+        process = make_process()
+        yaml_store.save_team(process)
+        yaml_store.save_event(
+            make_persisted_event(team_id=process.team_id, sequence=1)
+        )
+        yaml_store.save_agent_state(
+            make_agent_state_snapshot(team_id=process.team_id, agent_id="agent-a")
+        )
+
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "inspect", str(process.team_id)]
+        )
+        assert result.exit_code == 0
+        assert str(process.team_id) in result.output
+        assert process.team_card.name in result.output
+
+    def test_inspect_nonexistent_team(
+        self, cli_runner: CliRunner, data_dir: object
+    ) -> None:
+        """AC7: inspect non-existent team shows error, exit code 1."""
+        fake_id = str(uuid.uuid4())
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "inspect", fake_id]
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+    def test_inspect_invalid_uuid(
+        self, cli_runner: CliRunner, data_dir: object
+    ) -> None:
+        """AC7: inspect with invalid UUID shows error, exit code 1."""
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "inspect", "not-a-uuid"]
+        )
+        assert result.exit_code == 1
+        assert "Invalid UUID" in result.output
+
+    def test_inspect_json_format(
+        self, cli_runner: CliRunner, data_dir: object, yaml_store: YamlEventStore
+    ) -> None:
+        """AC5, AC6: inspect --format json includes event and agent state counts."""
+        process = make_process()
+        yaml_store.save_team(process)
+        yaml_store.save_event(
+            make_persisted_event(team_id=process.team_id, sequence=1)
+        )
+
+        result = cli_runner.invoke(
+            app,
+            [
+                "--data-dir", str(data_dir),
+                "--format", "json",
+                "inspect", str(process.team_id),
+            ],
+        )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["event_count"] == 1
+        assert parsed["agent_state_count"] == 0
+
+
+class TestGlobalOptions:
+    """Tests for global CLI options (AC1, AC8)."""
+
+    def test_invalid_backend(self, cli_runner: CliRunner) -> None:
+        """AC1: Invalid backend shows error, exit code 1."""
+        result = cli_runner.invoke(
+            app, ["--backend", "sqlite", "list"]
+        )
+        assert result.exit_code == 1
+        assert "Invalid backend" in result.output
+
+    def test_mongodb_backend_without_mongo_uri(self, cli_runner: CliRunner) -> None:
+        """AC1: --backend mongodb without --mongo-uri shows error."""
+        result = cli_runner.invoke(
+            app, ["--backend", "mongodb", "list"]
+        )
+        assert result.exit_code == 1
+        assert "--mongo-uri" in result.output

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -175,3 +175,13 @@ class TestGlobalOptions:
         )
         assert result.exit_code == 1
         assert "--mongo-uri" in result.output
+
+    def test_list_invalid_status_filter(
+        self, cli_runner: CliRunner, data_dir: object
+    ) -> None:
+        """AC3: list --status with invalid value shows error, exit code 1."""
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "list", "--status", "bogus"]
+        )
+        assert result.exit_code == 1
+        assert "Invalid status" in result.output

--- a/tests/repositories/mongo/test_mongo.py
+++ b/tests/repositories/mongo/test_mongo.py
@@ -195,6 +195,29 @@ class TestMongoEventStore:
         assert isinstance(loaded[0].state, SampleAgentState)
         assert loaded[0].state.task_count == 5
 
+    # --- list_teams (AC9) ---
+
+    def test_list_teams_returns_empty_when_no_teams(
+        self, mongo_store: MongoEventStore
+    ) -> None:
+        """AC9: list_teams returns [] when no teams exist."""
+        result = mongo_store.list_teams()
+        assert result == []
+
+    def test_list_teams_returns_all_teams(
+        self, mongo_store: MongoEventStore
+    ) -> None:
+        """AC9: list_teams returns all saved team processes."""
+        p1 = make_process()
+        p2 = make_process()
+        mongo_store.save_team(p1)
+        mongo_store.save_team(p2)
+
+        result = mongo_store.list_teams()
+        assert len(result) == 2
+        ids = {p.team_id for p in result}
+        assert ids == {p1.team_id, p2.team_id}
+
     # --- Corrupted data resilience ---
 
     def test_load_team_returns_none_for_corrupted_document(

--- a/tests/repositories/test_yaml.py
+++ b/tests/repositories/test_yaml.py
@@ -205,6 +205,43 @@ class TestYamlEventStore:
         assert isinstance(loaded[0].state, SampleAgentState)
         assert loaded[0].state.task_count == 5
 
+    # --- list_teams ---
+
+    def test_list_teams_returns_empty_when_no_teams(
+        self, yaml_store: YamlEventStore
+    ) -> None:
+        """AC9: list_teams returns [] when data dir has no team directories."""
+        result = yaml_store.list_teams()
+        assert result == []
+
+    def test_list_teams_returns_all_teams(
+        self, yaml_store: YamlEventStore
+    ) -> None:
+        """AC9: list_teams returns all saved team processes."""
+        p1 = make_process()
+        p2 = make_process()
+        yaml_store.save_team(p1)
+        yaml_store.save_team(p2)
+
+        result = yaml_store.list_teams()
+        assert len(result) == 2
+        ids = {p.team_id for p in result}
+        assert ids == {p1.team_id, p2.team_id}
+
+    def test_list_teams_ignores_non_team_directories(
+        self, yaml_store: YamlEventStore, tmp_path: Path
+    ) -> None:
+        """AC9: list_teams skips non-UUID directories like .gitkeep."""
+        p1 = make_process()
+        yaml_store.save_team(p1)
+        # Create non-team entries
+        (tmp_path / ".gitkeep").touch()
+        (tmp_path / "__pycache__").mkdir()
+
+        result = yaml_store.list_teams()
+        assert len(result) == 1
+        assert result[0].team_id == p1.team_id
+
     # --- Protocol compliance ---
 
     def test_satisfies_event_store_protocol(self, tmp_path: Path) -> None:

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -46,6 +46,10 @@ class InMemoryEventStore:
         """Persist an agent state snapshot."""
         self.agent_states[(snapshot.team_id, snapshot.agent_id)] = snapshot
 
+    def list_teams(self) -> list[Process]:
+        """Load all team process snapshots."""
+        return list(self.teams.values())
+
     def load_agent_states(self, team_id: uuid.UUID) -> list[AgentStateSnapshot]:
         """Load all agent state snapshots for a team."""
         return [v for k, v in self.agent_states.items() if k[0] == team_id]


### PR DESCRIPTION
## Summary

- Add `list_teams()` to EventStore Protocol and both implementations (YamlEventStore, MongoEventStore)
- Create Typer-based CLI scaffold with `ak-team list` and `ak-team inspect` commands
- Implement `_output.py` with OutputFormat enum and render functions (table, json, yaml)
- Add global options: `--data-dir`, `--backend`, `--mongo-uri`, `--mongo-db`, `--format`
- Add `[project.scripts]` entry point for `ak-team` in pyproject.toml
- 179 tests passing, ruff clean, mypy clean (akgentic-team)

## Review Fixes Applied

- Added missing test for invalid `--status` filter value
- Wrapped MongoDB client construction in try/except for graceful error handling
- Fixed `or 0` pattern to proper `is not None` check in render()

Closes #29