### PR TITLE
Integration Test Suite for Team Behavior Verification

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,8 @@
+"""Integration tests for akgentic-team.
+
+Tests define and verify correct team behavior based on the V1 reference
+implementation. Uses real Akgent subclasses with real message handlers,
+real orchestrators, and real event flow.
+
+See ADR-004 for design rationale.
+"""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,253 @@
+"""Integration test fixtures: real agent classes, team card fixtures, and helpers.
+
+All agents are functional Akgent subclasses with real receiveMsg_UserMessage handlers.
+No stubs, no mocks -- these exercise the full actor lifecycle.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pykka
+import pytest
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_address_impl import ActorAddressImpl
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_card import AgentCard
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.agent_state import BaseState
+from akgentic.core.messages.message import UserMessage
+
+from akgentic.team.models import TeamCard, TeamCardMember
+
+# ---------------------------------------------------------------------------
+# Custom config for routing agents
+# ---------------------------------------------------------------------------
+
+
+class RoutingConfig(BaseConfig):
+    """Config that carries routes_to targets for the RoutingAgent."""
+
+    routes_to: list[str] = []
+
+
+# ---------------------------------------------------------------------------
+# Agent state
+# ---------------------------------------------------------------------------
+
+
+class RecordingState(BaseState):
+    """State that records received messages."""
+
+    messages: list[str] = []
+    counter: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Real agent classes
+# ---------------------------------------------------------------------------
+
+
+class RecordingAgent(Akgent[BaseConfig, RecordingState]):
+    """Agent that records every UserMessage it receives into state."""
+
+    def on_start(self) -> None:
+        """Initialize with RecordingState."""
+        self.state = RecordingState()
+
+    def receiveMsg_UserMessage(  # noqa: N802
+        self, msg: UserMessage, sender: ActorAddress
+    ) -> None:
+        """Append message content to state and increment counter."""
+        self.state.messages = [*self.state.messages, msg.content]
+        self.state.counter += 1
+        self.notify_state_change(self.state)
+
+
+class RoutingAgent(Akgent[RoutingConfig, BaseState]):
+    """Agent that forwards UserMessages to routes_to targets via the orchestrator."""
+
+    def receiveMsg_UserMessage(  # noqa: N802
+        self, msg: UserMessage, sender: ActorAddress
+    ) -> None:
+        """Look up each route target and forward the message."""
+        for target_name in self.config.routes_to:
+            addr = self.orchestrator_proxy_ask.get_team_member(target_name)
+            if addr is not None:
+                self.send(addr, msg)
+
+
+class StatefulAgent(Akgent[BaseConfig, RecordingState]):
+    """Agent that increments a counter on each UserMessage for lifecycle tests."""
+
+    def on_start(self) -> None:
+        """Initialize with RecordingState."""
+        self.state = RecordingState()
+
+    def receiveMsg_UserMessage(  # noqa: N802
+        self, msg: UserMessage, sender: ActorAddress
+    ) -> None:
+        """Increment counter and notify state change."""
+        self.state.counter += 1
+        self.notify_state_change(self.state)
+
+
+# ---------------------------------------------------------------------------
+# Helper: make_agent_card for integration tests
+# ---------------------------------------------------------------------------
+
+
+def make_integration_agent_card(
+    name: str,
+    role: str,
+    agent_class: type[Akgent[Any, Any]],
+    routes_to: list[str] | None = None,
+    config: BaseConfig | None = None,
+) -> AgentCard:
+    """Create an AgentCard with a real agent class for integration tests."""
+    if config is None:
+        if routes_to:
+            config = RoutingConfig(name=name, role=role, routes_to=routes_to)
+        else:
+            config = BaseConfig(name=name, role=role)
+    return AgentCard(
+        role=role,
+        description=f"Integration test agent: {role}",
+        skills=["testing"],
+        agent_class=agent_class,
+        config=config,
+        routes_to=routes_to or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Team card fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def routing_team_card() -> TeamCard:
+    """TeamCard: entry(RoutingAgent, routes_to=[@worker]) with one member worker(RecordingAgent).
+
+    The @ prefix mirrors V1 naming convention for routes_to targets.
+    """
+    entry = TeamCardMember(
+        card=make_integration_agent_card(
+            name="router",
+            role="Router",
+            agent_class=RoutingAgent,
+            routes_to=["worker"],
+        ),
+    )
+    worker = TeamCardMember(
+        card=make_integration_agent_card(
+            name="worker",
+            role="Worker",
+            agent_class=RecordingAgent,
+        ),
+    )
+    return TeamCard(
+        name="routing-team",
+        description="A routing team for integration tests",
+        entry_point=entry,
+        members=[worker],
+        message_types=[UserMessage],
+    )
+
+
+@pytest.fixture()
+def hierarchical_team_card() -> TeamCard:
+    """TeamCard: entry(RecordingAgent) with supervisor(RoutingAgent) containing workers.
+
+    Structure: entry → [supervisor(routes_to=[@worker_a]) → [worker_a, worker_b]]
+    """
+    worker_a = TeamCardMember(
+        card=make_integration_agent_card(
+            name="worker_a",
+            role="WorkerA",
+            agent_class=RecordingAgent,
+        ),
+    )
+    worker_b = TeamCardMember(
+        card=make_integration_agent_card(
+            name="worker_b",
+            role="WorkerB",
+            agent_class=RecordingAgent,
+        ),
+    )
+    supervisor = TeamCardMember(
+        card=make_integration_agent_card(
+            name="supervisor",
+            role="Supervisor",
+            agent_class=RoutingAgent,
+            routes_to=["worker_a"],
+        ),
+        members=[worker_a, worker_b],
+    )
+    entry = TeamCardMember(
+        card=make_integration_agent_card(
+            name="lead",
+            role="Lead",
+            agent_class=RecordingAgent,
+        ),
+    )
+    return TeamCard(
+        name="hierarchical-team",
+        description="A hierarchical team for integration tests",
+        entry_point=entry,
+        members=[supervisor],
+        message_types=[UserMessage],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Actor system fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def actor_system() -> ActorSystem:
+    """Create an ActorSystem, yield it, tear down all actors after test."""
+    system = ActorSystem()
+    yield system  # type: ignore[misc]
+    pykka.ActorRegistry.stop_all()
+
+
+# ---------------------------------------------------------------------------
+# Polling helper
+# ---------------------------------------------------------------------------
+
+
+def get_actor_from_addr(addr: ActorAddress) -> Akgent[Any, Any]:
+    """Extract the underlying Akgent instance from an ActorAddress."""
+    impl = addr
+    if isinstance(impl, ActorAddressImpl):
+        return impl._actor_ref._actor  # type: ignore[return-value]
+    msg = f"Cannot extract actor from address type: {type(addr)}"
+    raise TypeError(msg)
+
+
+def wait_for_agent_state(
+    addr: ActorAddress,
+    predicate: Any,
+    timeout: float = 2.0,
+) -> bool:
+    """Poll agent state until predicate returns True or timeout.
+
+    Args:
+        addr: ActorAddress of the agent to poll.
+        predicate: Callable(state) -> bool.
+        timeout: Maximum seconds to wait.
+
+    Returns:
+        True if predicate was satisfied, False on timeout.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        actor = get_actor_from_addr(addr)
+        if predicate(actor.state):
+            return True
+        time.sleep(0.05)
+    return False

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,6 +7,7 @@ No stubs, no mocks -- these exercise the full actor lifecycle.
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from typing import Any
 
 import pykka
@@ -221,7 +222,12 @@ def actor_system() -> ActorSystem:
 
 
 def get_actor_from_addr(addr: ActorAddress) -> Akgent[Any, Any]:
-    """Extract the underlying Akgent instance from an ActorAddress."""
+    """Extract the underlying Akgent instance from an ActorAddress.
+
+    Warning: reaches into Pykka internals (``_actor_ref._actor``).  This is
+    acceptable in integration tests but couples to Pykka's internal layout.
+    If Pykka upgrades break this, update the access path here.
+    """
     impl = addr
     if isinstance(impl, ActorAddressImpl):
         return impl._actor_ref._actor  # type: ignore[return-value]
@@ -231,14 +237,14 @@ def get_actor_from_addr(addr: ActorAddress) -> Akgent[Any, Any]:
 
 def wait_for_agent_state(
     addr: ActorAddress,
-    predicate: Any,
+    predicate: Callable[[BaseState], bool],
     timeout: float = 2.0,
 ) -> bool:
     """Poll agent state until predicate returns True or timeout.
 
     Args:
         addr: ActorAddress of the agent to poll.
-        predicate: Callable(state) -> bool.
+        predicate: Function that takes agent state and returns True when done.
         timeout: Maximum seconds to wait.
 
     Returns:

--- a/tests/integration/test_factory.py
+++ b/tests/integration/test_factory.py
@@ -1,0 +1,143 @@
+"""Integration tests for TeamFactory: verify built teams are functional.
+
+Tests use real Akgent subclasses, real orchestrators, and real message flow.
+Tests that fail due to the _spawn_child bug are marked with
+@pytest.mark.skip(reason="Awaiting factory fix - Story 11.2").
+"""
+
+from __future__ import annotations
+
+import pytest
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.orchestrator import Orchestrator
+
+from akgentic.team.factory import TeamFactory
+from akgentic.team.models import TeamCard, TeamRuntime
+from tests.integration.conftest import (
+    get_actor_from_addr,
+    wait_for_agent_state,
+)
+
+
+def _build_and_track(
+    team_card: TeamCard,
+    actor_system: ActorSystem,
+) -> TeamRuntime:
+    """Build a team and return the runtime."""
+    return TeamFactory.build(team_card, actor_system)
+
+
+class TestFactoryIntegration:
+    """TeamFactory integration tests -- verify built teams are functional."""
+
+    def test_built_team_agents_are_discoverable(
+        self,
+        routing_team_card: TeamCard,
+        actor_system: ActorSystem,
+    ) -> None:
+        """Every agent in the TeamCard is findable via orchestrator.get_team_member()."""
+        runtime = _build_and_track(routing_team_card, actor_system)
+
+        orchestrator_proxy: Orchestrator = actor_system.proxy_ask(
+            runtime.orchestrator_addr, Orchestrator
+        )
+
+        for name in routing_team_card.agent_cards:
+            addr = orchestrator_proxy.get_team_member(name)
+            assert addr is not None, f"Agent '{name}' not found via orchestrator"
+            assert addr.is_alive(), f"Agent '{name}' is not alive"
+
+    @pytest.mark.skip(reason="Awaiting factory fix - Story 11.2")
+    def test_built_team_message_reaches_target(
+        self,
+        routing_team_card: TeamCard,
+        actor_system: ActorSystem,
+    ) -> None:
+        """A message sent via runtime.send() reaches the worker agent."""
+        runtime = _build_and_track(routing_team_card, actor_system)
+
+        runtime.send("hello")
+
+        worker_addr = runtime.addrs["worker"]
+        reached = wait_for_agent_state(
+            worker_addr,
+            lambda state: "hello" in getattr(state, "messages", []),
+            timeout=3.0,
+        )
+        assert reached, "Message 'hello' did not reach worker agent"
+
+    @pytest.mark.skip(reason="Awaiting factory fix - Story 11.2")
+    def test_built_team_routes_to_resolves_to_existing_agents(
+        self,
+        routing_team_card: TeamCard,
+        actor_system: ActorSystem,
+    ) -> None:
+        """routes_to sends to existing members, not hiring new ones."""
+        runtime = _build_and_track(routing_team_card, actor_system)
+
+        orchestrator_proxy: Orchestrator = actor_system.proxy_ask(
+            runtime.orchestrator_addr, Orchestrator
+        )
+        initial_team_count = len(orchestrator_proxy.get_team())
+
+        runtime.send("test-routing")
+
+        worker_addr = runtime.addrs["worker"]
+        reached = wait_for_agent_state(
+            worker_addr,
+            lambda state: "test-routing" in getattr(state, "messages", []),
+            timeout=3.0,
+        )
+        assert reached, "Message did not reach worker"
+
+        final_team_count = len(orchestrator_proxy.get_team())
+        assert final_team_count == initial_team_count, (
+            f"Team size changed from {initial_team_count} to {final_team_count} "
+            f"-- duplicate hiring detected"
+        )
+
+    def test_built_team_parent_child_hierarchy(
+        self,
+        hierarchical_team_card: TeamCard,
+        actor_system: ActorSystem,
+    ) -> None:
+        """Spawned agents have correct parent-child relationships."""
+        runtime = _build_and_track(hierarchical_team_card, actor_system)
+
+        supervisor_addr = runtime.addrs["supervisor"]
+        worker_a_addr = runtime.addrs["worker_a"]
+        worker_b_addr = runtime.addrs["worker_b"]
+
+        worker_a_actor = get_actor_from_addr(worker_a_addr)
+        worker_b_actor = get_actor_from_addr(worker_b_addr)
+        supervisor_actor = get_actor_from_addr(supervisor_addr)
+
+        assert worker_a_actor._parent == supervisor_addr, (
+            "worker_a._parent does not point to supervisor"
+        )
+        assert worker_b_actor._parent == supervisor_addr, (
+            "worker_b._parent does not point to supervisor"
+        )
+        assert worker_a_addr in supervisor_actor._children, (
+            "supervisor._children does not contain worker_a"
+        )
+        assert worker_b_addr in supervisor_actor._children, (
+            "supervisor._children does not contain worker_b"
+        )
+
+    def test_built_team_orchestrator_propagated(
+        self,
+        hierarchical_team_card: TeamCard,
+        actor_system: ActorSystem,
+    ) -> None:
+        """Every agent has _orchestrator set to the orchestrator's address."""
+        runtime = _build_and_track(hierarchical_team_card, actor_system)
+
+        for name, addr in runtime.addrs.items():
+            actor = get_actor_from_addr(addr)
+            assert actor._orchestrator is not None, (
+                f"Agent '{name}' has _orchestrator=None"
+            )
+            assert actor._orchestrator == runtime.orchestrator_addr, (
+                f"Agent '{name}' _orchestrator does not match team orchestrator"
+            )

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -7,8 +7,11 @@ Tests that fail due to the _spawn_child bug are marked with
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.agent import Akgent
 from akgentic.core.messages.message import UserMessage
 
 from akgentic.team.manager import TeamManager
@@ -24,7 +27,7 @@ from tests.services.conftest import InMemoryEventStore
 
 
 def _make_simple_team_card(
-    agent_class: type = RecordingAgent,
+    agent_class: type[Akgent[Any, Any]] = RecordingAgent,
     name: str = "entry",
     role: str = "Entry",
 ) -> TeamCard:

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -1,0 +1,200 @@
+"""Integration tests for TeamManager lifecycle: create, stop, resume.
+
+Tests use real Akgent subclasses, real orchestrators, and real event flow.
+Tests that fail due to the _spawn_child bug are marked with
+@pytest.mark.skip(reason="Awaiting factory fix - Story 11.2").
+"""
+
+from __future__ import annotations
+
+import pytest
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.messages.message import UserMessage
+
+from akgentic.team.manager import TeamManager
+from akgentic.team.models import TeamCard, TeamCardMember, TeamStatus
+from tests.integration.conftest import (
+    RecordingAgent,
+    StatefulAgent,
+    get_actor_from_addr,
+    make_integration_agent_card,
+    wait_for_agent_state,
+)
+from tests.services.conftest import InMemoryEventStore
+
+
+def _make_simple_team_card(
+    agent_class: type = RecordingAgent,
+    name: str = "entry",
+    role: str = "Entry",
+) -> TeamCard:
+    """Create a minimal team card with a single entry-point agent."""
+    entry = TeamCardMember(
+        card=make_integration_agent_card(
+            name=name,
+            role=role,
+            agent_class=agent_class,
+        ),
+    )
+    return TeamCard(
+        name="simple-team",
+        description="A single-agent team for lifecycle tests",
+        entry_point=entry,
+        members=[],
+        message_types=[UserMessage],
+    )
+
+
+class TestLifecycleIntegration:
+    """TeamManager lifecycle integration tests."""
+
+    def test_create_team_is_functional(
+        self,
+        actor_system: ActorSystem,
+    ) -> None:
+        """A team created via TeamManager can receive messages."""
+        event_store = InMemoryEventStore()
+        manager = TeamManager(actor_system, event_store)
+        team_card = _make_simple_team_card()
+
+        runtime = manager.create_team(team_card)
+
+        # Send a message directly to the entry agent
+        actor_system.tell(
+            runtime.entry_addr,
+            UserMessage(content="lifecycle-test"),
+        )
+
+        reached = wait_for_agent_state(
+            runtime.entry_addr,
+            lambda state: "lifecycle-test" in getattr(state, "messages", []),
+            timeout=3.0,
+        )
+        assert reached, "Message did not reach entry agent"
+
+    def test_stop_team_persists_state(
+        self,
+        actor_system: ActorSystem,
+    ) -> None:
+        """Stopping a team persists Process and events to EventStore."""
+        event_store = InMemoryEventStore()
+        manager = TeamManager(actor_system, event_store)
+        team_card = _make_simple_team_card()
+
+        runtime = manager.create_team(team_card)
+        team_id = runtime.id
+
+        # Send messages to generate events
+        actor_system.tell(
+            runtime.entry_addr,
+            UserMessage(content="msg-1"),
+        )
+        wait_for_agent_state(
+            runtime.entry_addr,
+            lambda state: getattr(state, "counter", 0) >= 1,
+            timeout=3.0,
+        )
+
+        manager.stop_team(team_id)
+
+        # Verify persistence
+        process = event_store.load_team(team_id)
+        assert process is not None, "Process not found after stop"
+        assert process.status == TeamStatus.STOPPED, (
+            f"Expected STOPPED, got {process.status}"
+        )
+
+        events = event_store.load_events(team_id)
+        assert len(events) > 0, "No events persisted"
+
+    @pytest.mark.skip(reason="Awaiting factory fix - Story 11.2")
+    def test_resume_team_is_functional(
+        self,
+        actor_system: ActorSystem,
+    ) -> None:
+        """A resumed team can send and receive NEW messages."""
+        event_store = InMemoryEventStore()
+        manager = TeamManager(actor_system, event_store)
+        team_card = _make_simple_team_card()
+
+        runtime = manager.create_team(team_card)
+        team_id = runtime.id
+
+        actor_system.tell(
+            runtime.entry_addr,
+            UserMessage(content="message-1"),
+        )
+        wait_for_agent_state(
+            runtime.entry_addr,
+            lambda state: "message-1" in getattr(state, "messages", []),
+            timeout=3.0,
+        )
+
+        manager.stop_team(team_id)
+
+        # Resume the team
+        new_runtime = manager.resume_team(team_id)
+
+        actor_system.tell(
+            new_runtime.entry_addr,
+            UserMessage(content="message-2"),
+        )
+
+        reached = wait_for_agent_state(
+            new_runtime.entry_addr,
+            lambda state: "message-2" in getattr(state, "messages", []),
+            timeout=3.0,
+        )
+        assert reached, "Message 'message-2' did not reach entry agent on resumed team"
+
+    @pytest.mark.skip(reason="Awaiting factory fix - Story 11.2")
+    def test_resume_team_preserves_agent_state(
+        self,
+        actor_system: ActorSystem,
+    ) -> None:
+        """Agent state survives stop/resume cycle."""
+        event_store = InMemoryEventStore()
+        manager = TeamManager(actor_system, event_store)
+        team_card = _make_simple_team_card(
+            agent_class=StatefulAgent,
+            name="stateful",
+            role="Stateful",
+        )
+
+        runtime = manager.create_team(team_card)
+        team_id = runtime.id
+
+        # Send 3 messages to increment counter to 3
+        for i in range(3):
+            actor_system.tell(
+                runtime.entry_addr,
+                UserMessage(content=f"msg-{i}"),
+            )
+
+        wait_for_agent_state(
+            runtime.entry_addr,
+            lambda state: getattr(state, "counter", 0) >= 3,
+            timeout=3.0,
+        )
+
+        manager.stop_team(team_id)
+
+        # Resume and verify counter preserved
+        new_runtime = manager.resume_team(team_id)
+
+        actor = get_actor_from_addr(new_runtime.entry_addr)
+        assert actor.state.counter == 3, (
+            f"Expected counter=3 after resume, got {actor.state.counter}"
+        )
+
+        # Send 1 more message, counter should become 4
+        actor_system.tell(
+            new_runtime.entry_addr,
+            UserMessage(content="msg-extra"),
+        )
+        reached = wait_for_agent_state(
+            new_runtime.entry_addr,
+            lambda state: getattr(state, "counter", 0) >= 4,
+            timeout=3.0,
+        )
+        assert reached, "Counter did not increment to 4 after resume"

--- a/tests/integration/test_persistence.py
+++ b/tests/integration/test_persistence.py
@@ -8,6 +8,7 @@ Tests that fail due to the _spawn_child bug are marked with
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import pytest
@@ -71,7 +72,6 @@ class TestPersistenceIntegration:
         )
 
         # Allow events to propagate through orchestrator to subscriber
-        import time
         time.sleep(0.2)
 
         events = event_store.load_events(runtime.id)
@@ -107,7 +107,6 @@ class TestPersistenceIntegration:
             timeout=3.0,
         )
 
-        import time
         time.sleep(0.2)
 
         events_before_stop = len(event_store.load_events(team_id))

--- a/tests/integration/test_persistence.py
+++ b/tests/integration/test_persistence.py
@@ -1,0 +1,135 @@
+"""Integration tests for persistence: event sourcing and team restoration.
+
+Tests use real Akgent subclasses, real orchestrators, and real event flow
+with YamlEventStore for actual file-based persistence.
+Tests that fail due to the _spawn_child bug are marked with
+@pytest.mark.skip(reason="Awaiting factory fix - Story 11.2").
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.messages.message import UserMessage
+
+from akgentic.team.manager import TeamManager
+from akgentic.team.models import TeamCard, TeamCardMember
+from akgentic.team.repositories.yaml import YamlEventStore
+from tests.integration.conftest import (
+    RecordingAgent,
+    make_integration_agent_card,
+    wait_for_agent_state,
+)
+
+
+def _make_simple_team_card() -> TeamCard:
+    """Create a minimal team card with a single RecordingAgent entry point."""
+    entry = TeamCardMember(
+        card=make_integration_agent_card(
+            name="recorder",
+            role="Recorder",
+            agent_class=RecordingAgent,
+        ),
+    )
+    return TeamCard(
+        name="persistence-team",
+        description="A team for persistence integration tests",
+        entry_point=entry,
+        members=[],
+        message_types=[UserMessage],
+    )
+
+
+class TestPersistenceIntegration:
+    """Persistence integration tests with YamlEventStore."""
+
+    def test_all_messages_persisted(
+        self,
+        actor_system: ActorSystem,
+        tmp_path: Path,
+    ) -> None:
+        """Every message sent through the team is captured by PersistenceSubscriber."""
+        event_store = YamlEventStore(tmp_path)
+        manager = TeamManager(actor_system, event_store)
+        team_card = _make_simple_team_card()
+
+        runtime = manager.create_team(team_card)
+
+        # Send 3 messages
+        for i in range(3):
+            actor_system.tell(
+                runtime.entry_addr,
+                UserMessage(content=f"persist-msg-{i}"),
+            )
+
+        wait_for_agent_state(
+            runtime.entry_addr,
+            lambda state: getattr(state, "counter", 0) >= 3,
+            timeout=3.0,
+        )
+
+        # Allow events to propagate through orchestrator to subscriber
+        import time
+        time.sleep(0.2)
+
+        events = event_store.load_events(runtime.id)
+        # Events include StartMessages, ReceivedMessages, ProcessedMessages,
+        # StateChangedMessages, and SentMessages -- not just UserMessages.
+        # We verify that the total event count reflects all 3 messages flowing
+        # through the system (each message generates multiple telemetry events).
+        assert len(events) >= 3, (
+            f"Expected at least 3 events, got {len(events)}"
+        )
+
+    @pytest.mark.skip(reason="Awaiting factory fix - Story 11.2")
+    def test_restored_team_routes_messages(
+        self,
+        actor_system: ActorSystem,
+        tmp_path: Path,
+    ) -> None:
+        """A restored team routes messages and persists new events."""
+        event_store = YamlEventStore(tmp_path)
+        manager = TeamManager(actor_system, event_store)
+        team_card = _make_simple_team_card()
+
+        runtime = manager.create_team(team_card)
+        team_id = runtime.id
+
+        actor_system.tell(
+            runtime.entry_addr,
+            UserMessage(content="before-stop"),
+        )
+        wait_for_agent_state(
+            runtime.entry_addr,
+            lambda state: "before-stop" in getattr(state, "messages", []),
+            timeout=3.0,
+        )
+
+        import time
+        time.sleep(0.2)
+
+        events_before_stop = len(event_store.load_events(team_id))
+
+        manager.stop_team(team_id)
+
+        # Resume the team
+        new_runtime = manager.resume_team(team_id)
+
+        actor_system.tell(
+            new_runtime.entry_addr,
+            UserMessage(content="after-resume"),
+        )
+        reached = wait_for_agent_state(
+            new_runtime.entry_addr,
+            lambda state: "after-resume" in getattr(state, "messages", []),
+            timeout=3.0,
+        )
+        assert reached, "Message 'after-resume' did not reach agent on restored team"
+
+        time.sleep(0.2)
+        events_after_resume = event_store.load_events(team_id)
+        assert len(events_after_resume) > events_before_stop, (
+            "No new events persisted after resume"
+        )


### PR DESCRIPTION
## Summary

- Adds 11 integration tests (6 passing, 5 skipped) under `tests/integration/` that define correct team behavior based on V1 reference implementation
- Uses real `Akgent` subclasses (`RecordingAgent`, `RoutingAgent`, `StatefulAgent`) with real message handlers -- no stubs, no mocks
- Covers factory (5 tests), lifecycle (4 tests), and persistence (2 tests) integration scenarios
- Skipped tests await factory fix in Story 11.2 (`_spawn_child` bug)
- Code review fixes: proper `Callable` type annotation for `predicate`, module-level imports, type constraints

## Verification

- 208 passed, 5 skipped (202 existing + 11 new integration)
- Ruff: zero violations on new files
- Coverage: 93.42% (>= 80% threshold)
- No source code modified, no existing test files modified

Closes #49