### PR TITLE
CLI create and delete commands

### DIFF
--- a/src/akgentic/team/cli/main.py
+++ b/src/akgentic/team/cli/main.py
@@ -289,13 +289,21 @@ def create_cmd(
         )
         raise typer.Exit(code=1) from exc
 
-    console = Console()
-    console.print(f"Team created: {runtime.id}")
+    logger.info("Team created: %s", runtime.id)
+    Console().print(f"Team created: {runtime.id}")
 
     # Non-interactive in 6.2: create, display, stop, exit.
     # Story 6.3 adds blocking/SIGINT behavior.
-    team_manager.stop_team(runtime.id)
-    console.print(f"Team stopped: {runtime.id}")
+    try:
+        team_manager.stop_team(runtime.id)
+    except Exception as stop_exc:  # noqa: BLE001
+        err_console.print(
+            f"[red]Error:[/red] Team created ({runtime.id}) but failed to stop: {stop_exc}"
+        )
+        raise typer.Exit(code=1) from stop_exc
+
+    logger.info("Team stopped: %s", runtime.id)
+    Console().print(f"Team stopped: {runtime.id}")
 
 
 @app.command(name="delete")
@@ -338,5 +346,5 @@ def delete_cmd(
         raise typer.Exit(code=1)
 
     event_store.delete_team(parsed_id)
-    console = Console()
-    console.print(f"Team '{team_id}' deleted.")
+    logger.info("Team deleted: %s", team_id)
+    Console().print(f"Team '{team_id}' deleted.")

--- a/src/akgentic/team/cli/main.py
+++ b/src/akgentic/team/cli/main.py
@@ -12,9 +12,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import typer
+import yaml
+from pydantic import ValidationError
 from rich.console import Console
 
 from akgentic.team.cli._output import OutputFormat, render
+from akgentic.team.models import TeamCard, TeamStatus
 from akgentic.team.ports import EventStore
 
 __all__ = ["app"]
@@ -233,3 +236,107 @@ def inspect_cmd(
         event_count=event_count,
         agent_state_count=agent_state_count,
     )
+
+
+@app.command(name="create")
+def create_cmd(
+    ctx: typer.Context,
+    team_card_file: Path = typer.Argument(help="Path to a YAML file containing a TeamCard."),
+    user_id: str = typer.Option(
+        "cli",
+        "--user-id",
+        help="User identifier for the team creator.",
+    ),
+) -> None:
+    """Create a team from a TeamCard YAML file."""
+    if not team_card_file.exists():
+        err_console.print(
+            f"[red]Error:[/red] File not found: '{team_card_file}'"
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        raw = team_card_file.read_text(encoding="utf-8")
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        err_console.print(
+            f"[red]Error:[/red] Invalid YAML in '{team_card_file}': {exc}"
+        )
+        raise typer.Exit(code=1) from exc
+
+    try:
+        team_card = TeamCard.model_validate(data)
+    except ValidationError as exc:
+        err_console.print(
+            f"[red]Error:[/red] Invalid TeamCard in '{team_card_file}': {exc}"
+        )
+        raise typer.Exit(code=1) from exc
+
+    state = _get_state(ctx)
+    event_store = _build_event_store(state)
+
+    from akgentic.core.actor_system_impl import ActorSystem
+    from akgentic.team.manager import TeamManager
+
+    actor_system = ActorSystem()
+    team_manager = TeamManager(actor_system=actor_system, event_store=event_store)
+
+    try:
+        runtime = team_manager.create_team(team_card, user_id=user_id)
+    except Exception as exc:  # noqa: BLE001
+        err_console.print(
+            f"[red]Error:[/red] Failed to create team: {exc}"
+        )
+        raise typer.Exit(code=1) from exc
+
+    console = Console()
+    console.print(f"Team created: {runtime.id}")
+
+    # Non-interactive in 6.2: create, display, stop, exit.
+    # Story 6.3 adds blocking/SIGINT behavior.
+    team_manager.stop_team(runtime.id)
+    console.print(f"Team stopped: {runtime.id}")
+
+
+@app.command(name="delete")
+def delete_cmd(
+    ctx: typer.Context,
+    team_id: str = typer.Argument(help="Team UUID to delete."),
+) -> None:
+    """Delete a stopped team and purge all its data."""
+    try:
+        parsed_id = uuid.UUID(team_id)
+    except ValueError:
+        err_console.print(
+            f"[red]Error:[/red] Invalid UUID format: '{team_id}'"
+        )
+        raise typer.Exit(code=1)  # noqa: B904
+
+    state = _get_state(ctx)
+    # delete is a pure data-purge operation — no ActorSystem needed.
+    # We use EventStore directly instead of TeamManager to avoid
+    # creating an unnecessary ActorSystem (expensive, starts threads).
+    event_store = _build_event_store(state)
+
+    process = event_store.load_team(parsed_id)
+    if process is None:
+        err_console.print(
+            f"[red]Error:[/red] Team '{team_id}' not found."
+        )
+        raise typer.Exit(code=1)
+
+    if process.status == TeamStatus.RUNNING:
+        err_console.print(
+            "[red]Error:[/red] Cannot delete: team is running. Stop it first."
+        )
+        raise typer.Exit(code=1)
+
+    if process.status == TeamStatus.DELETED:
+        err_console.print(
+            "[red]Error:[/red] Team already deleted."
+        )
+        raise typer.Exit(code=1)
+
+    event_store.delete_team(parsed_id)
+    console = Console()
+    console.print(f"Team '{team_id}' deleted.")

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -258,7 +258,7 @@ class TestCreateCommand:
             app, ["--data-dir", str(data_dir), "create", str(bad_file)]
         )
         assert result.exit_code == 1
-        assert "Invalid YAML" in result.output or "Invalid TeamCard" in result.output
+        assert "Invalid YAML" in result.output
 
     def test_create_invalid_team_card_structure(
         self, cli_runner: CliRunner, data_dir: Path
@@ -272,6 +272,19 @@ class TestCreateCommand:
         )
         assert result.exit_code == 1
         assert "Invalid TeamCard" in result.output
+
+    def test_create_team_build_failure(
+        self, cli_runner: CliRunner, data_dir: Path
+    ) -> None:
+        """Error path: TeamFactory.build failure shows friendly error, exit code 1."""
+        team_card = make_team_card(agent_class="nonexistent.module.FakeAgent")
+        card_file = _write_team_card_yaml(team_card, data_dir)
+
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "create", str(card_file)]
+        )
+        assert result.exit_code == 1
+        assert "Failed to create team" in result.output
 
 
 class TestDeleteCommand:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,21 +1,22 @@
 """Tests for the ak-team CLI commands.
 
-Validates list, inspect, and global options using Typer CliRunner
-with YamlEventStore backed by temporary directories.
+Validates list, inspect, global options, create, and delete commands
+using Typer CliRunner with YamlEventStore backed by temporary directories.
 
-Acceptance Criteria: AC1-AC11 from Story 6.1.
+Acceptance Criteria: AC1-AC11 from Story 6.1, AC1-AC9 from Story 6.2.
 """
 
 from __future__ import annotations
 
 import json
 import uuid
+from pathlib import Path
 
 import yaml
 from typer.testing import CliRunner
 
 from akgentic.team.cli.main import app
-from akgentic.team.models import TeamStatus
+from akgentic.team.models import TeamCard, TeamStatus
 from akgentic.team.repositories.yaml import YamlEventStore
 
 from tests.cli.conftest import populate_teams
@@ -23,6 +24,7 @@ from tests.models.conftest import (
     make_agent_state_snapshot,
     make_persisted_event,
     make_process,
+    make_team_card,
 )
 
 
@@ -185,3 +187,143 @@ class TestGlobalOptions:
         )
         assert result.exit_code == 1
         assert "Invalid status" in result.output
+
+
+def _write_team_card_yaml(team_card: TeamCard, path: Path) -> Path:
+    """Serialize a TeamCard to YAML and write to file."""
+    data = team_card.model_dump(mode="json")
+    file = path / "team-card.yaml"
+    file.write_text(yaml.dump(data, default_flow_style=False))
+    return file
+
+
+class TestCreateCommand:
+    """Tests for `ak-team create` command (AC1, AC2, AC3, AC4 from Story 6.2)."""
+
+    def test_create_valid_team_card(
+        self, cli_runner: CliRunner, data_dir: Path
+    ) -> None:
+        """AC1: create from valid TeamCard YAML shows team_id, exit code 0."""
+        team_card = make_team_card(agent_class="akgentic.core.agent.Akgent")
+        card_file = _write_team_card_yaml(team_card, data_dir)
+
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "create", str(card_file)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "Team created:" in result.output
+        assert "Team stopped:" in result.output
+
+    def test_create_with_user_id(
+        self, cli_runner: CliRunner, data_dir: Path, yaml_store: YamlEventStore
+    ) -> None:
+        """AC2: create with --user-id passes it to TeamManager."""
+        team_card = make_team_card(agent_class="akgentic.core.agent.Akgent")
+        card_file = _write_team_card_yaml(team_card, data_dir)
+
+        result = cli_runner.invoke(
+            app,
+            [
+                "--data-dir", str(data_dir),
+                "create", str(card_file),
+                "--user-id", "myuser",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        # Verify user_id was stored in the Process
+        teams = yaml_store.list_teams()
+        assert len(teams) == 1
+        assert teams[0].user_id == "myuser"
+
+    def test_create_nonexistent_file(
+        self, cli_runner: CliRunner, data_dir: Path
+    ) -> None:
+        """AC3: create with non-existent file shows error, exit code 1."""
+        result = cli_runner.invoke(
+            app,
+            ["--data-dir", str(data_dir), "create", "/no/such/file.yaml"],
+        )
+        assert result.exit_code == 1
+        assert "File not found" in result.output
+
+    def test_create_invalid_yaml(
+        self, cli_runner: CliRunner, data_dir: Path
+    ) -> None:
+        """AC4: create with invalid YAML shows error, exit code 1."""
+        bad_file = data_dir / "bad.yaml"
+        bad_file.write_text("not: valid: teamcard: {{{}}}:")
+
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "create", str(bad_file)]
+        )
+        assert result.exit_code == 1
+        assert "Invalid YAML" in result.output or "Invalid TeamCard" in result.output
+
+    def test_create_invalid_team_card_structure(
+        self, cli_runner: CliRunner, data_dir: Path
+    ) -> None:
+        """AC4: create with valid YAML but invalid TeamCard shows error, exit code 1."""
+        bad_file = data_dir / "bad-card.yaml"
+        bad_file.write_text(yaml.dump({"name": "incomplete"}))
+
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "create", str(bad_file)]
+        )
+        assert result.exit_code == 1
+        assert "Invalid TeamCard" in result.output
+
+
+class TestDeleteCommand:
+    """Tests for `ak-team delete` command (AC5, AC6, AC7, AC8 from Story 6.2)."""
+
+    def test_delete_stopped_team(
+        self, cli_runner: CliRunner, data_dir: Path, yaml_store: YamlEventStore
+    ) -> None:
+        """AC5: delete stopped team succeeds, exit code 0."""
+        process = make_process(status=TeamStatus.STOPPED)
+        yaml_store.save_team(process)
+
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "delete", str(process.team_id)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "deleted" in result.output
+
+        # Verify team is actually deleted from store
+        assert yaml_store.load_team(process.team_id) is None
+
+    def test_delete_running_team(
+        self, cli_runner: CliRunner, data_dir: Path, yaml_store: YamlEventStore
+    ) -> None:
+        """AC6: delete running team shows error, exit code 1."""
+        process = make_process(status=TeamStatus.RUNNING)
+        yaml_store.save_team(process)
+
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "delete", str(process.team_id)]
+        )
+        assert result.exit_code == 1
+        assert "running" in result.output.lower()
+        assert "stop" in result.output.lower()
+
+    def test_delete_nonexistent_team(
+        self, cli_runner: CliRunner, data_dir: Path
+    ) -> None:
+        """AC7: delete non-existent team shows error, exit code 1."""
+        fake_id = str(uuid.uuid4())
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "delete", fake_id]
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+    def test_delete_invalid_uuid(
+        self, cli_runner: CliRunner, data_dir: Path
+    ) -> None:
+        """AC8: delete with invalid UUID shows error, exit code 1."""
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "delete", "not-a-uuid"]
+        )
+        assert result.exit_code == 1
+        assert "Invalid UUID" in result.output


### PR DESCRIPTION
## Summary

- Implement `ak-team create <team-card-file>` command: loads TeamCard from YAML, validates with Pydantic, creates team via TeamManager, displays team_id, immediately stops (non-interactive per 6.2 design)
- Implement `ak-team delete <team-id>` command: validates UUID, checks team existence and state, uses EventStore directly (no ActorSystem needed), purges data for STOPPED teams only
- Add 6 create tests and 4 delete tests covering happy paths and all error paths
- Code review fixes: wrap stop_team() in try/except, add logging, strengthen test assertions, add build-failure error-path test

Closes #31