### PR TITLE
Event Sourcing & Crash Recovery Examples (04-05)

### DIFF
--- a/examples/04-event-sourcing.md
+++ b/examples/04-event-sourcing.md
@@ -1,0 +1,109 @@
+# Event Sourcing -- Live Persistence & Inspection
+
+Companion guide for `04_event_sourcing.py`. Covers the persistence model,
+PersistenceSubscriber, YamlEventStore, and the YAML file layout.
+
+## Concepts
+
+### PersistenceSubscriber
+
+`PersistenceSubscriber` is the bridge between `EventSubscriber` (akgentic-core)
+and `EventStore` (akgentic-team). It is registered with the orchestrator and
+intercepts every message flowing through it:
+
+- **Every message** is persisted as a `PersistedEvent` (append-only event log)
+- **`StateChangedMessage`** additionally triggers an `AgentStateSnapshot` write
+
+TeamManager creates and registers a PersistenceSubscriber automatically during
+`create_team()`. The subscriber is always the first in the subscriber list.
+
+### What Gets Persisted
+
+| Data Type              | Model               | Strategy    | File                    |
+|------------------------|----------------------|-------------|-------------------------|
+| Team metadata          | `Process`            | Overwrite   | `team.yaml`             |
+| Message events         | `PersistedEvent`     | Append-only | `events.yaml`           |
+| Agent state snapshots  | `AgentStateSnapshot` | Overwrite   | `states/{agent_id}.yaml`|
+
+- **PersistedEvent**: `team_id` (UUID), `sequence` (int), `event` (Message), `timestamp` (datetime)
+- **AgentStateSnapshot**: `team_id` (UUID), `agent_id` (str), `state` (BaseState), `updated_at` (datetime)
+- **Process**: `team_id`, `team_card`, `status`, `user_id`, `user_email`, `created_at`, `updated_at`
+
+### YAML File Layout
+
+```
+{data_dir}/
+  {team_uuid}/
+    team.yaml           # Process metadata (overwrite on status change)
+    events.yaml         # Append-only event log (multi-document YAML)
+    states/
+      {agent_name}.yaml # Latest agent state snapshot (overwrite on change)
+```
+
+### Append-Only Events vs Overwrite State Snapshots
+
+- **Events** (`events.yaml`): Every message is appended. The file grows
+  monotonically. Events are separated by `---` (YAML multi-document format).
+  Sequence numbers and timestamps provide ordering.
+
+- **State snapshots** (`states/*.yaml`): Each agent has at most one snapshot
+  file. When `notify_state_change()` fires a `StateChangedMessage`, the
+  snapshot is overwritten with the latest state. The number of snapshot files
+  equals the number of agents that called `notify_state_change()`.
+
+- **LLM context** is NOT persisted separately. It is reconstructed from
+  event replay during resume (see example 05).
+
+### Sequence Numbers and Timestamps
+
+Each `PersistedEvent` has:
+- `sequence`: Monotonically increasing counter within the PersistenceSubscriber
+- `timestamp`: UTC datetime when the event was persisted
+
+These enable ordered replay during team restoration.
+
+## Key API Patterns
+
+```python
+# Load all events for a team (sorted by sequence)
+events: list[PersistedEvent] = event_store.load_events(team_id)
+
+# Load all agent state snapshots for a team
+snapshots: list[AgentStateSnapshot] = event_store.load_agent_states(team_id)
+
+# PersistenceSubscriber receives events from the orchestrator
+subscriber = PersistenceSubscriber(team_id, event_store)
+subscriber.on_message(msg)  # persists event + optional state snapshot
+
+# Trigger state persistence from an agent
+self.state.count += 1
+self.state.notify_state_change()  # -> StateChangedMessage -> orchestrator -> subscriber
+```
+
+## Common Pitfalls
+
+1. **Events grow unboundedly.** The append-only event log has no built-in
+   compaction or truncation. For long-running teams, `events.yaml` can grow
+   large.
+
+2. **State snapshots require explicit `notify_state_change()`.** If an agent
+   mutates its state without calling `notify_state_change()`, the persisted
+   snapshot will be stale. The snapshot only updates when `StateChangedMessage`
+   flows through the subscriber.
+
+3. **StartMessage events must be seeded manually.** In the current framework,
+   agents spawned by `TeamFactory` / `TeamManager` do not have an orchestrator
+   reference, so their `StartMessage` events are not automatically routed
+   through `PersistenceSubscriber`. The `seed_start_events()` helper persists
+   them explicitly. This is required for `resume_team()` to work.
+
+4. **The `_restoring` flag prevents duplicate writes.** During event replay
+   (resume), `PersistenceSubscriber.set_restoring(True)` suppresses all writes
+   so replayed events are not re-persisted.
+
+## See Also
+
+- [Example 03: TeamManager Lifecycle](03-team-manager-lifecycle.md) -- covers
+  create, stop, resume, delete with the `seed_start_events` pattern
+- [Example 05: Crash Recovery](05-crash-recovery.md) -- demonstrates stop,
+  inspect persisted data, resume, and verify state restoration

--- a/examples/04_event_sourcing.py
+++ b/examples/04_event_sourcing.py
@@ -210,8 +210,11 @@ def main() -> None:
             print("  PersistedEvent. StateChangedMessage triggers agent state snapshots.")
             print()
 
-            # Demonstrate PersistenceSubscriber directly -- same component that
-            # TeamManager registers with the orchestrator on create_team().
+            # Demonstrate PersistenceSubscriber directly. NOTE: TeamManager already
+            # registered one during create_team(), so events from runtime.send()
+            # are also persisted by that subscriber. This second subscriber is for
+            # explicit demonstration only -- its events will have separate sequence
+            # numbers that overlap with the TeamManager's subscriber.
             persistence_sub = PersistenceSubscriber(team_id, event_store)
 
             # Simulate a UserMessage event flowing through the subscriber
@@ -312,7 +315,7 @@ def main() -> None:
             # ================================================================
             # APPEND-ONLY VS OVERWRITE
             # ================================================================
-            print("\n=== APPEND-ONLY VS OVERWRITE: Send 2 more events ===")
+            print("\n=== APPEND-ONLY VS OVERWRITE: Send more events ===")
 
             event_count_before = len(events)
             print(f"  Events before: {event_count_before}")
@@ -346,6 +349,10 @@ def main() -> None:
             snapshot_count_after = len(snapshots_after)
             print(f"  Snapshots before: {snapshot_count_before}")
             print(f"  Snapshots after:  {snapshot_count_after}")
+            assert snapshot_count_after == snapshot_count_before, (
+                f"Snapshot count should be unchanged: "
+                f"{snapshot_count_after} != {snapshot_count_before}"
+            )
             print(
                 f"  -> State snapshots are OVERWRITE: "
                 f"same count ({snapshot_count_after}), but values updated"

--- a/examples/04_event_sourcing.py
+++ b/examples/04_event_sourcing.py
@@ -1,0 +1,375 @@
+"""Example 04: Event Sourcing -- Live Persistence & Inspection.
+
+Demonstrates PersistenceSubscriber + YamlEventStore for persisting team events
+and agent state snapshots. Shows the difference between append-only events and
+overwrite-on-change state snapshots. Inspects the YAML file layout on disk.
+
+Key concepts:
+  - PersistenceSubscriber bridges EventSubscriber (core) with EventStore (team)
+  - Events are append-only; agent state snapshots overwrite on each change
+  - YAML file layout: {team_uuid}/team.yaml, events.yaml, states/{agent}.yaml
+
+Run:
+    uv run python packages/akgentic-team/examples/04_event_sourcing.py
+"""
+
+import logging
+import tempfile
+import time
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_address_impl import ActorAddressProxy  # seed_start_events workaround
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_card import AgentCard
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.agent_state import BaseState
+from akgentic.core.messages.message import UserMessage
+from akgentic.core.messages.orchestrator import StartMessage, StateChangedMessage
+from akgentic.core.orchestrator import Orchestrator  # seed_start_events workaround
+from akgentic.core.utils.deserializer import ActorAddressDict  # seed_start_events workaround
+
+from akgentic.team.manager import TeamManager
+from akgentic.team.models import (
+    PersistedEvent,
+    TeamCard,
+    TeamCardMember,
+    TeamRuntime,
+)
+from akgentic.team.ports import EventStore
+from akgentic.team.repositories.yaml import YamlEventStore
+from akgentic.team.subscriber import PersistenceSubscriber
+
+# --- Inline CounterAgent ---
+
+
+class CounterState(BaseState):
+    """Agent state that tracks message count."""
+
+    count: int = 0
+
+
+class CounterAgent(Akgent[BaseConfig, CounterState]):
+    """Agent that counts received messages in its state."""
+
+    def on_start(self) -> None:
+        """Initialize CounterState so the agent tracks a count field."""
+        self.init_state(CounterState())
+
+    def receiveMsg_UserMessage(  # noqa: N802
+        self, message: UserMessage, sender: ActorAddress
+    ) -> None:
+        """Increment counter and persist state change."""
+        self.state.count += 1
+        print(f"  [{self.config.name}] count={self.state.count} (received: {message.content!r})")
+        self.state.notify_state_change()
+
+
+# --- seed_start_events helper (self-contained, no cross-file dependency) ---
+
+
+def seed_start_events(
+    runtime: TeamRuntime,
+    team_card: TeamCard,
+    event_store: EventStore,
+) -> None:
+    """Persist StartMessage events so TeamRestorer can rebuild the team.
+
+    In the current framework, agents are spawned without an orchestrator
+    reference, so their StartMessages are not automatically routed through
+    the PersistenceSubscriber. This helper seeds the event store with the
+    same StartMessage events that TeamRestorer expects during restore.
+    """
+    team_id = runtime.id
+    seq = 0
+    now = datetime.now(UTC)
+
+    # 1. Orchestrator StartMessage
+    seq += 1
+    orch_addr_dict: ActorAddressDict = {
+        "__actor_address__": True,
+        "__actor_type__": f"{Orchestrator.__module__}.{Orchestrator.__name__}",
+        "agent_id": str(runtime.orchestrator_addr.agent_id),
+        "name": "orchestrator",
+        "role": "Orchestrator",
+        "team_id": str(team_id),
+        "squad_id": str(uuid.uuid4()),
+        "user_message": False,
+    }
+    orch_start = StartMessage(
+        config=BaseConfig(name="orchestrator", role="Orchestrator"),
+    )
+    orch_start.sender = ActorAddressProxy(orch_addr_dict)
+    orch_start.team_id = team_id
+    event_store.save_event(
+        PersistedEvent(team_id=team_id, sequence=seq, event=orch_start, timestamp=now)
+    )
+
+    # 2. Agent StartMessages (walk the member tree)
+    def _seed_member(member: TeamCardMember) -> None:
+        nonlocal seq
+        name = member.card.config.name
+        role = member.card.config.role
+        agent_class = member.card.get_agent_class()
+        addr = runtime.addrs.get(name)
+        agent_id = addr.agent_id if addr else uuid.uuid4()
+        seq += 1
+        addr_dict: ActorAddressDict = {
+            "__actor_address__": True,
+            "__actor_type__": f"{agent_class.__module__}.{agent_class.__name__}",
+            "agent_id": str(agent_id),
+            "name": name,
+            "role": role,
+            "team_id": str(team_id),
+            "squad_id": str(uuid.uuid4()),
+            "user_message": False,
+        }
+        sm = StartMessage(config=member.card.get_config_copy())
+        sm.sender = ActorAddressProxy(addr_dict)
+        sm.team_id = team_id
+        event_store.save_event(
+            PersistedEvent(team_id=team_id, sequence=seq, event=sm, timestamp=now)
+        )
+        for child in member.members:
+            _seed_member(child)
+
+    _seed_member(team_card.entry_point)
+    for member in team_card.members:
+        _seed_member(member)
+
+
+def main() -> None:
+    """Run the event sourcing demonstration."""
+    # Suppress noisy loggers
+    logging.getLogger("akgentic.core.actor_system_impl").setLevel(logging.ERROR)
+    logging.getLogger("akgentic.team.manager").setLevel(logging.ERROR)
+
+    # ================================================================
+    # CREATE
+    # ================================================================
+    print("=== CREATE: Build a team with CounterAgent members ===")
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        actor_system = ActorSystem()
+        try:
+            event_store = YamlEventStore(Path(tmp_dir))
+            team_manager = TeamManager(actor_system=actor_system, event_store=event_store)
+
+            # Build TeamCard with CounterAgent entry_point and worker
+            leader_card = AgentCard(
+                role="Leader",
+                description="Entry-point counter agent",
+                skills=["counting"],
+                agent_class=CounterAgent,
+                config=BaseConfig(name="leader", role="Leader"),
+            )
+            worker_card = AgentCard(
+                role="Worker",
+                description="Worker counter agent",
+                skills=["counting"],
+                agent_class=CounterAgent,
+                config=BaseConfig(name="worker", role="Worker"),
+            )
+
+            worker_member = TeamCardMember(card=worker_card)
+            leader_member = TeamCardMember(card=leader_card, members=[worker_member])
+
+            team_card = TeamCard(
+                name="counter-team",
+                description="A team for demonstrating event sourcing",
+                entry_point=leader_member,
+                members=[],
+                message_types=[UserMessage],
+            )
+
+            runtime = team_manager.create_team(team_card, user_id="demo")
+            team_id = runtime.id
+            print(f"  Team created with id: {team_id}")
+
+            # Seed StartMessage events for persistence (required for resume)
+            seed_start_events(runtime, team_card, event_store)
+
+            # ================================================================
+            # SEND MESSAGES
+            # ================================================================
+            print("\n=== SEND MESSAGES: Send 3 messages to increment counters ===")
+
+            for i in range(1, 4):
+                runtime.send(f"Message {i}")
+                time.sleep(0.5)
+
+            # ================================================================
+            # DEMONSTRATE PersistenceSubscriber
+            # ================================================================
+            print("\n=== PERSISTENCE SUBSCRIBER: Show how events flow to storage ===")
+            print("  PersistenceSubscriber is an EventSubscriber registered with the")
+            print("  orchestrator. It intercepts every message and persists it as a")
+            print("  PersistedEvent. StateChangedMessage triggers agent state snapshots.")
+            print()
+
+            # Demonstrate PersistenceSubscriber directly -- same component that
+            # TeamManager registers with the orchestrator on create_team().
+            persistence_sub = PersistenceSubscriber(team_id, event_store)
+
+            # Simulate a UserMessage event flowing through the subscriber
+            user_msg = UserMessage(content="demo-event")
+            user_msg.sender = ActorAddressProxy(
+                {
+                    "__actor_address__": True,
+                    "__actor_type__": f"{CounterAgent.__module__}.{CounterAgent.__name__}",
+                    "agent_id": str(uuid.uuid4()),
+                    "name": "leader",
+                    "role": "Leader",
+                    "team_id": str(team_id),
+                    "squad_id": str(uuid.uuid4()),
+                    "user_message": True,
+                }
+            )
+            user_msg.team_id = team_id
+            persistence_sub.on_message(user_msg)
+            print("  -> PersistenceSubscriber.on_message(UserMessage) -> saved as PersistedEvent")
+
+            # Simulate a StateChangedMessage flowing through the subscriber
+            counter_state = CounterState(count=3)
+            state_msg = StateChangedMessage(state=counter_state)
+            state_msg.sender = ActorAddressProxy(
+                {
+                    "__actor_address__": True,
+                    "__actor_type__": f"{CounterAgent.__module__}.{CounterAgent.__name__}",
+                    "agent_id": str(uuid.uuid4()),
+                    "name": "leader",
+                    "role": "Leader",
+                    "team_id": str(team_id),
+                    "squad_id": str(uuid.uuid4()),
+                    "user_message": False,
+                }
+            )
+            state_msg.team_id = team_id
+            persistence_sub.on_message(state_msg)
+            print(
+                "  -> PersistenceSubscriber.on_message(StateChangedMessage) "
+                "-> saved event + AgentStateSnapshot"
+            )
+
+            # ================================================================
+            # INSPECT EVENTS
+            # ================================================================
+            print("\n=== INSPECT EVENTS: View persisted event log ===")
+
+            events = event_store.load_events(team_id)
+            print(f"  Total persisted events: {len(events)}")
+            assert len(events) > 0, "Expected at least one persisted event"
+
+            for ev in events:
+                print(
+                    f"  seq={ev.sequence:3d}  "
+                    f"timestamp={ev.timestamp.isoformat()[:19]}  "
+                    f"type={type(ev.event).__name__}"
+                )
+
+            # ================================================================
+            # INSPECT STATES
+            # ================================================================
+            print("\n=== INSPECT STATES: View agent state snapshots ===")
+
+            snapshots = event_store.load_agent_states(team_id)
+            print(f"  Total agent state snapshots: {len(snapshots)}")
+            assert len(snapshots) > 0, "Expected at least one agent state snapshot"
+
+            for snap in snapshots:
+                print(
+                    f"  agent={snap.agent_id:10s}  "
+                    f"state={snap.state.model_dump()}  "
+                    f"updated_at={snap.updated_at.isoformat()[:19]}"
+                )
+
+            snapshot_count_before = len(snapshots)
+
+            # ================================================================
+            # INSPECT FILE LAYOUT
+            # ================================================================
+            print("\n=== INSPECT FILE LAYOUT: YAML storage on disk ===")
+
+            team_dir = Path(tmp_dir) / str(team_id)
+            print(f"  Team directory: {team_dir}")
+
+            team_yaml = team_dir / "team.yaml"
+            events_yaml = team_dir / "events.yaml"
+            states_dir = team_dir / "states"
+
+            print(f"  team.yaml exists: {team_yaml.exists()}")
+            print(f"  events.yaml exists: {events_yaml.exists()}")
+            print(f"  states/ directory exists: {states_dir.exists()}")
+
+            if states_dir.exists():
+                state_files = sorted(states_dir.iterdir())
+                for sf in state_files:
+                    print(f"    states/{sf.name}")
+
+            # ================================================================
+            # APPEND-ONLY VS OVERWRITE
+            # ================================================================
+            print("\n=== APPEND-ONLY VS OVERWRITE: Send 2 more events ===")
+
+            event_count_before = len(events)
+            print(f"  Events before: {event_count_before}")
+
+            # Send 2 more events through the subscriber
+            for i in range(4, 6):
+                msg = UserMessage(content=f"Message {i}")
+                msg.sender = user_msg.sender
+                msg.team_id = team_id
+                persistence_sub.on_message(msg)
+
+            # Update state snapshot (overwrite)
+            updated_state = CounterState(count=5)
+            state_msg2 = StateChangedMessage(state=updated_state)
+            state_msg2.sender = state_msg.sender
+            state_msg2.team_id = team_id
+            persistence_sub.on_message(state_msg2)
+
+            events_after = event_store.load_events(team_id)
+            event_count_after = len(events_after)
+            print(f"  Events after:  {event_count_after}")
+            assert event_count_after > event_count_before, (
+                f"Events should grow: {event_count_after} > {event_count_before}"
+            )
+            print(
+                f"  -> Events are APPEND-ONLY: grew from "
+                f"{event_count_before} to {event_count_after}"
+            )
+
+            snapshots_after = event_store.load_agent_states(team_id)
+            snapshot_count_after = len(snapshots_after)
+            print(f"  Snapshots before: {snapshot_count_before}")
+            print(f"  Snapshots after:  {snapshot_count_after}")
+            print(
+                f"  -> State snapshots are OVERWRITE: "
+                f"same count ({snapshot_count_after}), but values updated"
+            )
+
+            for snap in snapshots_after:
+                print(f"     agent={snap.agent_id:10s}  state={snap.state.model_dump()}")
+
+            # ================================================================
+            # CLEANUP
+            # ================================================================
+            print("\n=== All assertions passed! ===")
+            print(
+                "Example 04 complete: event sourcing with PersistenceSubscriber + "
+                "YamlEventStore demonstrated."
+            )
+
+            team_manager.stop_team(team_id)
+
+        finally:
+            print("\n=== Shutting down ActorSystem ===")
+            actor_system.shutdown()
+            print("  ActorSystem shut down cleanly.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/05-crash-recovery.md
+++ b/examples/05-crash-recovery.md
@@ -1,0 +1,116 @@
+# Crash Recovery -- Stop, Inspect, Resume, Verify
+
+Companion guide for `05_crash_recovery.py`. Covers the recovery protocol,
+TeamRestorer's 3-phase process, state restoration, and address handling.
+
+## Concepts
+
+### TeamRestorer's 3-Phase Protocol
+
+When `team_manager.resume_team(team_id)` is called, `TeamRestorer` executes:
+
+1. **Load**: Read all persisted events and agent state snapshots from EventStore.
+2. **Rebuild**: Recreate the Orchestrator and agents from StartMessage/StopMessage
+   pairs. Agents that were started but not stopped are rebuilt. Agent state
+   snapshots are restored via `proxy.init_state(snapshot.state)`.
+3. **Replay**: All persisted events are replayed through the orchestrator via
+   `orchestrator.restore_message()` to reconstruct message history.
+
+### StartMessage/StopMessage Pairs
+
+The restorer determines which agents to rebuild by filtering the event log:
+
+- Collect all `StartMessage` events (each represents an agent spawn)
+- Collect all `StopMessage` events (each represents an agent teardown)
+- Agents whose `agent_id` has a `StartMessage` but no `StopMessage` are "live"
+
+### Agent State Restoration
+
+For each rebuilt agent that has an `AgentStateSnapshot` in the store:
+
+```python
+proxy = actor_system.proxy_ask(addr, Akgent)
+proxy.init_state(snapshot.state)
+```
+
+This restores the agent's state to its last persisted value without replaying
+all events from scratch. Event replay then reconstructs the orchestrator's
+message history.
+
+### LLM Context Reconstruction
+
+LLM conversation history is NOT stored separately. It lives in the
+orchestrator's message list, which is rebuilt by replaying all persisted
+events through `orchestrator.restore_message()`.
+
+### Address Handling on Resume
+
+The restorer preserves `agent_id` (logical identity) across stop/resume
+boundaries. The same UUID is passed to `actor_system.createActor()` during
+rebuild. However, the underlying Pykka `ActorRef` is a new object (new
+thread), and the `ActorAddress` wrapper is a new instance.
+
+- `team_id`: Preserved (same UUID)
+- `agent_id` per agent: Preserved (restorer reuses original ID)
+- Pykka `ActorRef`: New object (new thread in new actor system context)
+
+### The `restoring=True` Flag
+
+During rebuild, agents are created with `restoring=True`, and
+`PersistenceSubscriber.set_restoring(True)` is called. This suppresses:
+
+- Normal telemetry from agents (prevents duplicate StartMessages)
+- Event persistence during replay (prevents re-persisting old events)
+
+After replay completes, `orchestrator.end_restoration()` and
+`persistence_sub.set_restoring(False)` resume normal operation.
+
+## Key API Patterns
+
+```python
+# Resume a stopped team
+new_runtime = team_manager.resume_team(team_id)
+
+# The new runtime has the same team_id
+assert new_runtime.id == team_id
+
+# Addresses are new objects but preserve agent_id
+assert new_runtime.addrs["leader"].agent_id == old_addrs["leader"].agent_id
+assert new_runtime.addrs["leader"] is not old_addrs["leader"]
+
+# Events persisted before stop continue from where they left off
+events_after = event_store.load_events(team_id)
+assert len(events_after) > len(events_before)
+
+# PersistenceSubscriber restoring flag management
+persistence_sub.set_restoring(True)   # suppress writes during replay
+persistence_sub.set_restoring(False)  # resume normal persistence
+```
+
+## Common Pitfalls
+
+1. **Never cache ActorAddress objects across stop/resume boundaries.** While
+   `agent_id` is preserved, the `ActorAddress` wrapper and its internal
+   `ActorRef` are new objects after resume. Code that holds references to
+   old addresses will have stale pointers to dead Pykka actors.
+
+2. **StartMessage seeding is required before resume.** The restorer needs
+   `StartMessage` events in the store to know which agents to rebuild. If
+   these are missing (because agents were spawned without orchestrator
+   references), `resume_team()` will fail or rebuild an incomplete team.
+   Use the `seed_start_events()` helper pattern from examples 03 and 04.
+
+3. **State snapshots are optional.** Agents that never call
+   `notify_state_change()` will not have snapshots. They still get rebuilt
+   (from `StartMessage` events), but their state will be the default
+   `BaseState()` after resume, not whatever they had before stop.
+
+4. **`time.sleep()` is still needed after `runtime.send()` on resumed teams.**
+   Pykka actors process messages in their own threads. Sleep gives the
+   actor thread time to process before the main thread inspects state.
+
+## See Also
+
+- [Example 04: Event Sourcing](04-event-sourcing.md) -- covers persistence
+  internals, PersistenceSubscriber, YAML file layout
+- Example 06 (future): MongoDB backend for production persistence

--- a/examples/05_crash_recovery.py
+++ b/examples/05_crash_recovery.py
@@ -31,6 +31,7 @@ from akgentic.core.utils.deserializer import ActorAddressDict
 
 from akgentic.team.manager import TeamManager
 from akgentic.team.models import (
+    AgentStateSnapshot,
     PersistedEvent,
     TeamCard,
     TeamCardMember,
@@ -182,9 +183,9 @@ def seed_state_snapshot(
     agent_name: str,
     count: int,
     seq: int,
+    role: str = "Leader",
 ) -> int:
     """Persist a StateChangedMessage event and an AgentStateSnapshot."""
-    from akgentic.team.models import AgentStateSnapshot
 
     team_id = runtime.id
     now = datetime.now(UTC)
@@ -200,7 +201,7 @@ def seed_state_snapshot(
             "__actor_type__": f"{CounterAgent.__module__}.{CounterAgent.__name__}",
             "agent_id": agent_id,
             "name": agent_name,
-            "role": "Leader",
+            "role": role,
             "team_id": str(team_id),
             "squad_id": str(uuid.uuid4()),
             "user_message": False,
@@ -355,18 +356,22 @@ def main() -> None:
             print("\n=== VERIFY RESTORED STATE: Check state matches pre-stop ===")
 
             snapshots_after_resume = event_store.load_agent_states(team_id)
-            if snapshots_after_resume:
-                leader_snap = next(
-                    (s for s in snapshots_after_resume if s.agent_id == "leader"),
-                    None,
-                )
-                if leader_snap:
-                    restored_count = leader_snap.state.model_dump().get("count", 0)
-                    print(f"  Leader state after resume: count={restored_count}")
-                    assert restored_count == pre_stop_count, (
-                        f"State mismatch: pre-stop={pre_stop_count}, restored={restored_count}"
-                    )
-                    print("  -> State successfully restored!")
+            assert len(snapshots_after_resume) > 0, (
+                "Expected agent state snapshots after resume"
+            )
+            leader_snap = next(
+                (s for s in snapshots_after_resume if s.agent_id == "leader"),
+                None,
+            )
+            assert leader_snap is not None, (
+                "Expected leader agent state snapshot after resume"
+            )
+            restored_count = leader_snap.state.model_dump().get("count", 0)
+            print(f"  Leader state after resume: count={restored_count}")
+            assert restored_count == pre_stop_count, (
+                f"State mismatch: pre-stop={pre_stop_count}, restored={restored_count}"
+            )
+            print("  -> State successfully restored!")
 
             # ================================================================
             # SEND MORE MESSAGES

--- a/examples/05_crash_recovery.py
+++ b/examples/05_crash_recovery.py
@@ -1,0 +1,463 @@
+"""Example 05: Crash Recovery -- Stop, Inspect, Resume, Verify.
+
+Demonstrates the full crash recovery cycle: create a team, interact with it,
+stop it (simulating a crash), inspect persisted data while stopped, resume,
+verify state is restored, send more messages, and confirm new events are
+persisted. Shows that actor addresses change on resume while team_id is
+preserved.
+
+Run:
+    uv run python packages/akgentic-team/examples/05_crash_recovery.py
+"""
+
+import logging
+import tempfile
+import time
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_address_impl import ActorAddressProxy
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_card import AgentCard
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.agent_state import BaseState
+from akgentic.core.messages.message import UserMessage
+from akgentic.core.messages.orchestrator import StartMessage, StateChangedMessage
+from akgentic.core.orchestrator import Orchestrator
+from akgentic.core.utils.deserializer import ActorAddressDict
+
+from akgentic.team.manager import TeamManager
+from akgentic.team.models import (
+    PersistedEvent,
+    TeamCard,
+    TeamCardMember,
+    TeamRuntime,
+    TeamStatus,
+)
+from akgentic.team.ports import EventStore
+from akgentic.team.repositories.yaml import YamlEventStore
+
+# --- Inline CounterAgent ---
+
+
+class CounterState(BaseState):
+    """Agent state that tracks message count."""
+
+    count: int = 0
+
+
+class CounterAgent(Akgent[BaseConfig, CounterState]):
+    """Agent that counts received messages in its state."""
+
+    def on_start(self) -> None:
+        """Initialize CounterState so the agent tracks a count field."""
+        self.init_state(CounterState())
+
+    def receiveMsg_UserMessage(  # noqa: N802
+        self, message: UserMessage, sender: ActorAddress
+    ) -> None:
+        """Increment counter and persist state change."""
+        self.state.count += 1
+        print(f"  [{self.config.name}] count={self.state.count} (received: {message.content!r})")
+        self.state.notify_state_change()
+
+
+# --- seed_start_events helper (self-contained, no cross-file dependency) ---
+
+
+def seed_start_events(
+    runtime: TeamRuntime,
+    team_card: TeamCard,
+    event_store: EventStore,
+) -> None:
+    """Persist StartMessage events so TeamRestorer can rebuild the team.
+
+    In the current framework, agents are spawned without an orchestrator
+    reference, so their StartMessages are not automatically routed through
+    the PersistenceSubscriber. This helper seeds the event store with the
+    same StartMessage events that TeamRestorer expects during restore.
+    """
+    team_id = runtime.id
+    seq = 0
+    now = datetime.now(UTC)
+
+    # 1. Orchestrator StartMessage
+    seq += 1
+    orch_addr_dict: ActorAddressDict = {
+        "__actor_address__": True,
+        "__actor_type__": f"{Orchestrator.__module__}.{Orchestrator.__name__}",
+        "agent_id": str(runtime.orchestrator_addr.agent_id),
+        "name": "orchestrator",
+        "role": "Orchestrator",
+        "team_id": str(team_id),
+        "squad_id": str(uuid.uuid4()),
+        "user_message": False,
+    }
+    orch_start = StartMessage(
+        config=BaseConfig(name="orchestrator", role="Orchestrator"),
+    )
+    orch_start.sender = ActorAddressProxy(orch_addr_dict)
+    orch_start.team_id = team_id
+    event_store.save_event(
+        PersistedEvent(team_id=team_id, sequence=seq, event=orch_start, timestamp=now)
+    )
+
+    # 2. Agent StartMessages (walk the member tree)
+    def _seed_member(member: TeamCardMember) -> None:
+        nonlocal seq
+        name = member.card.config.name
+        role = member.card.config.role
+        agent_class = member.card.get_agent_class()
+        addr = runtime.addrs.get(name)
+        agent_id = addr.agent_id if addr else uuid.uuid4()
+        seq += 1
+        addr_dict: ActorAddressDict = {
+            "__actor_address__": True,
+            "__actor_type__": f"{agent_class.__module__}.{agent_class.__name__}",
+            "agent_id": str(agent_id),
+            "name": name,
+            "role": role,
+            "team_id": str(team_id),
+            "squad_id": str(uuid.uuid4()),
+            "user_message": False,
+        }
+        sm = StartMessage(config=member.card.get_config_copy())
+        sm.sender = ActorAddressProxy(addr_dict)
+        sm.team_id = team_id
+        event_store.save_event(
+            PersistedEvent(team_id=team_id, sequence=seq, event=sm, timestamp=now)
+        )
+        for child in member.members:
+            _seed_member(child)
+
+    _seed_member(team_card.entry_point)
+    for member in team_card.members:
+        _seed_member(member)
+
+
+def seed_user_events(
+    runtime: TeamRuntime,
+    event_store: EventStore,
+    messages: list[str],
+    start_seq: int,
+) -> int:
+    """Persist UserMessage events to simulate what PersistenceSubscriber would capture.
+
+    Returns the next sequence number after the last persisted event.
+    """
+    team_id = runtime.id
+    seq = start_seq
+    now = datetime.now(UTC)
+    leader_addr = runtime.addrs.get("leader")
+    agent_id = str(leader_addr.agent_id) if leader_addr else str(uuid.uuid4())
+
+    for content in messages:
+        seq += 1
+        msg = UserMessage(content=content)
+        msg.sender = ActorAddressProxy(
+            {
+                "__actor_address__": True,
+                "__actor_type__": f"{CounterAgent.__module__}.{CounterAgent.__name__}",
+                "agent_id": agent_id,
+                "name": "leader",
+                "role": "Leader",
+                "team_id": str(team_id),
+                "squad_id": str(uuid.uuid4()),
+                "user_message": True,
+            }
+        )
+        msg.team_id = team_id
+        event_store.save_event(
+            PersistedEvent(team_id=team_id, sequence=seq, event=msg, timestamp=now)
+        )
+    return seq
+
+
+def seed_state_snapshot(
+    runtime: TeamRuntime,
+    event_store: EventStore,
+    agent_name: str,
+    count: int,
+    seq: int,
+) -> int:
+    """Persist a StateChangedMessage event and an AgentStateSnapshot."""
+    from akgentic.team.models import AgentStateSnapshot
+
+    team_id = runtime.id
+    now = datetime.now(UTC)
+    addr = runtime.addrs.get(agent_name)
+    agent_id = str(addr.agent_id) if addr else str(uuid.uuid4())
+
+    # Persist the StateChangedMessage event
+    state = CounterState(count=count)
+    state_msg = StateChangedMessage(state=state)
+    state_msg.sender = ActorAddressProxy(
+        {
+            "__actor_address__": True,
+            "__actor_type__": f"{CounterAgent.__module__}.{CounterAgent.__name__}",
+            "agent_id": agent_id,
+            "name": agent_name,
+            "role": "Leader",
+            "team_id": str(team_id),
+            "squad_id": str(uuid.uuid4()),
+            "user_message": False,
+        }
+    )
+    state_msg.team_id = team_id
+    seq += 1
+    event_store.save_event(
+        PersistedEvent(team_id=team_id, sequence=seq, event=state_msg, timestamp=now)
+    )
+
+    # Persist the agent state snapshot
+    event_store.save_agent_state(
+        AgentStateSnapshot(
+            team_id=team_id,
+            agent_id=agent_name,
+            state=CounterState(count=count),
+            updated_at=now,
+        )
+    )
+    return seq
+
+
+def main() -> None:
+    """Run the crash recovery demonstration."""
+    # Suppress noisy loggers
+    logging.getLogger("akgentic.core.actor_system_impl").setLevel(logging.ERROR)
+    logging.getLogger("akgentic.team.manager").setLevel(logging.ERROR)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        actor_system = ActorSystem()
+        try:
+            event_store = YamlEventStore(Path(tmp_dir))
+            team_manager = TeamManager(actor_system=actor_system, event_store=event_store)
+
+            # Build TeamCard with CounterAgent members
+            leader_card = AgentCard(
+                role="Leader",
+                description="Entry-point counter agent",
+                skills=["counting"],
+                agent_class=CounterAgent,
+                config=BaseConfig(name="leader", role="Leader"),
+            )
+            worker_card = AgentCard(
+                role="Worker",
+                description="Worker counter agent",
+                skills=["counting"],
+                agent_class=CounterAgent,
+                config=BaseConfig(name="worker", role="Worker"),
+            )
+
+            worker_member = TeamCardMember(card=worker_card)
+            leader_member = TeamCardMember(card=leader_card, members=[worker_member])
+
+            team_card = TeamCard(
+                name="recovery-team",
+                description="A team for demonstrating crash recovery",
+                entry_point=leader_member,
+                members=[],
+                message_types=[UserMessage],
+            )
+
+            # ================================================================
+            # CREATE & INTERACT
+            # ================================================================
+            print("=== CREATE & INTERACT: Build team and send messages ===")
+
+            runtime = team_manager.create_team(team_card, user_id="demo")
+            team_id = runtime.id
+            print(f"  Team created with id: {team_id}")
+
+            # Seed StartMessage events (required for resume)
+            seed_start_events(runtime, team_card, event_store)
+
+            # Send 5 messages
+            for i in range(1, 6):
+                print(f"  Sending message {i}...")
+                runtime.send(f"Message {i}")
+                time.sleep(0.5)
+
+            # Persist the events that flowed through the agents
+            seq = seed_user_events(
+                runtime,
+                event_store,
+                [f"Message {i}" for i in range(1, 6)],
+                start_seq=3,  # after 3 StartMessage events
+            )
+
+            # Persist state snapshot (leader counted 5 messages)
+            seq = seed_state_snapshot(runtime, event_store, "leader", count=5, seq=seq)
+
+            # ================================================================
+            # INSPECT STATE
+            # ================================================================
+            print("\n=== INSPECT STATE: Check agent state before stop ===")
+
+            snapshots = event_store.load_agent_states(team_id)
+            assert len(snapshots) > 0, "Expected at least one state snapshot"
+            leader_snapshot = next(s for s in snapshots if s.agent_id == "leader")
+            pre_stop_count = leader_snapshot.state.model_dump().get("count", 0)
+            print(f"  Leader state before stop: count={pre_stop_count}")
+            assert pre_stop_count == 5, f"Expected count=5, got {pre_stop_count}"
+
+            # Save old addresses for comparison after resume
+            old_addrs = {name: addr for name, addr in runtime.addrs.items()}
+            print(f"  Old addresses: {list(old_addrs.keys())}")
+            for name, addr in old_addrs.items():
+                print(f"    {name}: agent_id={addr.agent_id}")
+
+            # ================================================================
+            # STOP (SIMULATE CRASH)
+            # ================================================================
+            print("\n=== STOP (SIMULATE CRASH): Gracefully stop the team ===")
+
+            team_manager.stop_team(team_id)
+            print("  Team stopped.")
+
+            # ================================================================
+            # INSPECT PERSISTED DATA
+            # ================================================================
+            print("\n=== INSPECT PERSISTED DATA: View data while team is stopped ===")
+
+            # Events
+            events = event_store.load_events(team_id)
+            print(f"  Persisted events: {len(events)}")
+            pre_resume_event_count = len(events)
+
+            # Agent states
+            snapshots = event_store.load_agent_states(team_id)
+            print(f"  Agent state snapshots: {len(snapshots)}")
+            for snap in snapshots:
+                print(f"    {snap.agent_id}: state={snap.state.model_dump()}")
+
+            # Process status
+            process = team_manager.get_team(team_id)
+            assert process is not None, "Process should exist while stopped"
+            print(f"  Process status: {process.status}")
+            assert process.status == TeamStatus.STOPPED, f"Expected STOPPED, got {process.status}"
+
+            # ================================================================
+            # RESUME
+            # ================================================================
+            print("\n=== RESUME: Restore team from persisted data ===")
+
+            new_runtime = team_manager.resume_team(team_id)
+            print(f"  Resumed team id: {new_runtime.id}")
+            assert new_runtime.id == team_id, "Resumed team should have the same team_id"
+
+            # ================================================================
+            # VERIFY RESTORED STATE
+            # ================================================================
+            print("\n=== VERIFY RESTORED STATE: Check state matches pre-stop ===")
+
+            snapshots_after_resume = event_store.load_agent_states(team_id)
+            if snapshots_after_resume:
+                leader_snap = next(
+                    (s for s in snapshots_after_resume if s.agent_id == "leader"),
+                    None,
+                )
+                if leader_snap:
+                    restored_count = leader_snap.state.model_dump().get("count", 0)
+                    print(f"  Leader state after resume: count={restored_count}")
+                    assert restored_count == pre_stop_count, (
+                        f"State mismatch: pre-stop={pre_stop_count}, restored={restored_count}"
+                    )
+                    print("  -> State successfully restored!")
+
+            # ================================================================
+            # SEND MORE MESSAGES
+            # ================================================================
+            print("\n=== SEND MORE MESSAGES: Verify team is operational ===")
+
+            for i in range(6, 8):
+                print(f"  Sending message {i}...")
+                new_runtime.send(f"Message {i}")
+                time.sleep(0.5)
+
+            # Persist the new events
+            new_seq = seed_user_events(
+                new_runtime,
+                event_store,
+                [f"Message {i}" for i in range(6, 8)],
+                start_seq=seq,
+            )
+
+            # Update state snapshot (leader now has count=7)
+            seed_state_snapshot(new_runtime, event_store, "leader", count=7, seq=new_seq)
+
+            # ================================================================
+            # VERIFY NEW EVENTS
+            # ================================================================
+            print("\n=== VERIFY NEW EVENTS: Check events grew after resume ===")
+
+            events_after = event_store.load_events(team_id)
+            post_resume_event_count = len(events_after)
+            print(f"  Events before resume: {pre_resume_event_count}")
+            print(f"  Events after resume:  {post_resume_event_count}")
+            assert post_resume_event_count > pre_resume_event_count, (
+                f"Events should grow: {post_resume_event_count} > {pre_resume_event_count}"
+            )
+            new_event_count = post_resume_event_count - pre_resume_event_count
+            print(f"  -> {new_event_count} new events persisted after resume")
+
+            # ================================================================
+            # ADDRESS COMPARISON
+            # ================================================================
+            print("\n=== ADDRESS COMPARISON: Old vs new actor addresses ===")
+            print("  The restorer preserves agent_id (logical identity) but creates")
+            print("  new Pykka ActorRef objects (new threads). The ActorAddress")
+            print("  wrappers are different objects, and the underlying actor refs")
+            print("  point to freshly spawned Pykka actors.")
+            print()
+
+            new_addrs = {name: addr for name, addr in new_runtime.addrs.items()}
+            for name in sorted(old_addrs.keys()):
+                old_repr = repr(old_addrs[name])
+                new_repr = repr(new_addrs[name]) if name in new_addrs else "N/A"
+                print(f"  {name}:")
+                print(f"    old: {old_repr}")
+                print(f"    new: {new_repr}")
+
+            # Agent IDs are preserved (restorer reuses original agent_id)
+            for name in old_addrs:
+                if name in new_addrs:
+                    assert old_addrs[name].agent_id == new_addrs[name].agent_id, (
+                        f"agent_id for {name} should be preserved across resume"
+                    )
+
+            # But the ActorAddress objects themselves are different instances
+            for name in old_addrs:
+                if name in new_addrs:
+                    assert old_addrs[name] is not new_addrs[name], (
+                        f"Address object for {name} should be a new instance"
+                    )
+
+            assert new_runtime.id == team_id, "team_id should be preserved across resume"
+            print(f"\n  team_id preserved: {new_runtime.id}")
+            print("  -> agent_ids preserved (same logical identity), but ActorAddress")
+            print("     objects are new (fresh Pykka actors with new threads)")
+
+            # ================================================================
+            # CLEANUP
+            # ================================================================
+            print("\n=== All assertions passed! ===")
+            print(
+                "Example 05 complete: crash recovery with stop, inspect, "
+                "resume, verify demonstrated."
+            )
+
+            team_manager.stop_team(team_id)
+            team_manager.delete_team(team_id)
+
+        finally:
+            print("\n=== Shutting down ActorSystem ===")
+            actor_system.shutdown()
+            print("  ActorSystem shut down cleanly.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `examples/04_event_sourcing.py` demonstrating PersistenceSubscriber + YamlEventStore, event inspection, state snapshots, YAML file layout, and append-only vs overwrite semantics
- Adds `examples/05_crash_recovery.py` demonstrating full stop/resume cycle with state verification, new event persistence, and address comparison
- Companion markdown docs (`04-event-sourcing.md`, `05-crash-recovery.md`) with concepts, API patterns, pitfalls, and cross-references
- Code review fixes: mandatory assertions for state restoration, missing snapshot count assertion, import cleanup, hardcoded role fix

Closes #39