### PR TITLE
docs: add CLI README, improve examples README, rewrite project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,42 +3,349 @@
 [![CI](https://github.com/b12consulting/akgentic-team/actions/workflows/ci.yml/badge.svg)](https://github.com/b12consulting/akgentic-team/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/jltournay/708bb547b8679308d083be7beaf4448a/raw/coverage.json)](https://github.com/b12consulting/akgentic-team/actions/workflows/ci.yml)
 
-**Status:** Alpha - 1.0.0-alpha.1
+Team lifecycle management for the [Akgentic](https://github.com/b12consulting/akgentic-quick-start)
+multi-agent framework. Create, resume, stop, and delete multi-agent teams
+with event-sourced persistence and crash recovery.
 
-Team lifecycle management for the Akgentic platform. Create, resume, stop, and delete multi-agent teams with event-sourced persistence and crash recovery.
+## Table of Contents
+
+- [Overview](#overview)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Architecture](#architecture)
+- [Team Definitions](#team-definitions)
+- [Lifecycle Management](#lifecycle-management)
+- [Persistence](#persistence)
+- [CLI](#cli)
+- [Examples](#examples)
+- [Development](#development)
+- [License](#license)
+
+## Overview
+
+`akgentic-team` provides the runtime lifecycle layer for Akgentic agent
+teams. It sits between static team definitions and the running actor system,
+providing:
+
+- **Declarative team definitions** via `TeamCard` / `TeamCardMember` models
+  with hierarchical member trees
+- **One-call team building** via `TeamFactory` — from a `TeamCard` to live
+  Pykka actors with routing wired
+- **Full lifecycle management** via `TeamManager` — create, stop, resume,
+  delete with state machine enforcement
+- **Event-sourced persistence** via `PersistenceSubscriber` — every message
+  is captured for crash recovery
+- **Crash recovery** via `TeamRestorer` — 3-phase restore protocol rebuilds
+  teams from persisted events
+- **Two storage backends** (YAML files and MongoDB) behind a common
+  `EventStore` protocol
+- **CLI** (`ak-team`) for managing team instances from the command line
+
+```
+TeamCard ──▶ TeamFactory.build() ──▶ TeamRuntime (live actors)
+                                          │
+                              TeamManager  │  PersistenceSubscriber
+                              ┌────────────┤  ┌──────────────────┐
+                              │ create     │  │ save_event()     │
+                              │ stop       │  │ save_agent_state │
+                              │ resume ◀───┼──│ (event sourcing) │
+                              │ delete     │  └──────────────────┘
+                              └────────────┘
+                                    │
+                              EventStore Protocol
+                              ┌─────┴──────┐
+                              │            │
+                         YamlEventStore  MongoEventStore
+```
 
 ## Installation
 
+### Workspace Installation (Recommended)
+
+This package is designed for use within the Akgentic monorepo workspace:
+
 ```bash
-# Within the Akgentic workspace (from root)
-uv sync --all-packages
+git clone git@github.com:b12consulting/akgentic-quick-start.git
+cd akgentic-quick-start
+git submodule update --init --recursive
 
-# With MongoDB support
-uv sync --all-packages --extra mongo
-
-# With CLI
-uv sync --all-packages --extra cli
+uv venv
+source .venv/bin/activate
+uv sync --all-packages --all-extras
 ```
 
-## Dependencies
+All dependencies (`akgentic-core`) resolve automatically via workspace
+configuration.
 
-**Required:**
-- `akgentic` (akgentic-core) - Actor framework, orchestrator, messaging
-- `pydantic>=2.0.0` - Data validation and serialization
+### Optional Extras
 
-**Optional:**
-- `pymongo>=4.0.0` - MongoDB persistence backend (`[mongo]` extra)
-- `typer>=0.9.0`, `rich>=13.0.0` - CLI interface (`[cli]` extra)
+```bash
+# CLI (Typer + Rich)
+uv sync --extra cli
+
+# MongoDB backend
+uv sync --extra mongo
+
+# Everything
+uv sync --all-extras
+```
+
+## Quick Start
+
+Create a team, send a message, stop it, and resume it:
+
+```python
+from pathlib import Path
+from akgentic.core import ActorSystem, AgentCard, BaseConfig, BaseState
+from akgentic.core.akgent import Akgent
+from akgentic.team import (
+    TeamCard, TeamCardMember, TeamManager, YamlEventStore,
+)
+
+# Define a simple agent
+class EchoAgent(Akgent):
+    def receiveMsg_UserMessage(self, msg):
+        print(f"Echo: {msg.content}")
+
+# Build a team definition
+card = AgentCard(
+    role="Echo", description="Echoes messages",
+    skills=["echo"], agent_class=EchoAgent,
+    config=BaseConfig(name="@Echo", role="Echo"),
+)
+team_card = TeamCard(
+    name="echo-team", description="Simple echo team",
+    entry_point=TeamCardMember(card=card),
+    members=[TeamCardMember(card=card)],
+)
+
+# Create and manage a team
+actor_system = ActorSystem()
+event_store = YamlEventStore(Path("./data"))
+manager = TeamManager(actor_system=actor_system, event_store=event_store)
+
+runtime = manager.create_team(team_card)
+runtime.send("Hello!")  # → Echo: Hello!
+
+# Stop and resume
+manager.stop_team(runtime.id)
+resumed = manager.resume_team(runtime.id)  # full state restored
+resumed.send("Back!")   # → Echo: Back!
+
+# Clean up
+manager.stop_team(resumed.id)
+manager.delete_team(resumed.id)
+```
+
+## Architecture
+
+The package follows a layered architecture with strict upward dependency
+flow:
+
+```
+┌──────────────────────────────────────────────┐
+│  Interfaces: CLI (ak-team), Python API       │
+├──────────────────────────────────────────────┤
+│  TeamManager (lifecycle facade)              │
+│  TeamFactory / TeamRestorer                  │
+│  PersistenceSubscriber                       │
+├──────────────────────────────────────────────┤
+│  Models: TeamCard, TeamRuntime, Process      │
+│  Ports:  EventStore, ServiceRegistry         │
+├──────────────────────────────────────────────┤
+│  Repositories: YamlEventStore, MongoEventStore│
+└──────────────────────────────────────────────┘
+```
+
+### Layer Responsibilities
+
+| Layer | Role |
+|---|---|
+| **Models** | Pydantic models for team definitions, runtime state, and persistence |
+| **Ports** | Protocol-based abstractions for storage and service discovery |
+| **Services** | TeamFactory (build), TeamManager (lifecycle), TeamRestorer (recovery) |
+| **Repositories** | EventStore implementations — YAML and MongoDB |
+| **Interfaces** | CLI commands and direct Python imports |
+
+### State Machine
+
+Teams follow a strict lifecycle:
+
+```
+    create_team()        stop_team()         delete_team()
+  ──────────────▶ RUNNING ──────────▶ STOPPED ──────────▶ DELETED
+                    ▲                    │
+                    └────────────────────┘
+                       resume_team()
+```
+
+## Team Definitions
+
+### TeamCard
+
+Declarative team structure with hierarchical member trees:
+
+```python
+team_card = TeamCard(
+    name="research-team",
+    description="A research team with lead and workers",
+    entry_point=TeamCardMember(card=lead_card),
+    members=[
+        TeamCardMember(card=lead_card, members=[
+            TeamCardMember(card=researcher_card, headcount=3),
+            TeamCardMember(card=reviewer_card),
+        ]),
+    ],
+)
+
+team_card.agent_cards    # flat index of all AgentCards by name
+team_card.supervisors    # AgentCards with subordinates
+```
+
+### TeamRuntime
+
+Live handle to a running team, returned by `create_team()` and
+`resume_team()`:
+
+```python
+runtime.send("Hello!")                    # send to entry point
+runtime.send_to("@Reviewer", message)    # directed messaging
+runtime.id                                # team UUID
+runtime.addrs                             # agent name → ActorAddress
+```
+
+## Persistence
+
+### Event Sourcing
+
+Every message flowing through the orchestrator is captured by
+`PersistenceSubscriber` as an append-only event. Agent state snapshots
+are saved on `StateChangedMessage`.
+
+### Storage Backends
+
+**YAML (default)** — zero infrastructure, per-team directory layout:
+
+```
+data/{team-uuid}/
+  team.yaml              # Process metadata (overwrite)
+  events.yaml            # All events (append-only)
+  states/{agent-id}.yaml # Agent state snapshots (overwrite)
+```
+
+**MongoDB** — install the `[mongo]` extra:
+
+```python
+from akgentic.team import MongoEventStore
+import pymongo
+
+db = pymongo.MongoClient("mongodb://localhost:27017")["akgentic"]
+event_store = MongoEventStore(db)
+# Collections: teams, events, agent_states
+```
+
+### Crash Recovery
+
+`TeamRestorer` executes a 3-phase protocol:
+1. **Load** persisted events and agent state snapshots
+2. **Rebuild** agents from the event log (Orchestrator first, then others)
+3. **Replay** all events to reconstruct full state including LLM context
+
+## CLI
+
+The `ak-team` command is available when the `[cli]` extra is installed.
+See the [CLI README](src/akgentic/team/cli/README.md) for full documentation.
+
+```bash
+# List all teams
+ak-team list
+ak-team list --status running
+
+# Inspect a team
+ak-team inspect <team-id>
+
+# Create a team from a TeamCard YAML file (interactive — Ctrl+C to stop)
+ak-team create team-card.yaml
+
+# Resume a stopped team
+ak-team resume <team-id>
+
+# Delete a stopped team
+ak-team delete <team-id>
+
+# Use MongoDB backend
+ak-team --backend mongodb --mongo-uri mongodb://localhost:27017 --mongo-db akgentic list
+```
+
+## Examples
+
+Six progressive, self-contained examples in the [examples/](examples/)
+directory. See the [Examples README](examples/README.md) for full
+descriptions and learning path. Each includes a runnable `.py` script
+and a companion `.md` explaining concepts and pitfalls.
+
+```bash
+uv run python examples/01_team_definition.py
+```
+
+| # | Script | Topic |
+|---|---|---|
+| 01 | `01_team_definition.py` | TeamCard & TeamCardMember hierarchies |
+| 02 | `02_team_factory.py` | TeamFactory.build() & TeamRuntime |
+| 03 | `03_team_manager_lifecycle.py` | Full lifecycle: create, stop, resume, delete |
+| 04 | `04_event_sourcing.py` | PersistenceSubscriber & YamlEventStore |
+| 05 | `05_crash_recovery.py` | TeamRestorer & crash recovery |
+| 06 | `06_mongo_backend.py` | MongoEventStore & backend portability |
 
 ## Development
+
+### Prerequisites
+
+- Python 3.12+
+- [uv](https://docs.astral.sh/uv/) package manager
+
+### Setup
+
+```bash
+uv sync --all-extras
+```
+
+### Commands
 
 ```bash
 # Run tests
 uv run pytest packages/akgentic-team/tests/
 
-# Type checking (strict mode)
-uv run mypy packages/akgentic-team/src/
+# Run tests with coverage
+uv run pytest packages/akgentic-team/tests/ --cov=akgentic.team --cov-fail-under=80
 
-# Linting
-ruff check packages/akgentic-team/src/
+# Lint
+uv run ruff check packages/akgentic-team/src/
+
+# Format
+uv run ruff format packages/akgentic-team/src/
+
+# Type check
+uv run mypy packages/akgentic-team/src/
 ```
+
+### Project Structure
+
+```
+src/akgentic/team/
+    __init__.py          # Public API (17 exports)
+    models.py            # TeamCard, TeamRuntime, Process, TeamStatus, persistence models
+    ports.py             # EventStore, ServiceRegistry protocols, NullServiceRegistry
+    factory.py           # TeamFactory — static builder
+    manager.py           # TeamManager — lifecycle facade
+    restorer.py          # TeamRestorer — crash recovery
+    subscriber.py        # PersistenceSubscriber — event sourcing bridge
+    repositories/        # YamlEventStore, MongoEventStore
+    cli/                 # ak-team CLI (Typer)
+examples/                # 6 progressive examples with companion docs
+tests/                   # 196 tests organized by domain
+```
+
+## License
+
+See the repository root for license information.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,27 @@
 # akgentic-team Examples
 
-A progressive tutorial that walks through the akgentic-team package, from static team definitions to full lifecycle management with persistence and crash recovery.
+A progressive tutorial that walks through the akgentic-team package, from
+static team definitions to full lifecycle management with persistence and
+crash recovery.
 
-Each example builds on concepts from previous ones. Start with example 01 and work through in order.
+## Learning Path
+
+The examples are designed to be followed in order. Each one builds on
+concepts from the previous:
+
+```
+01 Team Definition     → What is a TeamCard? How do member trees work?
+        ↓
+02 Team Factory        → How do you turn a TeamCard into live actors?
+        ↓
+03 Manager Lifecycle   → How do you create, stop, resume, and delete teams?
+        ↓
+04 Event Sourcing      → What gets persisted? How does the event log work?
+        ↓
+05 Crash Recovery      → How does TeamRestorer rebuild a team from events?
+        ↓
+06 MongoDB Backend     → How do you swap storage backends?
+```
 
 ## Prerequisites
 
@@ -12,18 +31,8 @@ From the workspace root, install all packages:
 uv sync --all-packages --all-extras
 ```
 
-## Examples
-
-| # | File | Summary | Status |
-|---|------|---------|--------|
-| 01 | `01_team_definition.py` | TeamCard & TeamCardMember hierarchies, agent_cards/supervisors inspection, Pydantic round-trip | Implemented |
-| 02 | `02_team_factory.py` | TeamFactory.build(), TeamRuntime inspection, message sending, error paths, clean shutdown | Implemented |
-| 03 | `03_team_manager_lifecycle.py` | TeamManager create/stop/resume/delete lifecycle, state machine transitions, error paths | Implemented |
-| 04 | `04_event_sourcing.py` | PersistenceSubscriber, YamlEventStore, event replay | Implemented |
-| 05 | `05_crash_recovery.py` | TeamRestorer, resume from persisted state | Implemented |
-| 06 | `06_mongo_backend.py` | MongoEventStore with mongomock, backend portability demonstration | Implemented |
-
-Each `.py` file has a companion `.md` file with concepts, API patterns, and pitfalls.
+This installs akgentic-core, akgentic-team, and all optional extras
+(MongoDB, CLI, dev tools).
 
 ## Running
 
@@ -31,25 +40,95 @@ From the workspace root:
 
 ```bash
 uv run python packages/akgentic-team/examples/01_team_definition.py
-uv run python packages/akgentic-team/examples/02_team_factory.py
-uv run python packages/akgentic-team/examples/03_team_manager_lifecycle.py
-uv run python packages/akgentic-team/examples/04_event_sourcing.py
-uv run python packages/akgentic-team/examples/05_crash_recovery.py
-uv run python packages/akgentic-team/examples/06_mongo_backend.py
 ```
 
-Or from the package root (`packages/akgentic-team/`):
+Or from the package directory:
 
 ```bash
+cd packages/akgentic-team
 uv run python examples/01_team_definition.py
-uv run python examples/02_team_factory.py
-uv run python examples/03_team_manager_lifecycle.py
-uv run python examples/04_event_sourcing.py
-uv run python examples/05_crash_recovery.py
-uv run python examples/06_mongo_backend.py
 ```
 
-## Dependencies
+## Examples
 
-- Examples 01-05 depend on `akgentic-core` and `akgentic-team` only.
-- Example 06 additionally requires `mongomock` (included in the `[dev]` extra) and `pymongo` (included in the `[mongo]` extra).
+### 01 — Team Definition
+
+**File:** [`01_team_definition.py`](01_team_definition.py) |
+**Guide:** [`01-team-definition.md`](01-team-definition.md)
+
+Build `TeamCard` and `TeamCardMember` hierarchies. Inspect the flat
+`agent_cards` index and `supervisors` discovery. Verify Pydantic
+serialization round-trip.
+
+**Key types:** `TeamCard`, `TeamCardMember`, `AgentCard`, `BaseConfig`
+
+### 02 — Team Factory
+
+**File:** [`02_team_factory.py`](02_team_factory.py) |
+**Guide:** [`02-team-factory.md`](02-team-factory.md)
+
+Use `TeamFactory.build()` to create live Pykka actors from a TeamCard.
+Inspect the `TeamRuntime` (addresses, proxies), send messages, and
+perform clean actor teardown.
+
+**Key types:** `TeamFactory`, `TeamRuntime`, `ActorSystem`
+
+### 03 — Team Manager Lifecycle
+
+**File:** [`03_team_manager_lifecycle.py`](03_team_manager_lifecycle.py) |
+**Guide:** [`03-team-manager-lifecycle.md`](03-team-manager-lifecycle.md)
+
+Full lifecycle management via `TeamManager`: create, stop, resume, delete.
+Exercise the state machine transitions and error paths (resume RUNNING,
+delete RUNNING, resume DELETED).
+
+**Key types:** `TeamManager`, `YamlEventStore`, `TeamStatus`
+
+### 04 — Event Sourcing
+
+**File:** [`04_event_sourcing.py`](04_event_sourcing.py) |
+**Guide:** [`04-event-sourcing.md`](04-event-sourcing.md)
+
+See what `PersistenceSubscriber` captures: append-only events in
+`events.yaml`, agent state snapshots in `states/`. Inspect the YAML file
+layout on disk and understand the difference between append-only events
+and overwrite state snapshots.
+
+**Key types:** `PersistenceSubscriber`, `YamlEventStore`, `PersistedEvent`,
+`AgentStateSnapshot`
+
+### 05 — Crash Recovery
+
+**File:** [`05_crash_recovery.py`](05_crash_recovery.py) |
+**Guide:** [`05-crash-recovery.md`](05-crash-recovery.md)
+
+Create a team, interact with it, stop it, inspect the persisted data, then
+resume. Verify that state is fully restored and new events continue
+persisting after recovery. Observe that Pykka addresses change on resume
+(new actors) while the team_id stays the same.
+
+**Key types:** `TeamRestorer`, `TeamManager.resume_team()`
+
+### 06 — MongoDB Backend
+
+**File:** [`06_mongo_backend.py`](06_mongo_backend.py) |
+**Guide:** [`06-mongo-backend.md`](06-mongo-backend.md)
+
+Run the same create/stop/resume/delete lifecycle with `MongoEventStore`
+backed by mongomock (no MongoDB server required). Inspect collection
+contents. The code diff from YAML is minimal — only the EventStore
+constructor changes.
+
+**Key types:** `MongoEventStore`
+
+**Extra dependencies:** `mongomock` (included in `[dev]` extra),
+`pymongo` (included in `[mongo]` extra)
+
+## Companion Guides
+
+Each `.py` example has a matching `.md` guide that explains:
+
+- **Concepts** — the design patterns and architecture behind the code
+- **Key API patterns** — important method signatures and usage
+- **Pitfalls** — common mistakes and how to avoid them
+- **Cross-references** — links to related examples and source code

--- a/src/akgentic/team/cli/README.md
+++ b/src/akgentic/team/cli/README.md
@@ -1,0 +1,206 @@
+# ak-team CLI
+
+Command-line interface for managing akgentic-team lifecycle instances.
+
+## Installation
+
+The CLI requires the `[cli]` optional extra:
+
+```bash
+uv sync --extra cli
+```
+
+This installs [Typer](https://typer.tiangolo.com/) and
+[Rich](https://rich.readthedocs.io/) for the terminal interface.
+
+## Global Options
+
+All commands accept these options:
+
+| Option | Default | Description |
+|---|---|---|
+| `--data-dir` | `./data/` | Root directory for team data files |
+| `--format` | `table` | Output format: `table`, `json`, or `yaml` |
+| `--backend` | `yaml` | Storage backend: `yaml` or `mongodb` |
+| `--mongo-uri` | — | MongoDB connection URI (required for `mongodb` backend) |
+| `--mongo-db` | — | MongoDB database name (required for `mongodb` backend) |
+
+`--mongo-uri` and `--mongo-db` can also be set via `MONGO_URI` and `MONGO_DB`
+environment variables.
+
+## Commands
+
+### `ak-team list`
+
+List all team instances.
+
+```bash
+# List all teams
+ak-team list
+
+# Filter by status
+ak-team list --status running
+ak-team list --status stopped
+ak-team list --status deleted
+
+# Output as JSON
+ak-team list --format json
+```
+
+**Options:**
+
+| Option | Description |
+|---|---|
+| `--status` | Filter by team status: `running`, `stopped`, or `deleted` |
+
+### `ak-team inspect`
+
+Display detailed information about a team instance.
+
+```bash
+ak-team inspect 550e8400-e29b-41d4-a716-446655440000
+ak-team inspect 550e8400-e29b-41d4-a716-446655440000 --format json
+```
+
+Shows: team ID, name, status, user info, timestamps, event count, and agent
+state count.
+
+**Arguments:**
+
+| Argument | Description |
+|---|---|
+| `TEAM_ID` | Team UUID to inspect |
+
+### `ak-team create`
+
+Create a new team from a TeamCard YAML file and run it interactively.
+
+```bash
+ak-team create team-card.yaml
+ak-team create team-card.yaml --user-id alice
+```
+
+The command creates the team, starts it, and blocks until you press **Ctrl+C**.
+On SIGINT, the team is gracefully stopped (actors torn down, state persisted
+as STOPPED).
+
+**Arguments:**
+
+| Argument | Description |
+|---|---|
+| `TEAM_CARD_FILE` | Path to a YAML file containing a serialized TeamCard |
+
+**Options:**
+
+| Option | Default | Description |
+|---|---|---|
+| `--user-id` | `cli` | User identifier for the team creator |
+
+**TeamCard YAML format:**
+
+```yaml
+name: my-team
+description: A simple team
+entry_point:
+  card:
+    role: Echo
+    description: Echoes messages
+    skills: [echo]
+    agent_class: mymodule.EchoAgent
+    config:
+      name: "@Echo"
+      role: Echo
+members:
+  - card:
+      role: Echo
+      description: Echoes messages
+      skills: [echo]
+      agent_class: mymodule.EchoAgent
+      config:
+        name: "@Echo"
+        role: Echo
+```
+
+### `ak-team resume`
+
+Resume a stopped team and run it interactively.
+
+```bash
+ak-team resume 550e8400-e29b-41d4-a716-446655440000
+```
+
+Restores the team from persisted events and agent state snapshots using the
+3-phase restore protocol. The team resumes with full state (including LLM
+conversation context reconstructed from event replay).
+
+Like `create`, blocks until **Ctrl+C** for graceful shutdown.
+
+**Arguments:**
+
+| Argument | Description |
+|---|---|
+| `TEAM_ID` | Team UUID to resume |
+
+### `ak-team delete`
+
+Permanently delete a stopped team and purge all persisted data.
+
+```bash
+ak-team delete 550e8400-e29b-41d4-a716-446655440000
+```
+
+This removes all data: Process metadata, events, and agent state snapshots.
+The team must be in STOPPED state — running teams must be stopped first.
+
+**Arguments:**
+
+| Argument | Description |
+|---|---|
+| `TEAM_ID` | Team UUID to delete |
+
+## Backend Configuration
+
+### YAML (default)
+
+Teams are stored as YAML files in a per-team directory layout:
+
+```bash
+ak-team --data-dir ./my-data list
+```
+
+```
+my-data/{team-uuid}/
+  team.yaml              # Process metadata
+  events.yaml            # Append-only event log
+  states/{agent-id}.yaml # Agent state snapshots
+```
+
+### MongoDB
+
+Requires the `[mongo]` optional extra (`pymongo`):
+
+```bash
+ak-team --backend mongodb \
+        --mongo-uri mongodb://localhost:27017 \
+        --mongo-db akgentic \
+        list
+```
+
+Or via environment variables:
+
+```bash
+export MONGO_URI=mongodb://localhost:27017
+export MONGO_DB=akgentic
+ak-team --backend mongodb list
+```
+
+## Examples
+
+```bash
+# Full lifecycle from the CLI
+ak-team create team-card.yaml          # creates and runs (Ctrl+C to stop)
+ak-team list                           # see the stopped team
+ak-team inspect <team-id>              # view details
+ak-team resume <team-id>               # resume (Ctrl+C to stop again)
+ak-team delete <team-id>               # purge all data
+```


### PR DESCRIPTION
## Summary

- **Project README** — full rewrite following akgentic-catalog structure: overview, installation, quick start, architecture diagram, state machine, persistence backends, CLI summary, examples table, development commands, project structure
- **CLI README** (`src/akgentic/team/cli/README.md`) — new file documenting all 6 `ak-team` commands with options, arguments, YAML format, and backend configuration
- **Examples README** — improved with visual learning path, per-example descriptions with key types, and companion guide section

Closes #45