### PR TITLE
Fix factory to spawn via parent proxy

### DIFF
--- a/src/akgentic/team/factory.py
+++ b/src/akgentic/team/factory.py
@@ -76,8 +76,7 @@ class TeamFactory:
             orchestrator_proxy: Orchestrator = actor_system.proxy_ask(
                 orchestrator_addr, Orchestrator
             )
-            for sub in subscribers or []:
-                orchestrator_proxy.subscribe(sub)
+            TeamFactory._register_subscribers(orchestrator_proxy, subscribers)
 
             # 3. Walk TeamCard tree and spawn all agents
             addrs: dict[str, ActorAddress] = {}
@@ -131,7 +130,30 @@ class TeamFactory:
             raise
 
     @staticmethod
-    def _spawn_child(
+    def _register_subscribers(
+        orchestrator_proxy: Orchestrator,
+        subscribers: list[EventSubscriber] | None,
+    ) -> None:
+        """Register subscribers and replay missed orchestrator startup events.
+
+        The orchestrator generates its own StartMessage during ``on_start()``,
+        before any subscribers are registered. This method replays those
+        startup events so subscribers capture the full event history.
+
+        Args:
+            orchestrator_proxy: Proxy to the orchestrator actor.
+            subscribers: Optional list of event subscribers to register.
+        """
+        for sub in subscribers or []:
+            orchestrator_proxy.subscribe(sub)
+
+        if subscribers:
+            for msg in orchestrator_proxy.get_messages():
+                for sub in subscribers:
+                    sub.on_message(msg)
+
+    @staticmethod
+    def _spawn_through_parent(
         agent_class: type[Akgent[Any, Any]],
         parent_addr: ActorAddress,
         config: BaseConfig,
@@ -180,8 +202,8 @@ class TeamFactory:
     ) -> dict[str, ActorAddress]:
         """Spawn a member and its subordinates recursively.
 
-        Agents are spawned through the parent via ``_spawn_child()`` so that
-        ``_orchestrator`` and ``_parent`` propagate automatically.
+        Agents are spawned through the parent via ``_spawn_through_parent()``
+        so that ``_orchestrator`` and ``_parent`` propagate automatically.
 
         Args:
             member: The TeamCardMember to spawn.
@@ -196,7 +218,7 @@ class TeamFactory:
         name = member.card.config.name
 
         if member.headcount == 1:
-            addr = TeamFactory._spawn_child(
+            addr = TeamFactory._spawn_through_parent(
                 agent_class, parent_addr,
                 config=member.card.get_config_copy(),
             )
@@ -207,7 +229,7 @@ class TeamFactory:
                 indexed_name = f"{name}_{i}"
                 config = member.card.get_config_copy()
                 config.name = indexed_name
-                addr = TeamFactory._spawn_child(
+                addr = TeamFactory._spawn_through_parent(
                     agent_class, parent_addr,
                     config=config,
                 )

--- a/src/akgentic/team/models.py
+++ b/src/akgentic/team/models.py
@@ -254,7 +254,8 @@ class TeamRuntime(SerializableBaseModel):
         message = self._make_message(content)
         self.actor_system.tell(self.entry_addr, message)
         for addr in self.supervisor_addrs.values():
-            self._entry_proxy.send(addr, message)
+            if addr != self.entry_addr:
+                self._entry_proxy.send(addr, message)
 
     def send_to(self, agent_name: str, content: str) -> None:
         """Send a directed message to a specific agent by name.

--- a/src/akgentic/team/models.py
+++ b/src/akgentic/team/models.py
@@ -240,15 +240,19 @@ class TeamRuntime(SerializableBaseModel):
         return self._message_cls(content=content)  # type: ignore[call-arg]
 
     def send(self, content: str) -> None:
-        """Broadcast a message to all supervisors via the entry proxy.
+        """Send a message into the team through the entry-point agent.
 
-        Creates a message from the team's declared message type and sends
-        it via the entry proxy to each supervisor address.
+        The message is delivered to the entry-point agent's inbox so it
+        flows through the agent's normal message handler (e.g.
+        ``receiveMsg_UserMessage``), enabling routing via ``routes_to``.
+        Additionally, the message is relayed to each supervisor via the
+        entry proxy for direct delivery.
 
         Args:
             content: The message content to broadcast.
         """
         message = self._make_message(content)
+        self.actor_system.tell(self.entry_addr, message)
         for addr in self.supervisor_addrs.values():
             self._entry_proxy.send(addr, message)
 

--- a/src/akgentic/team/restorer.py
+++ b/src/akgentic/team/restorer.py
@@ -301,7 +301,8 @@ class TeamRestorer:
             orchestrator_start, team_id, spawned_addrs
         )
 
-        # 2c. Register subscribers
+        # 2c. Register subscribers (without startup replay — phase 3 handles
+        #      event replay, so TeamFactory._register_subscribers is not used here)
         persistence_sub = PersistenceSubscriber(team_id, self._event_store)
         persistence_sub.set_restoring(True)
 

--- a/src/akgentic/team/restorer.py
+++ b/src/akgentic/team/restorer.py
@@ -251,7 +251,7 @@ class TeamRestorer:
 
             config = sm.config.model_copy()
 
-            addr = TeamFactory._spawn_child(
+            addr = TeamFactory._spawn_through_parent(
                 agent_class,
                 orchestrator_addr,
                 config=config,

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -9,7 +9,6 @@ from typer.testing import CliRunner
 
 from akgentic.team.models import Process, TeamStatus
 from akgentic.team.repositories.yaml import YamlEventStore
-
 from tests.models.conftest import make_process
 
 

--- a/tests/integration/test_factory.py
+++ b/tests/integration/test_factory.py
@@ -7,7 +7,6 @@ Tests that fail due to the _spawn_child bug are marked with
 
 from __future__ import annotations
 
-import pytest
 from akgentic.core.actor_system_impl import ActorSystem
 from akgentic.core.orchestrator import Orchestrator
 
@@ -47,7 +46,6 @@ class TestFactoryIntegration:
             assert addr is not None, f"Agent '{name}' not found via orchestrator"
             assert addr.is_alive(), f"Agent '{name}' is not alive"
 
-    @pytest.mark.skip(reason="Awaiting factory fix - Story 11.2")
     def test_built_team_message_reaches_target(
         self,
         routing_team_card: TeamCard,
@@ -66,7 +64,6 @@ class TestFactoryIntegration:
         )
         assert reached, "Message 'hello' did not reach worker agent"
 
-    @pytest.mark.skip(reason="Awaiting factory fix - Story 11.2")
     def test_built_team_routes_to_resolves_to_existing_agents(
         self,
         routing_team_card: TeamCard,

--- a/tests/integration/test_factory.py
+++ b/tests/integration/test_factory.py
@@ -1,8 +1,6 @@
 """Integration tests for TeamFactory: verify built teams are functional.
 
 Tests use real Akgent subclasses, real orchestrators, and real message flow.
-Tests that fail due to the _spawn_child bug are marked with
-@pytest.mark.skip(reason="Awaiting factory fix - Story 11.2").
 """
 
 from __future__ import annotations

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
 from akgentic.core.actor_system_impl import ActorSystem
 from akgentic.core.agent import Akgent
 from akgentic.core.messages.message import UserMessage
@@ -110,7 +109,6 @@ class TestLifecycleIntegration:
         events = event_store.load_events(team_id)
         assert len(events) > 0, "No events persisted"
 
-    @pytest.mark.skip(reason="Awaiting factory fix - Story 11.2")
     def test_resume_team_is_functional(
         self,
         actor_system: ActorSystem,
@@ -150,7 +148,6 @@ class TestLifecycleIntegration:
         )
         assert reached, "Message 'message-2' did not reach entry agent on resumed team"
 
-    @pytest.mark.skip(reason="Awaiting factory fix - Story 11.2")
     def test_resume_team_preserves_agent_state(
         self,
         actor_system: ActorSystem,

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -1,8 +1,6 @@
 """Integration tests for TeamManager lifecycle: create, stop, resume.
 
 Tests use real Akgent subclasses, real orchestrators, and real event flow.
-Tests that fail due to the _spawn_child bug are marked with
-@pytest.mark.skip(reason="Awaiting factory fix - Story 11.2").
 """
 
 from __future__ import annotations

--- a/tests/integration/test_persistence.py
+++ b/tests/integration/test_persistence.py
@@ -2,8 +2,6 @@
 
 Tests use real Akgent subclasses, real orchestrators, and real event flow
 with YamlEventStore for actual file-based persistence.
-Tests that fail due to the _spawn_child bug are marked with
-@pytest.mark.skip(reason="Awaiting factory fix - Story 11.2").
 """
 
 from __future__ import annotations

--- a/tests/integration/test_persistence.py
+++ b/tests/integration/test_persistence.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import time
 from pathlib import Path
 
-import pytest
 from akgentic.core.actor_system_impl import ActorSystem
 from akgentic.core.messages.message import UserMessage
 
@@ -83,7 +82,6 @@ class TestPersistenceIntegration:
             f"Expected at least 3 events, got {len(events)}"
         )
 
-    @pytest.mark.skip(reason="Awaiting factory fix - Story 11.2")
     def test_restored_team_routes_messages(
         self,
         actor_system: ActorSystem,

--- a/tests/services/test_restorer.py
+++ b/tests/services/test_restorer.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 
 import pytest
 from akgentic.core.actor_address import ActorAddress
-from akgentic.core.actor_address_impl import ActorAddressImpl
 from akgentic.core.actor_system_impl import ActorSystem
 from akgentic.core.agent import Akgent
 from akgentic.core.agent_card import AgentCard
@@ -29,7 +28,6 @@ from akgentic.team.models import (
 )
 from akgentic.team.restorer import TeamRestorer
 from akgentic.team.subscriber import PersistenceSubscriber
-from tests.models.conftest import make_stub_addr
 from tests.services.conftest import InMemoryEventStore
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Renames `_spawn_child()` to `_spawn_through_parent()` (same hierarchy-propagating spawn mechanism)
- Adds `_register_subscribers()` helper to replay missed orchestrator startup events for `PersistenceSubscriber`
- Fixes `TeamRuntime.send()` to deliver messages to entry agent inbox via `actor_system.tell()`, enabling routing through `receiveMsg_UserMessage`
- Removes all 5 `@pytest.mark.skip` decorators from integration tests — all 213 tests pass, 0 skipped

## Code Review Fixes

- Guard against double-delivery in `TeamRuntime.send()` when entry point is also a supervisor
- Remove stale docstrings referencing `_spawn_child` and skip markers from 3 integration test files
- Add clarifying comment in restorer explaining intentional omission of `_register_subscribers`
- Fix ruff violations: unused imports in `test_restorer.py`, import sorting in `cli/conftest.py`

## Verification

- `pytest`: 213 passed, 0 failed, 0 skipped
- `ruff check` (src + tests): all checks passed
- `mypy`: 0 errors in akgentic-team (4 pre-existing in akgentic-core)
- Coverage: 93.57% (threshold: 80%)

Closes #51