### PR TITLE
Full lifecycle LLM integration test (ADR-005 bug reproduction)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
     "mypy>=1.8.0",
     "ruff>=0.1.0",
     "mongomock>=4.0.0",
+    "python-dotenv>=1.0.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,10 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
 
+[tool.pytest.ini_options]
+markers = ["integration: Full lifecycle tests requiring real LLM and API keys"]
+addopts = "-m 'not integration'"
+
 [tool.ruff]
 target-version = "py312"
 line-length = 100

--- a/tests/integration/test_llm_lifecycle.py
+++ b/tests/integration/test_llm_lifecycle.py
@@ -1,0 +1,290 @@
+"""Full lifecycle integration test: create → send → stop → restore → send again.
+
+Reproduces the exact src/agent_team flow with a real LLM to prove ADR-005 bugs
+exist (duplicate hiring, orchestrator death, restore crash). Requires OPENAI_API_KEY.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pykka
+import pytest
+from akgentic.agent import AgentConfig, AgentMessage, BaseAgent, HumanProxy
+from akgentic.core import AgentCard
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.messages.message import Message
+from akgentic.core.messages.orchestrator import EventMessage, SentMessage
+from akgentic.llm import ModelConfig, PromptTemplate
+from akgentic.tool.event import ToolCallEvent
+from akgentic.tool.planning import PlanningTool, UpdatePlanning
+from akgentic.tool.search import SearchTool, WebSearch
+from dotenv import load_dotenv
+
+from akgentic.team import TeamCard, TeamCardMember, TeamManager, TeamStatus, YamlEventStore
+
+LLM_MODEL = "gpt-5.2"
+
+
+# --- EventCollector ---
+
+
+class EventCollector:
+    """Collects SentMessage and ToolCallEvent for test assertions."""
+
+    def __init__(self) -> None:
+        self.sent_messages: list[SentMessage] = []
+        self.tool_events: list[ToolCallEvent] = []
+
+    def on_message(self, message: Message) -> None:
+        """Record SentMessage and ToolCallEvent events."""
+        if isinstance(message, SentMessage):
+            self.sent_messages.append(message)
+        if isinstance(message, EventMessage) and isinstance(message.event, ToolCallEvent):
+            self.tool_events.append(message.event)
+
+    def on_stop(self) -> None:
+        """No-op on orchestrator stop."""
+
+    def clear(self) -> None:
+        """Reset all collected events."""
+        self.sent_messages.clear()
+        self.tool_events.clear()
+
+
+# --- wait_for_stable_messages ---
+
+
+def wait_for_stable_messages(
+    collector: EventCollector,
+    stable_seconds: float = 15.0,
+    timeout: float = 120.0,
+) -> None:
+    """Poll SentMessage count; stable = unchanged for stable_seconds; fail on timeout."""
+    start = time.monotonic()
+    last_count = len(collector.sent_messages)
+    last_change = start
+
+    while True:
+        now = time.monotonic()
+        if now - start > timeout:
+            pytest.fail(
+                f"Conversation did not stabilize within {timeout}s "
+                f"(last count: {len(collector.sent_messages)} messages)"
+            )
+        current_count = len(collector.sent_messages)
+        if current_count != last_count:
+            last_count = current_count
+            last_change = now
+        elif now - last_change >= stable_seconds:
+            return  # Stable
+        time.sleep(2.0)
+
+
+# --- TeamCard construction ---
+
+
+def build_llm_team_card() -> TeamCard:
+    """Build a TeamCard programmatically matching src/agent_team structure."""
+    search_tool = SearchTool(web_search=WebSearch(max_results=3))
+    planning_tool = PlanningTool(
+        update_planning=UpdatePlanning(instructions="Keep the plan updated.")
+    )
+    tools = [search_tool, planning_tool]
+
+    human_card = AgentCard(
+        role="Human",
+        description="Human user interface",
+        skills=[],
+        agent_class=HumanProxy,
+        config=BaseConfig(name="@Human", role="Human"),
+        routes_to=["@Manager"],
+    )
+
+    manager_card = AgentCard(
+        role="Manager",
+        description="Helpful manager coordinating team work",
+        skills=["coordination", "delegation"],
+        agent_class=BaseAgent,
+        config=AgentConfig(
+            name="@Manager",
+            role="Manager",
+            prompt=PromptTemplate(
+                template="You are a helpful manager. Coordinate the team effectively.",
+            ),
+            model_cfg=ModelConfig(provider="openai", model=LLM_MODEL, temperature=0.3),
+            tools=tools,
+        ),
+        routes_to=["Assistant", "Expert"],
+    )
+
+    assistant_card = AgentCard(
+        role="Assistant",
+        description="Helpful assistant providing support",
+        skills=["research", "writing"],
+        agent_class=BaseAgent,
+        config=AgentConfig(
+            name="@Assistant",
+            role="Assistant",
+            prompt=PromptTemplate(
+                template="You are a helpful assistant. Provide clear and accurate information.",
+            ),
+            model_cfg=ModelConfig(provider="openai", model=LLM_MODEL, temperature=0.3),
+            tools=tools,
+        ),
+    )
+
+    expert_card = AgentCard(
+        role="Expert",
+        description="Helpful expert providing specialized knowledge",
+        skills=["analysis", "problem-solving"],
+        agent_class=BaseAgent,
+        config=AgentConfig(
+            name="@Expert",
+            role="Expert",
+            prompt=PromptTemplate(
+                template="You are a helpful expert. Provide deep specialized knowledge.",
+            ),
+            model_cfg=ModelConfig(provider="openai", model=LLM_MODEL, temperature=0.3),
+            tools=tools,
+        ),
+    )
+
+    # Build TeamCard — mirrors src/catalog/teams/agent-team.yaml
+    assistant_member = TeamCardMember(card=assistant_card)
+    expert_member = TeamCardMember(card=expert_card)
+    manager_member = TeamCardMember(
+        card=manager_card,
+        members=[assistant_member, expert_member],
+    )
+    human_member = TeamCardMember(card=human_card)
+
+    return TeamCard(
+        name="agent-team",
+        description="Manager coordinating Assistant and Expert agents",
+        entry_point=human_member,
+        members=[manager_member],
+        message_types=[AgentMessage],
+    )
+
+
+# --- Fixture ---
+
+
+@pytest.fixture()
+def llm_team_infrastructure(tmp_path: Path) -> dict:  # type: ignore[type-arg]
+    """Create infrastructure for LLM integration tests."""
+    # Load API key from project root .env
+    project_root = Path(__file__).resolve().parents[4]
+    load_dotenv(project_root / ".env")
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        pytest.fail(
+            "OPENAI_API_KEY not set in environment or .env — "
+            "cannot run LLM integration tests"
+        )
+
+    # Infrastructure
+    actor_system = ActorSystem()
+    event_store = YamlEventStore(tmp_path / "team-data")
+    collector = EventCollector()
+
+    def subscriber_factory(_team_id: object) -> list[EventCollector]:
+        return [collector]
+
+    team_manager = TeamManager(
+        actor_system=actor_system,
+        event_store=event_store,
+        subscriber_factory=subscriber_factory,
+    )
+
+    yield {
+        "actor_system": actor_system,
+        "team_manager": team_manager,
+        "collector": collector,
+    }
+
+    pykka.ActorRegistry.stop_all()
+
+
+# --- Integration Test ---
+
+
+@pytest.mark.integration
+@pytest.mark.skip(reason="ADR-005: reproduces known bugs — awaiting Story 12.2/12.3 fixes")
+def test_full_lifecycle_create_send_stop_restore(
+    llm_team_infrastructure: dict,  # type: ignore[type-arg]
+) -> None:
+    """Full lifecycle: create → send → stop → restore → send again."""
+    infra = llm_team_infrastructure
+    team_manager: TeamManager = infra["team_manager"]
+    collector: EventCollector = infra["collector"]
+    team_card = build_llm_team_card()
+
+    # --- Phase 1: Create and Send (AC: 1) ---
+    runtime = team_manager.create_team(team_card)
+    time.sleep(0.3)
+
+    initial_team_size = len(runtime.addrs)
+
+    prompt = (
+        "Could you ask your expert for information on the best practices "
+        "for tea harvesting in Kenya? Ask your assistant to provide me a "
+        "well-formatted report with the expert information."
+    )
+    runtime.send(prompt)
+
+    wait_for_stable_messages(collector, stable_seconds=15, timeout=120)
+
+    # Assertions — Phase 1
+    final_team_size = len(runtime.addrs)
+    hire_calls = [e for e in collector.tool_events if e.tool_name == "hire_members"]
+    assert final_team_size == initial_team_size, (
+        f"Team grew from {initial_team_size} to {final_team_size} — duplicate hiring"
+    )
+    assert len(hire_calls) == 0, f"hire_members called {len(hire_calls)} times"
+    # Orchestrator alive check — would throw ActorDeadError if dead
+    roster_after = runtime.orchestrator_proxy.cmd_get_team_roster()
+    assert roster_after is not None
+
+    # --- Phase 2: Stop (AC: 2) ---
+    team_id = runtime.id
+    team_manager.stop_team(team_id)
+
+    process = team_manager.get_team(team_id)
+    assert process is not None
+    assert process.status == TeamStatus.STOPPED
+
+    # --- Phase 3: Restore and Continue (AC: 3) ---
+    collector.clear()
+
+    restored_runtime = team_manager.resume_team(team_id)
+    time.sleep(0.3)
+
+    # Assert: same agents restored
+    restored_team_size = len(restored_runtime.addrs)
+    assert restored_team_size == initial_team_size, (
+        f"Restored team size {restored_team_size} != initial {initial_team_size}"
+    )
+
+    follow_up = "Can you summarize the key points from the tea harvesting report?"
+    restored_runtime.send(follow_up)
+    wait_for_stable_messages(collector, stable_seconds=15, timeout=120)
+
+    # Assert: no duplicates after restore
+    final_restored_size = len(restored_runtime.addrs)
+    hire_calls_phase3 = [
+        e for e in collector.tool_events if e.tool_name == "hire_members"
+    ]
+    assert final_restored_size == initial_team_size, (
+        f"Restored team grew from {initial_team_size} to {final_restored_size}"
+    )
+    assert len(hire_calls_phase3) == 0, (
+        f"hire_members called {len(hire_calls_phase3)} times after restore"
+    )
+    # Orchestrator alive
+    roster_phase3 = restored_runtime.orchestrator_proxy.cmd_get_team_roster()
+    assert roster_phase3 is not None

--- a/tests/integration/test_llm_lifecycle.py
+++ b/tests/integration/test_llm_lifecycle.py
@@ -8,12 +8,14 @@ from __future__ import annotations
 
 import os
 import time
+import uuid
 from pathlib import Path
+from typing import Any
 
 import pykka
 import pytest
 from akgentic.agent import AgentConfig, AgentMessage, BaseAgent, HumanProxy
-from akgentic.core import AgentCard
+from akgentic.core import AgentCard, EventSubscriber
 from akgentic.core.actor_system_impl import ActorSystem
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.messages.message import Message
@@ -32,7 +34,7 @@ LLM_MODEL = "gpt-5.2"
 # --- EventCollector ---
 
 
-class EventCollector:
+class EventCollector(EventSubscriber):
     """Collects SentMessage and ToolCallEvent for test assertions."""
 
     def __init__(self) -> None:
@@ -118,7 +120,7 @@ def build_llm_team_card() -> TeamCard:
             model_cfg=ModelConfig(provider="openai", model=LLM_MODEL, temperature=0.3),
             tools=tools,
         ),
-        routes_to=["Assistant", "Expert"],
+        routes_to=["@Assistant", "@Expert"],
     )
 
     assistant_card = AgentCard(
@@ -175,7 +177,7 @@ def build_llm_team_card() -> TeamCard:
 
 
 @pytest.fixture()
-def llm_team_infrastructure(tmp_path: Path) -> dict:  # type: ignore[type-arg]
+def llm_team_infrastructure(tmp_path: Path) -> dict[str, Any]:
     """Create infrastructure for LLM integration tests."""
     # Load API key from project root .env
     project_root = Path(__file__).resolve().parents[4]
@@ -192,7 +194,7 @@ def llm_team_infrastructure(tmp_path: Path) -> dict:  # type: ignore[type-arg]
     event_store = YamlEventStore(tmp_path / "team-data")
     collector = EventCollector()
 
-    def subscriber_factory(_team_id: object) -> list[EventCollector]:
+    def subscriber_factory(_team_id: uuid.UUID) -> list[EventCollector]:
         return [collector]
 
     team_manager = TeamManager(
@@ -216,7 +218,7 @@ def llm_team_infrastructure(tmp_path: Path) -> dict:  # type: ignore[type-arg]
 @pytest.mark.integration
 @pytest.mark.skip(reason="ADR-005: reproduces known bugs — awaiting Story 12.2/12.3 fixes")
 def test_full_lifecycle_create_send_stop_restore(
-    llm_team_infrastructure: dict,  # type: ignore[type-arg]
+    llm_team_infrastructure: dict[str, Any],
 ) -> None:
     """Full lifecycle: create → send → stop → restore → send again."""
     infra = llm_team_infrastructure


### PR DESCRIPTION
## Summary

- Adds a full lifecycle integration test (create → send → stop → restore → send again) that reproduces the exact `src/catalog/main.py` flow with a real LLM (OpenAI gpt-5.2)
- Proves ADR-005 bugs exist: duplicate hiring, invalid recipients, ActorDeadError during conversation
- Test is skip-marked pending Story 12.2/12.3 fixes; integration marker + `addopts` exclude from default runs
- Code review fixes: declared python-dotenv dependency, EventSubscriber inheritance, routes_to `@` prefix consistency, type annotation improvements

Closes #53