### PR TITLE
Factory and Restorer Spawn Through Hierarchy

### DIFF
--- a/src/akgentic/team/factory.py
+++ b/src/akgentic/team/factory.py
@@ -168,7 +168,9 @@ class TeamFactory:
             parent=parent_addr,
             orchestrator=orchestrator_addr,
         )
-        return ActorAddressImpl(actor_ref)
+        child_addr = ActorAddressImpl(actor_ref)
+        parent_actor._children.append(child_addr)
+        return child_addr
 
     @staticmethod
     def _spawn_member(

--- a/src/akgentic/team/factory.py
+++ b/src/akgentic/team/factory.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import Any
+from typing import Any, cast
 
 from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_address_impl import ActorAddressImpl
 from akgentic.core.actor_system_impl import ActorSystem
 from akgentic.core.agent import Akgent
 from akgentic.core.agent_config import BaseConfig
@@ -82,18 +83,18 @@ class TeamFactory:
             addrs: dict[str, ActorAddress] = {}
             entry_addr: ActorAddress | None = None
 
-            # Spawn entry point
+            # Spawn entry point through orchestrator
             entry_addrs = TeamFactory._spawn_member(
-                team_card.entry_point, actor_system, team_id, spawned_addrs
+                team_card.entry_point, orchestrator_addr, spawned_addrs
             )
             addrs.update(entry_addrs)
             # Entry point always has headcount=1, so use the card name
             entry_addr = entry_addrs[team_card.entry_point.card.config.name]
 
-            # Spawn top-level members
+            # Spawn top-level members through orchestrator
             for member in team_card.members:
                 member_addrs = TeamFactory._spawn_member(
-                    member, actor_system, team_id, spawned_addrs
+                    member, orchestrator_addr, spawned_addrs
                 )
                 addrs.update(member_addrs)
 
@@ -130,18 +131,59 @@ class TeamFactory:
             raise
 
     @staticmethod
+    def _spawn_child(
+        agent_class: type[Akgent[Any, Any]],
+        parent_addr: ActorAddress,
+        config: BaseConfig,
+        agent_id: uuid.UUID | None = None,
+    ) -> ActorAddress:
+        """Spawn a child actor through a parent, propagating hierarchy context.
+
+        Reads the parent actor's context (orchestrator, user_id, user_email,
+        team_id) and starts the child with ``parent`` and ``orchestrator`` set,
+        replicating what ``Akgent.createActor()`` does but from outside the
+        actor's message handler so exceptions propagate correctly.
+
+        Args:
+            agent_class: The agent class to instantiate.
+            parent_addr: Address of the parent actor.
+            config: Configuration for the new agent.
+            agent_id: Optional UUID for the new agent (e.g. during restore).
+
+        Returns:
+            ActorAddress of the newly created child agent.
+        """
+        parent_impl = cast(ActorAddressImpl, parent_addr)
+        parent_actor: Akgent[Any, Any] = parent_impl._actor_ref._actor
+
+        orchestrator_addr = parent_actor._orchestrator
+        config.squad_id = config.squad_id or parent_actor.config.squad_id
+
+        actor_ref = agent_class.start(
+            agent_id=agent_id,
+            config=config,
+            user_id=parent_actor._user_id,
+            user_email=parent_actor._user_email,
+            team_id=parent_actor._team_id,
+            parent=parent_addr,
+            orchestrator=orchestrator_addr,
+        )
+        return ActorAddressImpl(actor_ref)
+
+    @staticmethod
     def _spawn_member(
         member: TeamCardMember,
-        actor_system: ActorSystem,
-        team_id: uuid.UUID,
+        parent_addr: ActorAddress,
         spawned_addrs: list[ActorAddress],
     ) -> dict[str, ActorAddress]:
         """Spawn a member and its subordinates recursively.
 
+        Agents are spawned through the parent via ``_spawn_child()`` so that
+        ``_orchestrator`` and ``_parent`` propagate automatically.
+
         Args:
             member: The TeamCardMember to spawn.
-            actor_system: The actor system to host the actors.
-            team_id: Team identifier for all spawned actors.
+            parent_addr: Address of the parent actor to spawn through.
             spawned_addrs: Accumulator for rollback tracking.
 
         Returns:
@@ -152,10 +194,9 @@ class TeamFactory:
         name = member.card.config.name
 
         if member.headcount == 1:
-            addr = actor_system.createActor(
-                agent_class,
+            addr = TeamFactory._spawn_child(
+                agent_class, parent_addr,
                 config=member.card.get_config_copy(),
-                team_id=team_id,
             )
             spawned_addrs.append(addr)
             result[name] = addr
@@ -164,19 +205,22 @@ class TeamFactory:
                 indexed_name = f"{name}_{i}"
                 config = member.card.get_config_copy()
                 config.name = indexed_name
-                addr = actor_system.createActor(
-                    agent_class,
+                addr = TeamFactory._spawn_child(
+                    agent_class, parent_addr,
                     config=config,
-                    team_id=team_id,
                 )
                 spawned_addrs.append(addr)
                 result[indexed_name] = addr
 
-        # Recurse into subordinates
-        for child in member.members:
-            child_addrs = TeamFactory._spawn_member(
-                child, actor_system, team_id, spawned_addrs
-            )
-            result.update(child_addrs)
+        # Recurse into subordinates using the spawned agent as parent
+        if member.members:
+            # For headcount == 1, use the single spawned agent as parent
+            # For headcount > 1, use the last spawned instance as parent
+            last_addr = next(reversed(result.values()))
+            for child in member.members:
+                child_addrs = TeamFactory._spawn_member(
+                    child, last_addr, spawned_addrs
+                )
+                result.update(child_addrs)
 
         return result

--- a/src/akgentic/team/restorer.py
+++ b/src/akgentic/team/restorer.py
@@ -221,19 +221,25 @@ class TeamRestorer:
     def _spawn_agents(
         self,
         agent_starts: list[StartMessage],
-        team_id: uuid.UUID,
+        orchestrator_addr: ActorAddress,
         spawned_addrs: list[ActorAddress],
     ) -> dict[str, ActorAddress]:
         """Spawn non-orchestrator agents from their persisted StartMessages.
 
+        Agents are spawned through the orchestrator address so that
+        ``_orchestrator`` and ``_parent`` propagate correctly from the
+        hierarchy root.
+
         Args:
             agent_starts: StartMessages for agents to rebuild.
-            team_id: The team identifier.
+            orchestrator_addr: Address of the restored orchestrator to spawn through.
             spawned_addrs: Shared list for rollback tracking.
 
         Returns:
             A dict mapping agent names to their actor addresses.
         """
+        from akgentic.team.factory import TeamFactory
+
         addrs: dict[str, ActorAddress] = {}
 
         for sm in agent_starts:
@@ -246,12 +252,11 @@ class TeamRestorer:
 
             config = sm.config.model_copy()
 
-            addr = self._actor_system.createActor(
+            addr = TeamFactory._spawn_child(
                 agent_class,
-                restoring=True,
-                agent_id=original_agent_id,
-                team_id=team_id,
+                orchestrator_addr,
                 config=config,
+                agent_id=original_agent_id,
             )
             spawned_addrs.append(addr)
             addrs[agent_name] = addr
@@ -308,8 +313,8 @@ class TeamRestorer:
         for sub in subscribers:
             orchestrator_proxy.subscribe(sub)
 
-        # 2d. Spawn remaining agents
-        addrs = self._spawn_agents(agent_starts, team_id, spawned_addrs)
+        # 2d. Spawn remaining agents through orchestrator
+        addrs = self._spawn_agents(agent_starts, orchestrator_addr, spawned_addrs)
 
         # 2e. Restore agent states
         state_map: dict[str, AgentStateSnapshot] = {

--- a/src/akgentic/team/restorer.py
+++ b/src/akgentic/team/restorer.py
@@ -15,6 +15,7 @@ from akgentic.core.agent_config import BaseConfig
 from akgentic.core.messages.orchestrator import StartMessage, StopMessage
 from akgentic.core.orchestrator import EventSubscriber, Orchestrator
 from akgentic.core.utils.deserializer import import_class
+from akgentic.team.factory import TeamFactory
 from akgentic.team.models import (
     AgentStateSnapshot,
     PersistedEvent,
@@ -238,8 +239,6 @@ class TeamRestorer:
         Returns:
             A dict mapping agent names to their actor addresses.
         """
-        from akgentic.team.factory import TeamFactory
-
         addrs: dict[str, ActorAddress] = {}
 
         for sm in agent_starts:

--- a/tests/services/test_factory.py
+++ b/tests/services/test_factory.py
@@ -271,3 +271,89 @@ class TestTeamFactoryBuild:
         with patch.object(ActorAddress, "stop", side_effect=RuntimeError("stop failed")):
             with pytest.raises(RuntimeError, match="intentional error"):
                 TeamFactory.build(tc, actor_system)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Hierarchy propagation (Story 10-1, AC 1, 2, 5)
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryHierarchyPropagation:
+    """AC 1,2,5: Spawned agents have _orchestrator and _parent set."""
+
+    def test_orchestrator_set_on_spawned_agents(
+        self, actor_system: ActorSystem
+    ) -> None:
+        """AC 1,5: _orchestrator is not None on all spawned agents."""
+        worker = _make_member("worker", "Worker")
+        tc = _make_team_card(members=[worker])
+
+        runtime = TeamFactory.build(tc, actor_system)
+
+        for name, addr in runtime.addrs.items():
+            proxy: Akgent[Any, Any] = actor_system.proxy_ask(addr, Akgent)
+            orch = proxy.orchestrator
+            assert orch is not None, f"Agent '{name}' has _orchestrator=None"
+            assert orch.is_alive(), f"Agent '{name}' orchestrator is not alive"
+
+    def test_parent_set_correctly_for_top_level_agents(
+        self, actor_system: ActorSystem
+    ) -> None:
+        """AC 2,5: Top-level agents have orchestrator as parent."""
+        worker = _make_member("worker", "Worker")
+        tc = _make_team_card(members=[worker])
+
+        runtime = TeamFactory.build(tc, actor_system)
+
+        # Both lead (entry point) and worker (top-level member) should have
+        # the orchestrator as parent
+        for name in ("lead", "worker"):
+            addr = runtime.addrs[name]
+            impl = addr  # ActorAddressImpl
+            actor = impl._actor_ref._actor  # type: ignore[union-attr]
+            assert actor._parent is not None, f"Agent '{name}' has _parent=None"
+            assert actor._parent.agent_id == runtime.orchestrator_addr.agent_id, (
+                f"Agent '{name}' parent is not the orchestrator"
+            )
+
+    def test_parent_set_correctly_for_subordinates(
+        self, actor_system: ActorSystem
+    ) -> None:
+        """AC 2,5: Subordinate agents have their supervisor as parent."""
+        worker = _make_member("worker", "Worker")
+        supervisor = _make_member("supervisor", "Supervisor", members=[worker])
+        tc = _make_team_card(members=[supervisor])
+
+        runtime = TeamFactory.build(tc, actor_system)
+
+        # Worker should have supervisor as parent, not orchestrator
+        worker_addr = runtime.addrs["worker"]
+        worker_actor = worker_addr._actor_ref._actor  # type: ignore[union-attr]
+        supervisor_addr = runtime.addrs["supervisor"]
+
+        assert worker_actor._parent is not None
+        assert worker_actor._parent.agent_id == supervisor_addr.agent_id, (
+            "Worker's parent should be the supervisor"
+        )
+
+        # Supervisor should have orchestrator as parent
+        supervisor_actor = supervisor_addr._actor_ref._actor  # type: ignore[union-attr]
+        assert supervisor_actor._parent is not None
+        assert supervisor_actor._parent.agent_id == runtime.orchestrator_addr.agent_id
+
+    def test_orchestrator_set_on_headcount_agents(
+        self, actor_system: ActorSystem
+    ) -> None:
+        """AC 5: _orchestrator is set on agents with headcount > 1."""
+        multi = _make_member("worker", "Worker", headcount=2)
+        tc = _make_team_card(members=[multi])
+
+        runtime = TeamFactory.build(tc, actor_system)
+
+        for name in ("worker_0", "worker_1"):
+            proxy: Akgent[Any, Any] = actor_system.proxy_ask(
+                runtime.addrs[name], Akgent
+            )
+            assert proxy.orchestrator is not None, (
+                f"Agent '{name}' has _orchestrator=None"
+            )

--- a/tests/services/test_restorer.py
+++ b/tests/services/test_restorer.py
@@ -618,3 +618,58 @@ class TestTeamRestorerRollback:
         # Stop and verify on_stop called
         runtime.orchestrator_addr.stop()
         assert recording.stopped is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: Hierarchy propagation during restore (Story 10-1, AC 3, 5)
+# ---------------------------------------------------------------------------
+
+
+class TestRestorerHierarchyPropagation:
+    """AC 3,5: Restored agents have _orchestrator set."""
+
+    def test_orchestrator_set_on_restored_agents(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 3,5: _orchestrator is not None on agents rebuilt during restore."""
+        worker = _make_member("worker", "Worker")
+        tc = _make_team_card(members=[worker])
+
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime, _ = restorer.restore(process)
+
+        for name, addr in runtime.addrs.items():
+            proxy: Akgent[Any, Any] = actor_system.proxy_ask(addr, Akgent)
+            orch = proxy.orchestrator
+            assert orch is not None, f"Restored agent '{name}' has _orchestrator=None"
+            assert orch.is_alive(), (
+                f"Restored agent '{name}' orchestrator is not alive"
+            )
+
+    def test_parent_set_on_restored_agents(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 5: _parent is set on agents rebuilt during restore."""
+        worker = _make_member("worker", "Worker")
+        tc = _make_team_card(members=[worker])
+
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime, _ = restorer.restore(process)
+
+        # All restored agents should have orchestrator as parent
+        for name, addr in runtime.addrs.items():
+            actor = addr._actor_ref._actor  # type: ignore[union-attr]
+            assert actor._parent is not None, (
+                f"Restored agent '{name}' has _parent=None"
+            )
+            assert actor._parent.agent_id == runtime.orchestrator_addr.agent_id, (
+                f"Restored agent '{name}' parent is not the orchestrator"
+            )


### PR DESCRIPTION
## Summary

- Refactored `TeamFactory._spawn_member()` and `TeamRestorer._spawn_agents()` to spawn agents through the actor hierarchy instead of directly on the actor system
- Introduced `TeamFactory._spawn_child()` which reads parent context and propagates `_orchestrator`, `_parent`, `team_id`, `user_id`, `user_email` to children
- Subordinate agents are recursively spawned through their supervisor, building a correct parent-child tree
- Added 6 new tests (4 factory, 2 restorer) verifying hierarchy propagation
- Code review fix: added `_children` tracking in `_spawn_child()` to match `Akgent.createActor()` behavior
- Code review fix: moved deferred import to top-level in restorer.py

Closes #47