### PR TITLE
Redefine supervisor semantics and fix send() routing

### DIFF
--- a/src/akgentic/team/models.py
+++ b/src/akgentic/team/models.py
@@ -95,20 +95,18 @@ class TeamCard(SerializableBaseModel):
 
     @property
     def supervisors(self) -> list[AgentCard]:
-        """Return AgentCards for members that have subordinates.
+        """Return AgentCards for the first layer of ``members`` only.
 
-        The entry point is NOT included unless it has subordinates itself.
-        Use ``entry_point`` / ``TeamRuntime.entry_proxy`` to reach the
-        team's external interface (e.g. HumanProxy).
+        Supervisors are the agents that receive external messages routed
+        through the entry point.  The entry point itself is excluded --
+        it is the *sender*, not a recipient.  Deeper members (children
+        of first-layer members) are also excluded -- they are internal
+        to their supervisor's subtree.
 
         Returns:
-            List of AgentCards belonging to members with subordinates.
+            List of AgentCards for each top-level member.
         """
-        result: list[AgentCard] = []
-        self._collect_supervisors(self.entry_point, result)
-        for member in self.members:
-            self._collect_supervisors(member, result)
-        return result
+        return [m.card for m in self.members]
 
     @staticmethod
     def _collect_cards(
@@ -134,22 +132,6 @@ class TeamCard(SerializableBaseModel):
         result[name] = member.card
         for child in member.members:
             TeamCard._collect_cards(child, result)
-
-    @staticmethod
-    def _collect_supervisors(
-        member: TeamCardMember,
-        result: list[AgentCard],
-    ) -> None:
-        """Recursively collect supervisor AgentCards from a member subtree.
-
-        Args:
-            member: The member node to start from.
-            result: Accumulator list to populate with supervisor cards.
-        """
-        if member.members:
-            result.append(member.card)
-        for child in member.members:
-            TeamCard._collect_supervisors(child, result)
 
 
 # --- TeamRuntime ---
@@ -244,20 +226,15 @@ class TeamRuntime(SerializableBaseModel):
         """Send a message into the team through the entry-point agent.
 
         Routes through the entry proxy so that ``sender`` is set to the
-        entry agent (matching V1 behavior). Each recipient gets its own
-        message instance to avoid shared mutable state between actors.
-
-        For flat teams (no supervisors), the entry agent receives the
-        message directly and can route via ``routes_to``.  For hierarchical
-        teams, supervisors also receive a copy.
+        entry agent.  Each supervisor receives its own message instance
+        to avoid shared mutable state between actors.  The entry point
+        itself never receives a copy -- it is the sender, not a recipient.
 
         Args:
             content: The message content to send.
         """
-        self._entry_proxy.send(self.entry_addr, self._make_message(content))
         for addr in self.supervisor_addrs.values():
-            if addr != self.entry_addr:
-                self._entry_proxy.send(addr, self._make_message(content))
+            self._entry_proxy.send(addr, self._make_message(content))
 
     def send_to(self, agent_name: str, content: str) -> None:
         """Send a directed message to a specific agent by name.

--- a/tests/models/test_team_card.py
+++ b/tests/models/test_team_card.py
@@ -76,8 +76,8 @@ class TestTeamCard:
         cards = team.agent_cards
         assert set(cards.keys()) == {"root", "child", "gc"}
 
-    def test_supervisors_returns_members_with_subordinates(self) -> None:
-        """supervisors property returns only members with subordinates."""
+    def test_supervisors_returns_first_layer_members(self) -> None:
+        """supervisors property returns first-layer members only."""
         worker = TeamCardMember(card=make_agent_card(name="worker", role="Worker"))
         supervisor = TeamCardMember(
             card=make_agent_card(name="sup", role="Supervisor"),
@@ -92,17 +92,20 @@ class TestTeamCard:
         )
         sups = team.supervisors
         sup_names = {s.config.name for s in sups}
-        assert "entry" not in sup_names  # leaf entry point excluded
-        assert "sup" in sup_names        # member with subordinates
+        assert "entry" not in sup_names  # entry point is sender, not supervisor
+        assert "sup" in sup_names        # first-layer member
         assert len(sups) == 1
 
-    def test_supervisors_empty_when_no_subordinates(self) -> None:
-        """supervisors is empty when no member has subordinates."""
-        team = make_team_card(
-            member_names=["a", "b"],
-            member_roles=["A", "B"],
+    def test_supervisors_empty_when_no_members(self) -> None:
+        """supervisors is empty when members list is empty."""
+        team = TeamCard(
+            name="solo-team",
+            description="Just the entry point",
+            entry_point=TeamCardMember(
+                card=make_agent_card(name="solo", role="Solo"),
+            ),
+            members=[],
         )
-        # No member has subordinates; supervisors is empty
         assert len(team.supervisors) == 0
 
     def test_empty_members_list(self) -> None:
@@ -152,8 +155,8 @@ class TestTeamCard:
         sup_names = [s.config.name for s in sups]
         assert "proxy" not in sup_names
 
-    def test_supervisors_includes_entry_point_with_subordinates(self) -> None:
-        """Entry point with subordinates IS included in supervisors."""
+    def test_supervisors_excludes_entry_point_even_with_subordinates(self) -> None:
+        """Entry point is ALWAYS excluded from supervisors -- it is the sender."""
         child = TeamCardMember(card=make_agent_card(name="child", role="Child"))
         entry = TeamCardMember(
             card=make_agent_card(name="boss", role="Boss"),
@@ -166,28 +169,74 @@ class TestTeamCard:
             members=[],
         )
         sups = team.supervisors
-        assert len(sups) == 1
-        assert sups[0].config.name == "boss"
+        assert len(sups) == 0
+        sup_names = {s.config.name for s in sups}
+        assert "boss" not in sup_names
 
-    def test_supervisors_includes_only_members_with_subordinates(self) -> None:
-        """Only members with subordinates are in supervisors, not the leaf entry point."""
+    def test_supervisors_returns_all_first_layer_members_regardless_of_subordinates(
+        self,
+    ) -> None:
+        """ALL first-layer members are supervisors, regardless of whether they have children."""
         worker = TeamCardMember(card=make_agent_card(name="worker", role="Worker"))
         mid_sup = TeamCardMember(
             card=make_agent_card(name="mid", role="MiddleSup"),
             members=[worker],
         )
+        leaf = TeamCardMember(card=make_agent_card(name="leaf", role="Leaf"))
         entry = TeamCardMember(card=make_agent_card(name="lead", role="Lead"))
         team = TeamCard(
             name="mixed-team",
-            description="Entry point (leaf) + member supervisor",
+            description="Entry point + member supervisor + leaf member",
             entry_point=entry,
-            members=[mid_sup],
+            members=[mid_sup, leaf],
         )
         sups = team.supervisors
         sup_names = {s.config.name for s in sups}
-        assert "lead" not in sup_names  # leaf entry point excluded
-        assert "mid" in sup_names
-        assert len(sups) == 1
+        assert "lead" not in sup_names  # entry point always excluded
+        assert "mid" in sup_names       # first-layer member with children
+        assert "leaf" in sup_names      # first-layer member without children
+        assert len(sups) == 2
+
+    def test_supervisors_excludes_deep_hierarchy(self) -> None:
+        """Only first-layer members are supervisors, not deeper nested ones."""
+        assistant = TeamCardMember(card=make_agent_card(name="asst", role="Assistant"))
+        manager = TeamCardMember(
+            card=make_agent_card(name="manager", role="Manager"),
+            members=[assistant],
+        )
+        director = TeamCardMember(
+            card=make_agent_card(name="director", role="Director"),
+            members=[manager],
+        )
+        entry = TeamCardMember(card=make_agent_card(name="proxy", role="Proxy"))
+        team = TeamCard(
+            name="deep-team",
+            description="Deep hierarchy",
+            entry_point=entry,
+            members=[director],
+        )
+        sups = team.supervisors
+        sup_names = {s.config.name for s in sups}
+        assert sup_names == {"director"}
+        assert "manager" not in sup_names
+        assert "asst" not in sup_names
+
+    def test_supervisors_multi_member(self) -> None:
+        """Multiple first-layer members are all supervisors."""
+        entry = TeamCardMember(card=make_agent_card(name="proxy", role="Proxy"))
+        m1 = TeamCardMember(card=make_agent_card(name="m1", role="M1"))
+        m2 = TeamCardMember(card=make_agent_card(name="m2", role="M2"))
+        m3 = TeamCardMember(card=make_agent_card(name="m3", role="M3"))
+        team = TeamCard(
+            name="multi-team",
+            description="Multi supervisor team",
+            entry_point=entry,
+            members=[m1, m2, m3],
+        )
+        sups = team.supervisors
+        sup_names = {s.config.name for s in sups}
+        assert sup_names == {"m1", "m2", "m3"}
+        assert len(sups) == 3
 
 
 class TestTeamCardSerialization:
@@ -237,9 +286,9 @@ class TestTeamCardSerialization:
         dumped = team.model_dump()
         restored = TeamCard.model_validate(dumped)
         assert set(restored.agent_cards.keys()) == {"root", "l1", "l2", "l3"}
-        # Verify supervisors preserved (only members with subordinates)
+        # Verify supervisors preserved (first-layer members only)
         sup_names = {s.config.name for s in restored.supervisors}
-        assert sup_names == {"l1", "l2"}
+        assert sup_names == {"l1"}
 
     def test_routes_to_preserved_through_serialization(self) -> None:
         """routes_to on AgentCards within the tree survive round-trip."""

--- a/tests/models/test_team_runtime.py
+++ b/tests/models/test_team_runtime.py
@@ -184,6 +184,11 @@ class TestTeamRuntimeMessaging:
         call_addrs = {call.args[0] for call in runtime._entry_proxy.send.call_args_list}
         assert call_addrs == {sup1, sup2, sup3}
         assert runtime.entry_addr not in call_addrs
+        # Verify all messages carry the correct content
+        for call in runtime._entry_proxy.send.call_args_list:
+            msg = call.args[1]
+            assert isinstance(msg, UserMessage)
+            assert msg.content == "multi"
 
     def test_send_to_looks_up_agent(self) -> None:
         """AC6: send_to() looks up agent via orchestrator proxy."""

--- a/tests/models/test_team_runtime.py
+++ b/tests/models/test_team_runtime.py
@@ -131,8 +131,8 @@ class TestTeamRuntimeSerialization:
 class TestTeamRuntimeMessaging:
     """AC 5, 6: send() and send_to() messaging facade."""
 
-    def test_send_broadcasts_to_entry_and_all_supervisors(self) -> None:
-        """AC5: send() routes through entry proxy to entry agent and each supervisor."""
+    def test_send_broadcasts_to_supervisors_only(self) -> None:
+        """AC5: send() routes through entry proxy to supervisors only, not entry."""
         sup_addr_1 = make_stub_addr("supervisor-1")
         sup_addr_2 = make_stub_addr("supervisor-2")
         runtime = make_team_runtime(
@@ -140,25 +140,50 @@ class TestTeamRuntimeMessaging:
             supervisor_addrs={"sup1": sup_addr_1, "sup2": sup_addr_2},
         )
         runtime.send("hello")
-        # entry agent + 2 supervisors = 3 calls
-        assert runtime._entry_proxy.send.call_count == 3
+        # 2 supervisors only (entry does NOT receive)
+        assert runtime._entry_proxy.send.call_count == 2
         call_addrs = {call.args[0] for call in runtime._entry_proxy.send.call_args_list}
-        assert call_addrs == {runtime.entry_addr, sup_addr_1, sup_addr_2}
+        assert call_addrs == {sup_addr_1, sup_addr_2}
+        assert runtime.entry_addr not in call_addrs
         # Verify all messages are UserMessage with correct content
         for call in runtime._entry_proxy.send.call_args_list:
             msg = call.args[1]
             assert isinstance(msg, UserMessage)
             assert msg.content == "hello"
 
-    def test_send_with_empty_supervisors_sends_to_entry(self) -> None:
-        """AC5: send() with no supervisors still sends to entry agent."""
+    def test_send_with_empty_supervisors_is_noop(self) -> None:
+        """AC5: send() with no supervisors is a no-op (no recipients)."""
         runtime = make_team_runtime(message_types=[UserMessage])
         runtime.send("hello")
-        runtime._entry_proxy.send.assert_called_once()
-        call_args = runtime._entry_proxy.send.call_args
-        assert call_args.args[0] is runtime.entry_addr
-        assert isinstance(call_args.args[1], UserMessage)
-        assert call_args.args[1].content == "hello"
+        assert runtime._entry_proxy.send.call_count == 0
+
+    def test_send_does_not_send_to_entry_addr(self) -> None:
+        """send() never sends to entry_addr, only to supervisor addrs."""
+        sup_addr = make_stub_addr("supervisor")
+        runtime = make_team_runtime(
+            message_types=[UserMessage],
+            supervisor_addrs={"sup": sup_addr},
+        )
+        runtime.send("test")
+        assert runtime._entry_proxy.send.call_count == 1
+        call_addr = runtime._entry_proxy.send.call_args.args[0]
+        assert call_addr is sup_addr
+        assert call_addr is not runtime.entry_addr
+
+    def test_send_routes_to_multiple_supervisors(self) -> None:
+        """send() routes to all supervisors, entry does not receive."""
+        sup1 = make_stub_addr("sup1")
+        sup2 = make_stub_addr("sup2")
+        sup3 = make_stub_addr("sup3")
+        runtime = make_team_runtime(
+            message_types=[UserMessage],
+            supervisor_addrs={"s1": sup1, "s2": sup2, "s3": sup3},
+        )
+        runtime.send("multi")
+        assert runtime._entry_proxy.send.call_count == 3
+        call_addrs = {call.args[0] for call in runtime._entry_proxy.send.call_args_list}
+        assert call_addrs == {sup1, sup2, sup3}
+        assert runtime.entry_addr not in call_addrs
 
     def test_send_to_looks_up_agent(self) -> None:
         """AC6: send_to() looks up agent via orchestrator proxy."""

--- a/tests/services/test_factory.py
+++ b/tests/services/test_factory.py
@@ -259,16 +259,18 @@ class TestTeamFactoryBuild:
         assert runtime.orchestrator_addr.is_alive()
 
     def test_supervisor_addrs_populated(self, actor_system: ActorSystem) -> None:
-        """Supervisor addresses are populated for members with subordinates."""
+        """Supervisor addresses are populated for first-layer members."""
         worker = _make_member("worker", "Worker")
-        ep = _make_member("lead", "Lead", members=[worker])
-        tc = _make_team_card(entry_point=ep)
+        supervisor = _make_member("supervisor", "Supervisor", members=[worker])
+        tc = _make_team_card(members=[supervisor])
 
         runtime = TeamFactory.build(tc, actor_system)
 
-        # lead has subordinates, so it's a supervisor
-        assert "lead" in runtime.supervisor_addrs
-        assert runtime.supervisor_addrs["lead"] == runtime.addrs["lead"]
+        # supervisor is a first-layer member, so it's in supervisor_addrs
+        assert "supervisor" in runtime.supervisor_addrs
+        assert runtime.supervisor_addrs["supervisor"] == runtime.addrs["supervisor"]
+        # entry point (lead) is NOT in supervisor_addrs
+        assert "lead" not in runtime.supervisor_addrs
 
     def test_entry_point_headcount_gt1_raises(self, actor_system: ActorSystem) -> None:
         """Entry point with headcount > 1 raises ValueError."""

--- a/tests/services/test_restorer.py
+++ b/tests/services/test_restorer.py
@@ -370,18 +370,20 @@ class TestTeamRestorerRestore:
         actor_system: ActorSystem,
         event_store: InMemoryEventStore,
     ) -> None:
-        """AC 13: TeamRuntime has supervisor_addrs populated."""
+        """AC 13: TeamRuntime has supervisor_addrs populated for first-layer members."""
         worker = _make_member("worker", "Worker")
-        ep = _make_member("lead", "Lead", members=[worker])
-        tc = _make_team_card(entry_point=ep)
+        supervisor = _make_member("supervisor", "Supervisor", members=[worker])
+        tc = _make_team_card(members=[supervisor])
 
         team_id, process = _populate_stopped_team(event_store, tc)
 
         restorer = TeamRestorer(actor_system, event_store)
         runtime, _ = restorer.restore(process)
 
-        # lead is a supervisor (has subordinates)
-        assert "lead" in runtime.supervisor_addrs
+        # supervisor is a first-layer member, so it's in supervisor_addrs
+        assert "supervisor" in runtime.supervisor_addrs
+        # entry point (lead) is NOT in supervisor_addrs
+        assert "lead" not in runtime.supervisor_addrs
 
     def test_restore_with_agent_state_snapshots(
         self,


### PR DESCRIPTION
## Summary

- Rewrites `TeamCard.supervisors` to return first-layer `members` only (entry point excluded, deep hierarchy excluded)
- Deletes dead `_collect_supervisors()` static method
- Removes self-send line and redundant guard from `TeamRuntime.send()` -- entry point no longer receives its own outbound messages
- Updates 6 existing tests and adds 5 new tests covering deep hierarchy exclusion, multi-member supervisors, and send-to-entry prevention

Closes #64

## Test plan

- [x] All 230 tests pass (`pytest packages/akgentic-team/tests/`)
- [x] ruff check clean
- [x] mypy strict clean
- [x] Changes scoped to `packages/akgentic-team/` only