### PR TITLE
CLI Resume Command and Graceful Shutdown

### DIFF
--- a/src/akgentic/team/cli/main.py
+++ b/src/akgentic/team/cli/main.py
@@ -7,9 +7,12 @@ for managing team lifecycle instances.
 from __future__ import annotations
 
 import logging
+import signal
+import threading
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import typer
 import yaml
@@ -19,6 +22,10 @@ from rich.console import Console
 from akgentic.team.cli._output import OutputFormat, render
 from akgentic.team.models import TeamCard, TeamStatus
 from akgentic.team.ports import EventStore
+
+if TYPE_CHECKING:
+    from akgentic.team.manager import TeamManager
+    from akgentic.team.models import TeamRuntime
 
 __all__ = ["app"]
 
@@ -238,6 +245,39 @@ def inspect_cmd(
     )
 
 
+def _run_interactive(
+    team_manager: TeamManager,
+    runtime: TeamRuntime,
+) -> None:
+    """Block until SIGINT, then gracefully stop the team.
+
+    Registers a SIGINT handler that sets a threading.Event. The main thread
+    blocks on event.wait(). When SIGINT fires, the event is set, and the
+    main thread calls team_manager.stop_team(runtime.id) for clean teardown.
+
+    Args:
+        team_manager: TeamManager instance with stop_team method.
+        runtime: TeamRuntime instance with id attribute.
+    """
+
+    shutdown_event = threading.Event()
+
+    def _sigint_handler(signum: int, frame: object) -> None:
+        shutdown_event.set()
+
+    signal.signal(signal.SIGINT, _sigint_handler)
+    Console().print("Press Ctrl+C to stop the team.")
+
+    shutdown_event.wait()
+
+    Console().print("\nShutting down...")
+    try:
+        team_manager.stop_team(runtime.id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Error during shutdown: %s", exc)
+    Console().print(f"Team stopped: {runtime.id}")
+
+
 @app.command(name="create")
 def create_cmd(
     ctx: typer.Context,
@@ -292,18 +332,52 @@ def create_cmd(
     logger.info("Team created: %s", runtime.id)
     Console().print(f"Team created: {runtime.id}")
 
-    # Non-interactive in 6.2: create, display, stop, exit.
-    # Story 6.3 adds blocking/SIGINT behavior.
-    try:
-        team_manager.stop_team(runtime.id)
-    except Exception as stop_exc:  # noqa: BLE001
-        err_console.print(
-            f"[red]Error:[/red] Team created ({runtime.id}) but failed to stop: {stop_exc}"
-        )
-        raise typer.Exit(code=1) from stop_exc
+    _run_interactive(team_manager, runtime)
 
-    logger.info("Team stopped: %s", runtime.id)
-    Console().print(f"Team stopped: {runtime.id}")
+
+@app.command(name="resume")
+def resume_cmd(
+    ctx: typer.Context,
+    team_id: str = typer.Argument(help="Team UUID to resume."),
+    user_id: str = typer.Option(
+        "cli",
+        "--user-id",
+        help="User identifier for the resume operation.",
+    ),
+) -> None:
+    """Resume a stopped team by ID."""
+    try:
+        parsed_id = uuid.UUID(team_id)
+    except ValueError:
+        err_console.print(
+            f"[red]Error:[/red] Invalid UUID format: '{team_id}'"
+        )
+        raise typer.Exit(code=1)  # noqa: B904
+
+    state = _get_state(ctx)
+    event_store = _build_event_store(state)
+
+    from akgentic.core.actor_system_impl import ActorSystem
+    from akgentic.team.manager import TeamManager
+
+    actor_system = ActorSystem()
+    team_manager = TeamManager(actor_system=actor_system, event_store=event_store)
+
+    try:
+        runtime = team_manager.resume_team(parsed_id)
+    except ValueError as exc:
+        err_console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+    except Exception as exc:  # noqa: BLE001
+        err_console.print(
+            f"[red]Error:[/red] Failed to resume team: {exc}"
+        )
+        raise typer.Exit(code=1) from exc
+
+    logger.info("Team resumed: %s", runtime.id)
+    Console().print(f"Team resumed: {runtime.id}")
+
+    _run_interactive(team_manager, runtime)
 
 
 @app.command(name="delete")

--- a/src/akgentic/team/cli/main.py
+++ b/src/akgentic/team/cli/main.py
@@ -261,21 +261,24 @@ def _run_interactive(
     """
 
     shutdown_event = threading.Event()
+    console = Console()
 
     def _sigint_handler(signum: int, frame: object) -> None:
         shutdown_event.set()
 
     signal.signal(signal.SIGINT, _sigint_handler)
-    Console().print("Press Ctrl+C to stop the team.")
+    console.print("Press Ctrl+C to stop the team.")
 
     shutdown_event.wait()
 
-    Console().print("\nShutting down...")
+    console.print("\nShutting down...")
     try:
         team_manager.stop_team(runtime.id)
     except Exception as exc:  # noqa: BLE001
         logger.warning("Error during shutdown: %s", exc)
-    Console().print(f"Team stopped: {runtime.id}")
+        console.print(f"Team stopped with errors: {runtime.id}")
+        return
+    console.print(f"Team stopped: {runtime.id}")
 
 
 @app.command(name="create")
@@ -339,11 +342,6 @@ def create_cmd(
 def resume_cmd(
     ctx: typer.Context,
     team_id: str = typer.Argument(help="Team UUID to resume."),
-    user_id: str = typer.Option(
-        "cli",
-        "--user-id",
-        help="User identifier for the resume operation.",
-    ),
 ) -> None:
     """Resume a stopped team by ID."""
     try:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -10,6 +10,7 @@ AC1-AC6 from Story 6.3.
 from __future__ import annotations
 
 import json
+import signal
 import uuid
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -20,7 +21,6 @@ from typer.testing import CliRunner
 from akgentic.team.cli.main import app
 from akgentic.team.models import TeamCard, TeamStatus
 from akgentic.team.repositories.yaml import YamlEventStore
-
 from tests.cli.conftest import populate_teams
 from tests.models.conftest import (
     make_agent_state_snapshot,
@@ -456,8 +456,9 @@ class TestGracefulShutdown:
 
             _run_interactive(mock_manager, mock_runtime)
 
-            # Verify SIGINT handler was registered
+            # Verify SIGINT handler was registered with the correct signal
             mock_signal.assert_called_once()
+            assert mock_signal.call_args[0][0] == signal.SIGINT
             # Verify stop_team was called with correct id
             mock_manager.stop_team.assert_called_once_with(mock_runtime.id)
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,9 +1,10 @@
 """Tests for the ak-team CLI commands.
 
-Validates list, inspect, global options, create, and delete commands
+Validates list, inspect, global options, create, delete, and resume commands
 using Typer CliRunner with YamlEventStore backed by temporary directories.
 
-Acceptance Criteria: AC1-AC11 from Story 6.1, AC1-AC9 from Story 6.2.
+Acceptance Criteria: AC1-AC11 from Story 6.1, AC1-AC9 from Story 6.2,
+AC1-AC6 from Story 6.3.
 """
 
 from __future__ import annotations
@@ -11,6 +12,7 @@ from __future__ import annotations
 import json
 import uuid
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import yaml
 from typer.testing import CliRunner
@@ -200,8 +202,9 @@ def _write_team_card_yaml(team_card: TeamCard, path: Path) -> Path:
 class TestCreateCommand:
     """Tests for `ak-team create` command (AC1, AC2, AC3, AC4 from Story 6.2)."""
 
+    @patch("akgentic.team.cli.main._run_interactive")
     def test_create_valid_team_card(
-        self, cli_runner: CliRunner, data_dir: Path
+        self, mock_interactive: MagicMock, cli_runner: CliRunner, data_dir: Path
     ) -> None:
         """AC1: create from valid TeamCard YAML shows team_id, exit code 0."""
         team_card = make_team_card(agent_class="akgentic.core.agent.Akgent")
@@ -212,10 +215,15 @@ class TestCreateCommand:
         )
         assert result.exit_code == 0, result.output
         assert "Team created:" in result.output
-        assert "Team stopped:" in result.output
+        mock_interactive.assert_called_once()
 
+    @patch("akgentic.team.cli.main._run_interactive")
     def test_create_with_user_id(
-        self, cli_runner: CliRunner, data_dir: Path, yaml_store: YamlEventStore
+        self,
+        mock_interactive: MagicMock,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        yaml_store: YamlEventStore,
     ) -> None:
         """AC2: create with --user-id passes it to TeamManager."""
         team_card = make_team_card(agent_class="akgentic.core.agent.Akgent")
@@ -340,3 +348,135 @@ class TestDeleteCommand:
         )
         assert result.exit_code == 1
         assert "Invalid UUID" in result.output
+
+
+class TestResumeCommand:
+    """Tests for `ak-team resume` command (AC1, AC3, AC4, AC5 from Story 6.3)."""
+
+    @patch("akgentic.team.cli.main._run_interactive")
+    @patch("akgentic.team.manager.TeamManager.resume_team")
+    def test_resume_stopped_team(
+        self,
+        mock_resume: MagicMock,
+        mock_interactive: MagicMock,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        yaml_store: YamlEventStore,
+    ) -> None:
+        """AC1: resume stopped team shows team_id, exit code 0."""
+        process = make_process(status=TeamStatus.STOPPED)
+        yaml_store.save_team(process)
+
+        mock_runtime = MagicMock()
+        mock_runtime.id = process.team_id
+        mock_resume.return_value = mock_runtime
+
+        result = cli_runner.invoke(
+            app,
+            ["--data-dir", str(data_dir), "resume", str(process.team_id)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Team resumed:" in result.output
+        mock_resume.assert_called_once_with(process.team_id)
+        mock_interactive.assert_called_once()
+
+    def test_resume_running_team_shows_error(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        yaml_store: YamlEventStore,
+    ) -> None:
+        """AC3: resume a running team shows error, exit code 1."""
+        process = make_process(status=TeamStatus.RUNNING)
+        yaml_store.save_team(process)
+
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "resume", str(process.team_id)]
+        )
+        assert result.exit_code == 1
+        assert "running" in result.output.lower()
+
+    def test_resume_deleted_team_shows_error(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        yaml_store: YamlEventStore,
+    ) -> None:
+        """AC3: resume a deleted team shows error, exit code 1."""
+        process = make_process(status=TeamStatus.DELETED)
+        yaml_store.save_team(process)
+
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "resume", str(process.team_id)]
+        )
+        assert result.exit_code == 1
+        assert "deleted" in result.output.lower()
+
+    def test_resume_nonexistent_team_shows_error(
+        self, cli_runner: CliRunner, data_dir: Path
+    ) -> None:
+        """AC4: resume non-existent team shows error, exit code 1."""
+        fake_id = str(uuid.uuid4())
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "resume", fake_id]
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_resume_invalid_uuid_shows_error(
+        self, cli_runner: CliRunner, data_dir: Path
+    ) -> None:
+        """AC5: resume with invalid UUID shows error, exit code 1."""
+        result = cli_runner.invoke(
+            app, ["--data-dir", str(data_dir), "resume", "not-a-uuid"]
+        )
+        assert result.exit_code == 1
+        assert "Invalid UUID" in result.output
+
+
+class TestGracefulShutdown:
+    """Tests for SIGINT-based graceful shutdown (AC2 from Story 6.3)."""
+
+    def test_run_interactive_calls_stop_team_on_shutdown(self) -> None:
+        """AC2: _run_interactive calls stop_team when shutdown event fires."""
+        from akgentic.team.cli.main import _run_interactive
+
+        mock_manager = MagicMock()
+        mock_runtime = MagicMock()
+        mock_runtime.id = uuid.uuid4()
+
+        with (
+            patch("akgentic.team.cli.main.signal.signal") as mock_signal,
+            patch("akgentic.team.cli.main.threading.Event") as mock_event_cls,
+        ):
+            mock_event = MagicMock()
+            mock_event_cls.return_value = mock_event
+            # Make wait() return immediately (simulates shutdown event being set)
+            mock_event.wait.return_value = None
+
+            _run_interactive(mock_manager, mock_runtime)
+
+            # Verify SIGINT handler was registered
+            mock_signal.assert_called_once()
+            # Verify stop_team was called with correct id
+            mock_manager.stop_team.assert_called_once_with(mock_runtime.id)
+
+    def test_run_interactive_handles_stop_team_exception(self) -> None:
+        """AC2: _run_interactive handles stop_team errors gracefully."""
+        from akgentic.team.cli.main import _run_interactive
+
+        mock_manager = MagicMock()
+        mock_manager.stop_team.side_effect = RuntimeError("actors already dead")
+        mock_runtime = MagicMock()
+        mock_runtime.id = uuid.uuid4()
+
+        with (
+            patch("akgentic.team.cli.main.signal.signal"),
+            patch("akgentic.team.cli.main.threading.Event") as mock_event_cls,
+        ):
+            mock_event = MagicMock()
+            mock_event_cls.return_value = mock_event
+            mock_event.wait.return_value = None
+
+            # Should not raise even though stop_team fails
+            _run_interactive(mock_manager, mock_runtime)


### PR DESCRIPTION
## Summary

- Add `ak-team resume <team-id>` command with UUID parsing, state validation, and user-friendly error messages
- Implement `_run_interactive` helper with SIGINT-based graceful shutdown via `threading.Event`
- Upgrade `create_cmd` to block via `_run_interactive` instead of immediate stop
- 7 new tests: 5 resume command tests + 2 graceful shutdown tests
- Update existing create tests to patch `_run_interactive`

Closes #33