### PR TITLE
Fix ActorAddressProxy in restore flow

### DIFF
--- a/src/akgentic/team/models.py
+++ b/src/akgentic/team/models.py
@@ -14,6 +14,7 @@ from typing import Any
 from pydantic import Field, PrivateAttr
 
 from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_address_impl import ActorAddressProxy
 from akgentic.core.actor_system_impl import ActorSystem
 from akgentic.core.agent import Akgent
 from akgentic.core.agent_card import AgentCard
@@ -196,6 +197,7 @@ class TeamRuntime(SerializableBaseModel):
     _entry_proxy: Akgent[Any, Any] = PrivateAttr()
     _supervisor_proxies: dict[str, Akgent[Any, Any]] = PrivateAttr(default_factory=dict)
     _message_cls: type[Message] | None = PrivateAttr(default=None)
+    _addr_map: dict[uuid.UUID, ActorAddress] = PrivateAttr(default_factory=dict)
 
     def model_post_init(self, __context: Any) -> None:
         """Rebuild all ephemeral proxies from persistent addresses.
@@ -266,19 +268,30 @@ class TeamRuntime(SerializableBaseModel):
         """Send a directed message to a specific agent by name.
 
         Looks up the agent via the orchestrator proxy and sends a message
-        via the entry proxy.
+        via the entry proxy. Includes a safety net to resolve stale
+        ``ActorAddressProxy`` refs that may leak through after restore.
 
         Args:
             agent_name: Name of the target agent.
             content: The message content.
 
         Raises:
-            ValueError: If the agent is not found in the team.
+            ValueError: If the agent is not found or has a stale proxy address.
         """
         actor_addr = self._orchestrator_proxy.get_team_member(agent_name)
         if actor_addr is None:
             msg = f"Agent '{agent_name}' not found in team '{self.team.name}'"
             raise ValueError(msg)
+        # Safety net: resolve proxy if it leaked through after restore
+        if isinstance(actor_addr, ActorAddressProxy):
+            live = self._addr_map.get(actor_addr.agent_id)
+            if live is None:
+                msg = (
+                    f"Agent '{agent_name}' has stale proxy address "
+                    f"— no live mapping available"
+                )
+                raise ValueError(msg)
+            actor_addr = live
         message = self._make_message(content)
         self._entry_proxy.send(actor_addr, message)
 

--- a/src/akgentic/team/restorer.py
+++ b/src/akgentic/team/restorer.py
@@ -9,10 +9,17 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_address_impl import ActorAddressProxy
 from akgentic.core.actor_system_impl import ActorSystem
 from akgentic.core.agent import Akgent
 from akgentic.core.agent_config import BaseConfig
-from akgentic.core.messages.orchestrator import StartMessage, StopMessage
+from akgentic.core.messages.message import Message
+from akgentic.core.messages.orchestrator import (
+    ErrorMessage,
+    SentMessage,
+    StartMessage,
+    StopMessage,
+)
 from akgentic.core.orchestrator import EventSubscriber, Orchestrator
 from akgentic.core.utils.deserializer import import_class
 from akgentic.team.factory import TeamFactory
@@ -96,14 +103,23 @@ class TeamRestorer:
                 process, events, agent_states, spawned_addrs
             )
 
-            # Phase 3: Replay events
+            # Build address map: agent_id → live ActorAddress
+            addr_map: dict[uuid.UUID, ActorAddress] = {
+                result.orchestrator_addr.agent_id: result.orchestrator_addr,
+            }
+            for addr in result.addrs.values():
+                addr_map[addr.agent_id] = addr
+
+            # Phase 3: Replay events with proxy resolution
             self._replay_events(
-                team_id, result.orchestrator_proxy, result.persistence_sub, events
+                team_id, result.orchestrator_proxy, result.persistence_sub,
+                events, addr_map,
             )
 
             # Build and return TeamRuntime
             runtime = self._build_team_runtime(
-                team_id, process.team_card, result.orchestrator_addr, result.addrs
+                team_id, process.team_card, result.orchestrator_addr,
+                result.addrs, addr_map,
             )
 
             logger.info("Team %s restored successfully", team_id)
@@ -349,16 +365,24 @@ class TeamRestorer:
         orchestrator_proxy: Orchestrator,
         persistence_sub: PersistenceSubscriber,
         events: list[PersistedEvent],
+        addr_map: dict[uuid.UUID, ActorAddress],
     ) -> None:
         """Phase 3: Replay all persisted events through the orchestrator.
+
+        Resolves ``ActorAddressProxy`` instances in events to live addresses
+        before replay so that ``get_team()`` returns live ``ActorAddressImpl``
+        refs instead of stale proxies.
 
         Args:
             team_id: The team identifier (used for logging context).
             orchestrator_proxy: Proxy to the restored orchestrator actor.
             persistence_sub: The persistence subscriber to toggle restoring flag.
             events: Sorted persisted events to replay.
+            addr_map: Mapping of agent_id to live ActorAddress for proxy resolution.
         """
         logger.info("Restoring team %s: phase 3 -- replaying %d events", team_id, len(events))
+
+        self._resolve_event_addresses(events, addr_map)
 
         for pe in events:
             orchestrator_proxy.restore_message(pe.event)
@@ -366,12 +390,74 @@ class TeamRestorer:
         orchestrator_proxy.end_restoration()
         persistence_sub.set_restoring(False)
 
+    def _resolve_event_addresses(
+        self,
+        events: list[PersistedEvent],
+        addr_map: dict[uuid.UUID, ActorAddress],
+    ) -> None:
+        """Replace ActorAddressProxy with live addresses in all events.
+
+        Walks each event's address fields and swaps proxies for live
+        ``ActorAddressImpl`` refs using the addr_map built from Phase 2.
+
+        Args:
+            events: Persisted events to resolve in-place.
+            addr_map: Mapping of agent_id to live ActorAddress.
+        """
+        for pe in events:
+            self._resolve_message_addresses(pe.event, addr_map)
+
+    def _resolve_message_addresses(
+        self,
+        msg: Message,
+        addr_map: dict[uuid.UUID, ActorAddress],
+    ) -> None:
+        """Replace proxy addresses in a single message with live addresses.
+
+        Handles the ``sender`` field common to all messages, plus
+        type-specific fields: ``SentMessage.recipient``, ``SentMessage.message``,
+        ``StartMessage.parent``, ``ErrorMessage.current_message``.
+
+        Args:
+            msg: The message to resolve addresses in (mutated in-place).
+            addr_map: Mapping of agent_id to live ActorAddress.
+        """
+        msg.sender = self._resolve_addr(msg.sender, addr_map)
+
+        if isinstance(msg, SentMessage):
+            msg.recipient = self._resolve_addr(msg.recipient, addr_map) or msg.recipient
+            self._resolve_message_addresses(msg.message, addr_map)
+        elif isinstance(msg, StartMessage):
+            msg.parent = self._resolve_addr(msg.parent, addr_map)
+        elif isinstance(msg, ErrorMessage) and msg.current_message is not None:
+            self._resolve_message_addresses(msg.current_message, addr_map)
+
+    @staticmethod
+    def _resolve_addr(
+        addr: ActorAddress | None,
+        addr_map: dict[uuid.UUID, ActorAddress],
+    ) -> ActorAddress | None:
+        """Resolve a single proxy address to its live counterpart.
+
+        Args:
+            addr: The address to resolve (may be None or already live).
+            addr_map: Mapping of agent_id to live ActorAddress.
+
+        Returns:
+            The live address if the input was a proxy with a known mapping,
+            or the original address unchanged.
+        """
+        if addr is not None and isinstance(addr, ActorAddressProxy):
+            return addr_map.get(addr.agent_id, addr)
+        return addr
+
     def _build_team_runtime(
         self,
         team_id: uuid.UUID,
         team_card: TeamCard,
         orchestrator_addr: ActorAddress,
         addrs: dict[str, ActorAddress],
+        addr_map: dict[uuid.UUID, ActorAddress],
     ) -> TeamRuntime:
         """Construct a TeamRuntime from restored components.
 
@@ -380,6 +466,8 @@ class TeamRestorer:
             team_card: The declarative team definition.
             orchestrator_addr: Address of the restored orchestrator.
             addrs: Map of agent names to their actor addresses.
+            addr_map: Pre-built mapping of agent_id to live ActorAddress
+                for send_to() safety-net proxy resolution.
 
         Returns:
             A fully constructed TeamRuntime.
@@ -400,7 +488,7 @@ class TeamRestorer:
             if name in addrs:
                 supervisor_addrs[name] = addrs[name]
 
-        return TeamRuntime(
+        runtime = TeamRuntime(
             id=team_id,
             team=team_card,
             actor_system=self._actor_system,
@@ -409,3 +497,8 @@ class TeamRestorer:
             supervisor_addrs=supervisor_addrs,
             addrs=addrs,
         )
+
+        # Reuse addr_map for send_to() safety-net proxy resolution
+        runtime._addr_map = addr_map
+
+        return runtime

--- a/tests/integration/test_llm_lifecycle.py
+++ b/tests/integration/test_llm_lifecycle.py
@@ -260,5 +260,45 @@ def test_full_lifecycle_create_send_stop_restore(
     assert process.status == TeamStatus.STOPPED
 
     # --- Phase 3: Restore and Continue (AC: 3) ---
-    # Skipped: Story 12.3 will fix the ActorAddressProxy restore flow
-    pytest.skip("ADR-005: Phase 3 restore assertions deferred to Story 12.3")
+    collector.clear()
+
+    restored_runtime = team_manager.resume_team(team_id)
+    time.sleep(0.3)
+
+    # Verify restored addresses are live ActorAddressImpl, not stale proxies
+    from akgentic.core.actor_address_impl import ActorAddressImpl, ActorAddressProxy
+
+    restored_roster = restored_runtime.orchestrator_proxy.get_team()
+    for addr in restored_roster:
+        assert isinstance(addr, ActorAddressImpl), (
+            f"Expected ActorAddressImpl but got {type(addr).__name__} for '{addr.name}'"
+        )
+        assert not isinstance(addr, ActorAddressProxy), (
+            f"ActorAddressProxy leaked into restored roster for '{addr.name}'"
+        )
+
+    # Restored team should have same size as initial
+    restored_team_size = len(restored_runtime.addrs)
+    assert restored_team_size == initial_team_size, (
+        f"Restored team size {restored_team_size} != initial {initial_team_size}"
+    )
+
+    # Send a follow-up prompt through the restored team
+    follow_up = (
+        "Based on the earlier tea harvesting research, what are the top 3 "
+        "takeaways? Keep it brief."
+    )
+    restored_runtime.send(follow_up)
+
+    wait_for_stable_messages(collector, stable_seconds=15, timeout=120)
+
+    # Assertions — Phase 3
+    restore_hire_calls = [
+        e for e in collector.tool_events if e.tool_name == "hire_members"
+    ]
+    assert len(restore_hire_calls) == 0, (
+        f"hire_members called {len(restore_hire_calls)} times after restore"
+    )
+    # Orchestrator alive check — would throw ActorDeadError if dead
+    post_convo_roster = restored_runtime.orchestrator_proxy.get_team()
+    assert post_convo_roster is not None

--- a/tests/models/test_team_runtime.py
+++ b/tests/models/test_team_runtime.py
@@ -196,3 +196,68 @@ class TestTeamRuntimeMessaging:
         assert runtime.orchestrator_proxy is runtime._orchestrator_proxy
         assert runtime.entry_proxy is runtime._entry_proxy
         assert runtime.supervisor_proxies is runtime._supervisor_proxies
+
+
+class TestTeamRuntimeSendToResolution:
+    """AC 2 (Story 12.3): send_to() resolves proxy addresses via addr_map."""
+
+    def test_send_to_resolves_proxy_address(self) -> None:
+        """If orchestrator returns a proxy, send_to() resolves it via addr_map."""
+        from akgentic.core.actor_address_impl import ActorAddressProxy
+        from akgentic.core.utils.deserializer import ActorAddressDict
+
+        agent_id = uuid.uuid4()
+        team_id = uuid.uuid4()
+
+        # Create a proxy address (as would come from deserialized data)
+        addr_dict: ActorAddressDict = {
+            "__actor_address__": True,
+            "__actor_type__": "akgentic.core.agent.Akgent",
+            "agent_id": str(agent_id),
+            "name": "worker",
+            "role": "Worker",
+            "team_id": str(team_id),
+            "squad_id": str(uuid.uuid4()),
+            "user_message": False,
+        }
+        proxy_addr = ActorAddressProxy(addr_dict)
+
+        # Create a live address mock
+        live_addr = make_stub_addr("worker")
+        live_addr.agent_id = agent_id
+
+        runtime = make_team_runtime(message_types=[UserMessage])
+        runtime._orchestrator_proxy.get_team_member = MagicMock(return_value=proxy_addr)
+        runtime._addr_map = {agent_id: live_addr}
+
+        runtime.send_to("worker", "hello")
+
+        # Verify send was called with the live address, not the proxy
+        runtime._entry_proxy.send.assert_called_once()
+        call_args = runtime._entry_proxy.send.call_args
+        assert call_args.args[0] is live_addr
+        assert isinstance(call_args.args[1], UserMessage)
+
+    def test_send_to_raises_for_unmapped_proxy(self) -> None:
+        """If proxy has no mapping in addr_map, raise ValueError."""
+        from akgentic.core.actor_address_impl import ActorAddressProxy
+        from akgentic.core.utils.deserializer import ActorAddressDict
+
+        addr_dict: ActorAddressDict = {
+            "__actor_address__": True,
+            "__actor_type__": "akgentic.core.agent.Akgent",
+            "agent_id": str(uuid.uuid4()),
+            "name": "ghost",
+            "role": "Ghost",
+            "team_id": str(uuid.uuid4()),
+            "squad_id": str(uuid.uuid4()),
+            "user_message": False,
+        }
+        proxy_addr = ActorAddressProxy(addr_dict)
+
+        runtime = make_team_runtime(message_types=[UserMessage])
+        runtime._orchestrator_proxy.get_team_member = MagicMock(return_value=proxy_addr)
+        runtime._addr_map = {}  # No mapping
+
+        with pytest.raises(ValueError, match="stale proxy address"):
+            runtime.send_to("ghost", "hello")

--- a/tests/services/test_restorer.py
+++ b/tests/services/test_restorer.py
@@ -691,3 +691,87 @@ class TestRestorerHierarchyPropagation:
             assert actor._parent.agent_id == runtime.orchestrator_addr.agent_id, (
                 f"Restored agent '{name}' parent is not the orchestrator"
             )
+
+
+# ---------------------------------------------------------------------------
+# Tests: TestRestorerAddressResolution (Story 12.3, AC 1)
+# ---------------------------------------------------------------------------
+
+
+class TestRestorerAddressResolution:
+    """AC 1: Restored teams resolve serialized actor addresses to live refs."""
+
+    def test_restored_get_team_returns_live_addresses(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """After restore, get_team() returns ActorAddressImpl, not ActorAddressProxy."""
+        from akgentic.core.actor_address_impl import ActorAddressImpl, ActorAddressProxy
+
+        worker = _make_member("worker", "Worker")
+        tc = _make_team_card(members=[worker])
+
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime, _ = restorer.restore(process)
+
+        team = runtime.orchestrator_proxy.get_team()
+        for addr in team:
+            assert isinstance(addr, ActorAddressImpl), (
+                f"Expected ActorAddressImpl but got {type(addr).__name__} "
+                f"for agent '{addr.name}'"
+            )
+            assert not isinstance(addr, ActorAddressProxy), (
+                f"ActorAddressProxy leaked into get_team() for '{addr.name}'"
+            )
+
+    def test_restored_get_team_member_returns_live_address(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """After restore, get_team_member() returns the live address matching spawned actor."""
+        from akgentic.core.actor_address_impl import ActorAddressImpl
+
+        worker = _make_member("worker", "Worker")
+        tc = _make_team_card(members=[worker])
+
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime, _ = restorer.restore(process)
+
+        lead_addr = runtime.orchestrator_proxy.get_team_member("lead")
+        assert lead_addr is not None
+        assert isinstance(lead_addr, ActorAddressImpl)
+        assert lead_addr.is_alive()
+
+        worker_addr = runtime.orchestrator_proxy.get_team_member("worker")
+        assert worker_addr is not None
+        assert isinstance(worker_addr, ActorAddressImpl)
+        assert worker_addr.is_alive()
+
+    def test_replay_does_not_overwrite_live_with_proxy(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """Phase 3 replayed StartMessages do not overwrite Phase 2 live addresses."""
+        from akgentic.core.actor_address_impl import ActorAddressImpl
+
+        tc = _make_team_card()
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime, _ = restorer.restore(process)
+
+        # The entry agent should have a live address matching the spawned actor
+        lead_from_roster = runtime.orchestrator_proxy.get_team_member("lead")
+        lead_from_addrs = runtime.addrs["lead"]
+
+        assert lead_from_roster is not None
+        assert isinstance(lead_from_roster, ActorAddressImpl)
+        # The address from get_team_member should match the address from addrs
+        assert lead_from_roster.agent_id == lead_from_addrs.agent_id


### PR DESCRIPTION
## Summary

- Add `_resolve_event_addresses()` to `TeamRestorer` — walks all persisted events before Phase 3 replay and replaces `ActorAddressProxy` instances with live `ActorAddressImpl` refs using an address map built from Phase 2
- Add safety-net proxy resolution in `TeamRuntime.send_to()` via `_addr_map` PrivateAttr — catches any proxy that leaks through after restore
- Remove Phase 3 skip marker in integration test and add restore-and-continue assertions with proxy type verification

## Changes

| File | Change |
|------|--------|
| `src/akgentic/team/restorer.py` | Add `_resolve_event_addresses()`, `_resolve_message_addresses()`, `_resolve_addr()` methods; pass addr_map through `_replay_events()` and `_build_team_runtime()` |
| `src/akgentic/team/models.py` | Add `_addr_map` PrivateAttr to TeamRuntime; safety-net proxy resolution in `send_to()` |
| `tests/services/test_restorer.py` | Add `TestRestorerAddressResolution` (3 tests) |
| `tests/models/test_team_runtime.py` | Add `TestTeamRuntimeSendToResolution` (2 tests) |
| `tests/integration/test_llm_lifecycle.py` | Remove Phase 3 skip; add restore assertions with proxy type checks |

## Verification

- 220 unit tests pass
- ruff check clean
- mypy strict clean
- All changes scoped to `packages/akgentic-team/`

Closes #57