### PR TITLE
Team Definition & Factory Examples (01-02)

### DIFF
--- a/examples/01-team-definition.md
+++ b/examples/01-team-definition.md
@@ -1,0 +1,48 @@
+# Team Definition -- TeamCard & TeamCardMember Hierarchies
+
+## Concepts Covered
+
+- **AgentCard as role descriptor**: Each agent in a team is described by an `AgentCard` containing its role, skills, config, and routing rules. The card is a blueprint -- not a running instance.
+
+- **TeamCardMember tree structure**: `TeamCardMember` wraps an `AgentCard` with a `headcount` (how many instances to spawn) and a recursive `members` list (subordinates). This forms a tree describing the team hierarchy.
+
+- **TeamCard as team blueprint**: A `TeamCard` holds the team's `name`, `description`, an `entry_point` (the agent receiving external messages), top-level `members`, and `message_types`. It is a pure data model -- no actors are created until `TeamFactory.build()` is called.
+
+- **`agent_cards` property for O(1) lookup**: `TeamCard.agent_cards` walks the entire member tree and returns a flat `dict[str, AgentCard]` keyed by `config.name`. This gives constant-time access to any agent's card by name.
+
+- **`supervisors` property for hierarchy discovery**: `TeamCard.supervisors` returns the `AgentCard` for every `TeamCardMember` whose `.members` list is non-empty. This identifies which agents manage subordinates.
+
+- **Pydantic serialization round-trip**: `TeamCard` (and all nested models) are Pydantic models. `model_dump()` produces a plain dict; `model_validate()` reconstructs the full object graph. This enables persistence and transport.
+
+## Key API Patterns
+
+```python
+# Nesting members to form a hierarchy
+analyst_member = TeamCardMember(card=analyst_card)
+researcher_member = TeamCardMember(card=researcher_card, members=[analyst_member])
+
+# Building the TeamCard -- entry_point is separate from members
+team_card = TeamCard(
+    name="research-team",
+    description="...",
+    entry_point=manager_member,
+    members=[researcher_member, reviewer_member],
+    message_types=[],
+)
+
+# Property-based inspection
+all_cards = team_card.agent_cards      # dict[str, AgentCard]
+supervisors = team_card.supervisors    # list[AgentCard]
+```
+
+## Common Pitfalls
+
+- **Duplicate config names raise ValueError**: Every `AgentCard` in the tree must have a unique `config.name`. The `agent_cards` property enforces this and raises `ValueError` on duplicates.
+
+- **`entry_point` is NOT in `members`**: The `entry_point` is a separate field on `TeamCard`. The `members` list contains only the top-level members that are not the entry point. Both are walked by `agent_cards` and `supervisors`.
+
+- **`message_types` is a list of classes, not instances**: Pass message class references (e.g., `[UserMessage]`), not message objects.
+
+## See Also
+
+- [Example 02: Team Factory](./02-team-factory.md) -- building a running team from the card defined here.

--- a/examples/01_team_definition.py
+++ b/examples/01_team_definition.py
@@ -1,0 +1,154 @@
+"""Example 01: Team Definition -- TeamCard & TeamCardMember Hierarchies.
+
+Demonstrates how to build a TeamCard with a hierarchical TeamCardMember tree,
+inspect the flat agent_cards index and supervisors list, print the tree structure,
+and perform a Pydantic round-trip serialization.
+
+Run:
+    uv run python packages/akgentic-team/examples/01_team_definition.py
+"""
+
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_card import AgentCard
+from akgentic.core.agent_config import BaseConfig
+
+from akgentic.team.models import TeamCard, TeamCardMember
+
+
+def main() -> None:
+    """Build a team hierarchy, inspect it, and verify round-trip serialization."""
+
+    # --- 1.1: Create AgentCard definitions for 4 agents ---
+    manager_card = AgentCard(
+        role="Manager",
+        description="Coordinates research tasks and reviews deliverables",
+        skills=["coordination", "task-assignment", "review"],
+        agent_class=Akgent,
+        config=BaseConfig(name="manager", role="Manager"),
+        routes_to=["researcher", "reviewer"],
+    )
+
+    researcher_card = AgentCard(
+        role="Researcher",
+        description="Performs in-depth research on assigned topics",
+        skills=["web-search", "data-gathering", "summarization"],
+        agent_class=Akgent,
+        config=BaseConfig(name="researcher", role="Researcher"),
+    )
+
+    analyst_card = AgentCard(
+        role="Analyst",
+        description="Analyzes data and produces structured reports",
+        skills=["data-analysis", "statistics", "visualization"],
+        agent_class=Akgent,
+        config=BaseConfig(name="analyst", role="Analyst"),
+    )
+
+    reviewer_card = AgentCard(
+        role="Reviewer",
+        description="Reviews deliverables for quality and accuracy",
+        skills=["quality-check", "fact-verification", "feedback"],
+        agent_class=Akgent,
+        config=BaseConfig(name="reviewer", role="Reviewer"),
+    )
+
+    print("=== AgentCards Created ===")
+    for card in [manager_card, researcher_card, analyst_card, reviewer_card]:
+        print(f"  {card.config.name}: role={card.role}, skills={card.skills}")
+
+    # --- 1.2: Build TeamCardMember hierarchy ---
+    # Analyst is subordinate to researcher
+    analyst_member = TeamCardMember(card=analyst_card)
+    researcher_member = TeamCardMember(card=researcher_card, members=[analyst_member])
+    reviewer_member = TeamCardMember(card=reviewer_card)
+    manager_member = TeamCardMember(card=manager_card)
+
+    # --- 1.3: Create TeamCard ---
+    # entry_point is the manager; researcher (with analyst) and reviewer are members
+    team_card = TeamCard(
+        name="research-team",
+        description="A research team with a manager, researcher, analyst, and reviewer",
+        entry_point=manager_member,
+        members=[researcher_member, reviewer_member],
+        message_types=[],
+    )
+
+    print(f"\n=== TeamCard: {team_card.name} ===")
+    print(f"  Description: {team_card.description}")
+    print(f"  Entry point: {team_card.entry_point.card.config.name}")
+
+    # --- 1.4: Inspect agent_cards -- flat dict of all 4 AgentCards ---
+    agent_cards = team_card.agent_cards
+    print(f"\n=== agent_cards (flat index, {len(agent_cards)} agents) ===")
+    for name, card in agent_cards.items():
+        print(f"  {name}: role={card.role}")
+
+    assert len(agent_cards) == 4, f"Expected 4 agent cards, got {len(agent_cards)}"
+    assert "manager" in agent_cards, "manager missing from agent_cards"
+    assert "researcher" in agent_cards, "researcher missing from agent_cards"
+    assert "analyst" in agent_cards, "analyst missing from agent_cards"
+    assert "reviewer" in agent_cards, "reviewer missing from agent_cards"
+
+    # --- 1.5: Inspect supervisors ---
+    # Supervisors are members that have subordinate members:
+    #   - manager has members [researcher_member, reviewer_member] via TeamCard.members
+    #     (but manager itself has members=[] on TeamCardMember)
+    #   - researcher has members=[analyst_member]
+    # So only researcher is a supervisor at the TeamCardMember level.
+    supervisors = team_card.supervisors
+    supervisor_names = [s.config.name for s in supervisors]
+    print(f"\n=== Supervisors ({len(supervisors)}) ===")
+    for sup in supervisors:
+        print(f"  {sup.config.name}: role={sup.role}")
+
+    assert "researcher" in supervisor_names, "researcher should be a supervisor (has analyst)"
+    # manager_member has members=[] (it's the entry_point, not a member with subordinates)
+    # The TeamCard.members are top-level, not subordinates of manager_member itself
+    print("  (Supervisors are members whose .members list is non-empty)")
+
+    # --- 1.6: Print team tree structure ---
+    print("\n=== Team Tree ===")
+
+    def print_tree(member: TeamCardMember, indent: int = 0) -> None:
+        """Print a TeamCardMember tree with indentation."""
+        prefix = "  " * indent
+        role = member.card.role
+        name = member.card.config.name
+        hc = member.headcount
+        subs = len(member.members)
+        print(f"{prefix}- {name} (role={role}, headcount={hc}, subordinates={subs})")
+        for child in member.members:
+            print_tree(child, indent + 1)
+
+    print(f"Team: {team_card.name}")
+    print("Entry point:")
+    print_tree(team_card.entry_point, indent=1)
+    print("Members:")
+    for member in team_card.members:
+        print_tree(member, indent=1)
+
+    # --- 1.7: Pydantic round-trip serialization ---
+    print("\n=== Pydantic Round-Trip ===")
+    dumped = team_card.model_dump()
+    print(f"  model_dump() keys: {list(dumped.keys())}")
+    restored = TeamCard.model_validate(dumped)
+    print(f"  model_validate() -> TeamCard(name={restored.name!r})")
+
+    # Verify structural equality
+    assert restored.name == team_card.name, "Name mismatch after round-trip"
+    assert restored.description == team_card.description, "Description mismatch"
+    assert len(restored.agent_cards) == len(team_card.agent_cards), "Agent count mismatch"
+    assert set(restored.agent_cards.keys()) == set(
+        team_card.agent_cards.keys()
+    ), "Agent names mismatch"
+
+    restored_supervisors = [s.config.name for s in restored.supervisors]
+    assert set(restored_supervisors) == set(supervisor_names), "Supervisors mismatch"
+
+    # --- 1.8: Assert statements verify exit 0 = success ---
+    print("\n=== All assertions passed! ===")
+    print("Example 01 complete: TeamCard hierarchy built, inspected, and round-tripped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02-team-factory.md
+++ b/examples/02-team-factory.md
@@ -32,8 +32,11 @@ try:
     print(runtime.entry_addr)          # ActorAddress of entry point
     print(runtime.addrs)               # dict[str, ActorAddress]
 
-    # Send a message (broadcasts to supervisor addresses)
+    # Broadcast to supervisors (agents with subordinates)
     runtime.send("Hello team!")
+
+    # Directed message to a specific agent by name
+    runtime.send_to("worker", "Task for you!")
 
 finally:
     actor_system.shutdown()

--- a/examples/02-team-factory.md
+++ b/examples/02-team-factory.md
@@ -1,0 +1,55 @@
+# Team Factory -- Building a Running Team
+
+## Concepts Covered
+
+- **TeamFactory as static builder**: `TeamFactory.build()` is a static method that takes a `TeamCard`, an `ActorSystem`, and optional subscribers, then spawns all actors and returns a `TeamRuntime` handle. No instance of `TeamFactory` is needed.
+
+- **TeamRuntime persistent vs ephemeral fields**: `TeamRuntime` stores persistent actor addresses (`id`, `orchestrator_addr`, `entry_addr`, `addrs`, `supervisor_addrs`) that survive serialization. Ephemeral fields (proxies like `_orchestrator_proxy`, `_entry_proxy`) are rebuilt automatically in `model_post_init` from the persistent addresses.
+
+- **ActorSystem ownership**: The `ActorSystem` hosts all actor threads. It is passed to `TeamFactory.build()` and stored in `TeamRuntime` (excluded from serialization). The caller owns the `ActorSystem` and must call `shutdown()` to clean up.
+
+- **Subscriber list**: `subscribers` are `EventSubscriber` instances registered with the orchestrator during build. They receive team events for logging, persistence, or monitoring.
+
+- **Rollback on partial failure**: If any agent spawn fails during `build()`, all already-spawned actors are torn down before the exception is re-raised. This prevents orphaned actors.
+
+## Key API Patterns
+
+```python
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.team.factory import TeamFactory
+
+# Build a running team
+actor_system = ActorSystem()
+try:
+    runtime = TeamFactory.build(
+        team_card=team_card,
+        actor_system=actor_system,
+        subscribers=[],
+    )
+
+    # Inspect the runtime
+    print(runtime.id)                  # UUID
+    print(runtime.entry_addr)          # ActorAddress of entry point
+    print(runtime.addrs)               # dict[str, ActorAddress]
+
+    # Send a message (broadcasts to supervisor addresses)
+    runtime.send("Hello team!")
+
+finally:
+    actor_system.shutdown()
+```
+
+## Common Pitfalls
+
+- **Entry point must have `headcount=1`**: `TeamFactory.build()` raises `ValueError` if `entry_point.headcount != 1`. The entry point is the single external interface to the team.
+
+- **`ActorSystem.shutdown()` must be called**: Actors run on background threads. Forgetting to shut down the `ActorSystem` leaves threads running. Always use `try/finally`.
+
+- **TeamRuntime proxies are ephemeral**: The proxy objects (`_orchestrator_proxy`, `_entry_proxy`, etc.) are `PrivateAttr` fields rebuilt from addresses in `model_post_init`. After deserialization, they are automatically reconstructed -- but only if an `ActorSystem` with the same actors is available.
+
+- **Messages are processed asynchronously**: `runtime.send()` returns immediately. Use `time.sleep()` if you need to see output before shutdown.
+
+## See Also
+
+- [Example 01: Team Definition](./01-team-definition.md) -- constructing the TeamCard used here.
+- Example 03: TeamManager Lifecycle (coming soon) -- managing team create/stop/resume with persistence.

--- a/examples/02_team_factory.py
+++ b/examples/02_team_factory.py
@@ -1,0 +1,128 @@
+"""Example 02: Team Factory -- Building a Running Team.
+
+Demonstrates how to use TeamFactory.build() to create a running team from a
+TeamCard, inspect the TeamRuntime, send messages, handle error paths, and
+perform clean shutdown.
+
+Run:
+    uv run python packages/akgentic-team/examples/02_team_factory.py
+"""
+
+import time
+import uuid
+
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_card import AgentCard
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.agent_state import BaseState
+from akgentic.core.messages.message import UserMessage
+
+from akgentic.team.factory import TeamFactory
+from akgentic.team.models import TeamCard, TeamCardMember
+
+
+# --- 2.1: Inline EchoAgent ---
+class EchoAgent(Akgent[BaseConfig, BaseState]):
+    """Minimal agent that echoes messages back."""
+
+    def receiveMsg_UserMessage(  # noqa: N802
+        self, message: UserMessage, sender: ActorAddress
+    ) -> None:
+        """Echo the message content."""
+        print(f"  [{self.config.name}] received: {message.content!r}")
+
+
+def main() -> None:
+    """Build a running team, inspect it, send messages, and shut down cleanly."""
+
+    # --- 2.2: Build a TeamCard with 2 EchoAgent members ---
+    leader_card = AgentCard(
+        role="Leader",
+        description="Entry-point agent that receives external messages",
+        skills=["coordination"],
+        agent_class=EchoAgent,
+        config=BaseConfig(name="leader", role="Leader"),
+    )
+    worker_card = AgentCard(
+        role="Worker",
+        description="Worker agent that processes tasks",
+        skills=["processing"],
+        agent_class=EchoAgent,
+        config=BaseConfig(name="worker", role="Worker"),
+    )
+
+    worker_member = TeamCardMember(card=worker_card)
+    # Leader supervises the worker (worker is a subordinate of leader)
+    leader_member = TeamCardMember(card=leader_card, members=[worker_member])
+
+    team_card = TeamCard(
+        name="echo-team",
+        description="A simple team with a leader supervising a worker",
+        entry_point=leader_member,
+        members=[],
+        message_types=[UserMessage],
+    )
+
+    # --- 2.3: Create ActorSystem and build team ---
+    actor_system = ActorSystem()
+    try:
+        print("=== Building team with TeamFactory ===")
+        runtime = TeamFactory.build(
+            team_card=team_card,
+            actor_system=actor_system,
+            subscribers=[],
+        )
+
+        # --- 2.4: Inspect TeamRuntime ---
+        print("\n=== TeamRuntime ===")
+        print(f"  runtime.id: {runtime.id}")
+        print(f"  runtime.orchestrator_addr: {runtime.orchestrator_addr}")
+        print(f"  runtime.entry_addr: {runtime.entry_addr}")
+        print(f"  runtime.addrs: {dict(runtime.addrs)}")
+
+        # --- 2.8: Assert runtime attributes ---
+        assert isinstance(runtime.id, uuid.UUID), "runtime.id should be a UUID"
+        assert "leader" in runtime.addrs, "leader should be in runtime.addrs"
+        assert "worker" in runtime.addrs, "worker should be in runtime.addrs"
+        assert runtime.entry_addr is not None, "entry_addr should not be None"
+        assert runtime.orchestrator_addr is not None, "orchestrator_addr should not be None"
+
+        print(f"\n  Addresses ({len(runtime.addrs)} agents):")
+        for name, addr in runtime.addrs.items():
+            print(f"    {name}: {addr}")
+
+        # --- 2.5: Send a message ---
+        print("\n=== Sending message to team ===")
+        runtime.send("Hello team!")
+        time.sleep(0.5)  # Allow actor threads to process
+
+        # --- 2.6: Demonstrate error path ---
+        print("\n=== Error path: entry_point with headcount != 1 ===")
+        bad_member = TeamCardMember(card=leader_card, headcount=2)
+        bad_card = TeamCard(
+            name="bad-team",
+            description="Team with invalid entry point headcount",
+            entry_point=bad_member,
+            members=[],
+            message_types=[UserMessage],
+        )
+        try:
+            TeamFactory.build(bad_card, actor_system, subscribers=[])
+            assert False, "Should have raised ValueError"  # noqa: B011
+        except ValueError as e:
+            print(f"  Caught expected ValueError: {e}")
+
+        print("\n=== All assertions passed! ===")
+        print("Example 02 complete: team built, inspected, messaged, and error path verified.")
+
+    finally:
+        # --- 2.7: Clean shutdown ---
+        print("\n=== Shutting down ActorSystem ===")
+        actor_system.shutdown()
+        print("  ActorSystem shut down cleanly.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02_team_factory.py
+++ b/examples/02_team_factory.py
@@ -8,6 +8,7 @@ Run:
     uv run python packages/akgentic-team/examples/02_team_factory.py
 """
 
+import logging
 import time
 import uuid
 
@@ -36,6 +37,9 @@ class EchoAgent(Akgent[BaseConfig, BaseState]):
 
 def main() -> None:
     """Build a running team, inspect it, send messages, and shut down cleanly."""
+    # Suppress expected shutdown warnings from the actor system (e.g. "Stopping
+    # remaining N actors") so example output stays clean.
+    logging.getLogger("akgentic.core.actor_system_impl").setLevel(logging.ERROR)
 
     # --- 2.2: Build a TeamCard with 2 EchoAgent members ---
     leader_card = AgentCard(
@@ -93,10 +97,18 @@ def main() -> None:
         for name, addr in runtime.addrs.items():
             print(f"    {name}: {addr}")
 
-        # --- 2.5: Send a message ---
-        print("\n=== Sending message to team ===")
+        # --- 2.5: Send messages ---
+        # runtime.send() broadcasts to supervisor addresses. In this team,
+        # the leader is the only supervisor (it has worker as subordinate),
+        # so send() delivers to the leader -- not the worker.
+        print("\n=== Sending broadcast to supervisors ===")
         runtime.send("Hello team!")
         time.sleep(0.5)  # Allow actor threads to process
+
+        # Note: runtime.send_to(agent_name, content) is also available for
+        # directed messaging to a specific agent. It uses the orchestrator's
+        # agent registry, which requires agents to have completed their startup
+        # handshake (StartMessage). In long-running teams this works naturally.
 
         # --- 2.6: Demonstrate error path ---
         print("\n=== Error path: entry_point with headcount != 1 ===")
@@ -108,11 +120,13 @@ def main() -> None:
             members=[],
             message_types=[UserMessage],
         )
+        error_caught = False
         try:
             TeamFactory.build(bad_card, actor_system, subscribers=[])
-            assert False, "Should have raised ValueError"  # noqa: B011
         except ValueError as e:
+            error_caught = True
             print(f"  Caught expected ValueError: {e}")
+        assert error_caught, "TeamFactory.build should have raised ValueError"
 
         print("\n=== All assertions passed! ===")
         print("Example 02 complete: team built, inspected, messaged, and error path verified.")

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,5 +43,5 @@ uv run python examples/02_team_factory.py
 
 ## Dependencies
 
-- Examples 01--05 depend on `akgentic-core` and `akgentic-team` only.
+- Examples 01-05 depend on `akgentic-core` and `akgentic-team` only.
 - Example 06 additionally requires `mongomock`, available via the `[mongo]` extra.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,50 +1,47 @@
-# Examples for akgentic-\<module\>
+# akgentic-team Examples
 
-This directory contains example scripts demonstrating the usage of this module.
+A progressive tutorial that walks through the akgentic-team package, from static team definitions to full lifecycle management with persistence and crash recovery.
 
-## Running Examples
+Each example builds on concepts from previous ones. Start with example 01 and work through in order.
+
+## Prerequisites
+
+From the workspace root, install all packages:
 
 ```bash
-# From workspace root with activated venv
-python packages/akgentic-<module>/examples/example_basic.py
+uv sync --all-packages --all-extras
 ```
 
-## Available Examples
+## Examples
 
-### example_basic.py
+| # | File | Summary | Status |
+|---|------|---------|--------|
+| 01 | `01_team_definition.py` | TeamCard & TeamCardMember hierarchies, agent_cards/supervisors inspection, Pydantic round-trip | Implemented |
+| 02 | `02_team_factory.py` | TeamFactory.build(), TeamRuntime inspection, message sending, error paths, clean shutdown | Implemented |
+| 03 | `03_team_manager.py` | TeamManager create/stop lifecycle, state machine transitions | Coming soon |
+| 04 | `04_event_sourcing.py` | PersistenceSubscriber, YamlEventStore, event replay | Coming soon |
+| 05 | `05_crash_recovery.py` | TeamRestorer, resume from persisted state | Coming soon |
+| 06 | `06_mongodb_backend.py` | MongoEventStore with mongomock for testing | Coming soon |
 
-Basic usage demonstrating core functionality.
+Each `.py` file has a companion `.md` file with concepts, API patterns, and pitfalls.
 
-**Topics covered:**
-- Feature 1
-- Feature 2
-- Basic configuration
+## Running
 
-### example_advanced.py
+From the workspace root:
 
-Advanced usage showing integration with other modules.
+```bash
+uv run python packages/akgentic-team/examples/01_team_definition.py
+uv run python packages/akgentic-team/examples/02_team_factory.py
+```
 
-**Topics covered:**
-- Integration with akgentic-core
-- Integration with akgentic-llm
-- Complex scenarios
+Or from the package root (`packages/akgentic-team/`):
 
-## Example Structure
+```bash
+uv run python examples/01_team_definition.py
+uv run python examples/02_team_factory.py
+```
 
-Each example should:
+## Dependencies
 
-1. Import necessary dependencies
-2. Include clear comments explaining each step
-3. Demonstrate realistic use cases
-4. Handle errors appropriately
-5. Clean up resources (if applicable)
-
-## Adding New Examples
-
-When adding new examples:
-
-1. Create a descriptive filename: `example_<feature>.py`
-2. Add detailed comments
-3. Include a docstring explaining the example
-4. Update this README with a description
-5. Test the example works in isolation
+- Examples 01--05 depend on `akgentic-core` and `akgentic-team` only.
+- Example 06 additionally requires `mongomock`, available via the `[mongo]` extra.


### PR DESCRIPTION
## Summary

- Implement `examples/01_team_definition.py`: TeamCard/TeamCardMember construction, `agent_cards` and `supervisors` property inspection, tree print, Pydantic round-trip serialization
- Implement `examples/02_team_factory.py`: TeamFactory.build(), TeamRuntime inspection, message sending via `runtime.send()`, error path (headcount!=1 ValueError), try/finally clean shutdown
- Write companion docs `01-team-definition.md` and `02-team-factory.md` with concepts, API patterns, pitfalls, and cross-references
- Replace placeholder `examples/README.md` with progressive tutorial overview and run instructions

Code review fixes applied:
- Clarified `send()` broadcast semantics and documented `send_to()` directed messaging
- Suppressed confusing actor system shutdown warnings from example output
- Replaced `assert False` anti-pattern with flag-based error verification
- Fixed em-dash rendering in README

All quality gates pass: both examples exit 0, ruff clean, no forbidden imports, 196 tests pass.

Closes #35