### PR TITLE
Replace subscriber_factory with pre-instantiated subscribers

### DIFF
--- a/src/akgentic/team/manager.py
+++ b/src/akgentic/team/manager.py
@@ -44,8 +44,11 @@ class TeamManager:
             service_registry: Service discovery registry. Defaults to
                 NullServiceRegistry for single-process mode.
             subscribers: Pre-instantiated list of long-lived EventSubscribers
-                shared across all teams. PersistenceSubscriber is per-team
-                and created internally by TeamManager.
+                shared across all teams. These must be thread-safe since
+                different teams' orchestrators may call on_message()
+                concurrently from different actor threads.
+                PersistenceSubscriber is per-team and created internally
+                by TeamManager.
             instance_id: Worker instance identifier. Auto-generated if None.
         """
         self._actor_system = actor_system
@@ -201,9 +204,10 @@ class TeamManager:
 
         all_subs: list[EventSubscriber] = [persistence_sub] + list(self._shared_subscribers)
 
-        runtime = restorer.restore(process, subscribers=all_subs)
-
-        persistence_sub.set_restoring(False)
+        try:
+            runtime = restorer.restore(process, subscribers=all_subs)
+        finally:
+            persistence_sub.set_restoring(False)
 
         # Track runtime and subscribers for stop_team
         self._runtimes[team_id] = runtime

--- a/src/akgentic/team/manager.py
+++ b/src/akgentic/team/manager.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import uuid
-from collections.abc import Callable
 from datetime import UTC, datetime
 
 from akgentic.core.actor_system_impl import ActorSystem
@@ -34,7 +33,7 @@ class TeamManager:
         actor_system: ActorSystem,
         event_store: EventStore,
         service_registry: ServiceRegistry | None = None,
-        subscriber_factory: Callable[[uuid.UUID], list[EventSubscriber]] | None = None,
+        subscribers: list[EventSubscriber] | None = None,
         instance_id: uuid.UUID | None = None,
     ) -> None:
         """Initialize TeamManager with injected dependencies.
@@ -44,17 +43,18 @@ class TeamManager:
             event_store: Persistence backend for team state and events.
             service_registry: Service discovery registry. Defaults to
                 NullServiceRegistry for single-process mode.
-            subscriber_factory: Optional callable that receives a team_id
-                and returns additional EventSubscribers to register.
+            subscribers: Pre-instantiated list of long-lived EventSubscribers
+                shared across all teams. PersistenceSubscriber is per-team
+                and created internally by TeamManager.
             instance_id: Worker instance identifier. Auto-generated if None.
         """
         self._actor_system = actor_system
         self._event_store = event_store
         self._service_registry = service_registry or NullServiceRegistry()
-        self._subscriber_factory = subscriber_factory
+        self._shared_subscribers = subscribers or []
         self._instance_id = instance_id or uuid.uuid4()
         self._runtimes: dict[uuid.UUID, TeamRuntime] = {}
-        self._subscribers: dict[uuid.UUID, list[EventSubscriber]] = {}
+        self._team_subscribers: dict[uuid.UUID, list[EventSubscriber]] = {}
 
     def create_team(
         self,
@@ -65,7 +65,7 @@ class TeamManager:
         """Create and start a new team from a TeamCard.
 
         Pre-generates a team_id, creates a PersistenceSubscriber (always first),
-        appends any subscriber_factory results, then delegates to TeamFactory.build.
+        appends shared subscribers, then delegates to TeamFactory.build.
         On successful build, persists a Process with RUNNING status and registers
         the team with the ServiceRegistry.
 
@@ -88,18 +88,14 @@ class TeamManager:
 
         # Build subscriber list: PersistenceSubscriber always first
         persistence_sub = PersistenceSubscriber(team_id, self._event_store)
-        subscribers: list[EventSubscriber] = [persistence_sub]
-        if self._subscriber_factory is not None:
-            subscribers.extend(self._subscriber_factory(team_id))
+        subscribers: list[EventSubscriber] = [persistence_sub] + list(self._shared_subscribers)
 
         # Build the team — if this raises, no Process is persisted
-        runtime = TeamFactory.build(
-            team_card, self._actor_system, subscribers, team_id=team_id
-        )
+        runtime = TeamFactory.build(team_card, self._actor_system, subscribers, team_id=team_id)
 
         # Track runtime and subscribers for stop_team
         self._runtimes[team_id] = runtime
-        self._subscribers[team_id] = subscribers
+        self._team_subscribers[team_id] = subscribers
 
         # Persist Process metadata
         now = datetime.now(UTC)
@@ -150,10 +146,7 @@ class TeamManager:
             raise ValueError(msg)
         if process.status == TeamStatus.RUNNING:
             logger.warning("Delete rejected: team %s is currently running", team_id)
-            msg = (
-                f"Cannot delete team {team_id}: "
-                f"team is currently running. Stop it first."
-            )
+            msg = f"Cannot delete team {team_id}: team is currently running. Stop it first."
             raise ValueError(msg)
         if process.status == TeamStatus.DELETED:
             logger.warning("Delete rejected: team %s is already deleted", team_id)
@@ -167,7 +160,7 @@ class TeamManager:
 
         # Cleanup runtime tracking
         self._runtimes.pop(team_id, None)
-        self._subscribers.pop(team_id, None)
+        self._team_subscribers.pop(team_id, None)
 
     def resume_team(self, team_id: uuid.UUID) -> TeamRuntime:
         """Resume a stopped team by restoring from persisted EventStore data.
@@ -200,24 +193,21 @@ class TeamManager:
             msg = f"Cannot resume team {team_id}: team has been deleted"
             raise ValueError(msg)
 
-        restorer = TeamRestorer(
-            self._actor_system, self._event_store, self._subscriber_factory
-        )
-        runtime, persistence_sub = restorer.restore(process)
+        restorer = TeamRestorer(self._actor_system, self._event_store)
 
-        # NOTE: The restorer already called subscriber_factory and registered
-        # those subscriber instances with the orchestrator.  We call the
-        # factory again here to build a tracking list for stop_team.  These
-        # are different objects, so unsubscribe() may be a no-op for factory
-        # subscribers — but this is harmless because stop_team tears down
-        # actors immediately after unsubscribe.
-        subscribers: list[EventSubscriber] = [persistence_sub]
-        if self._subscriber_factory is not None:
-            subscribers.extend(self._subscriber_factory(team_id))
+        # Create PersistenceSubscriber once — passed to restorer and tracked for stop
+        persistence_sub = PersistenceSubscriber(team_id, self._event_store)
+        persistence_sub.set_restoring(True)
+
+        all_subs: list[EventSubscriber] = [persistence_sub] + list(self._shared_subscribers)
+
+        runtime = restorer.restore(process, subscribers=all_subs)
+
+        persistence_sub.set_restoring(False)
 
         # Track runtime and subscribers for stop_team
         self._runtimes[team_id] = runtime
-        self._subscribers[team_id] = subscribers
+        self._team_subscribers[team_id] = all_subs
 
         now = datetime.now(UTC)
         updated_process = Process(
@@ -251,7 +241,7 @@ class TeamManager:
             orchestrator_proxy: Orchestrator = self._actor_system.proxy_ask(
                 runtime.orchestrator_addr, Orchestrator
             )
-            for sub in self._subscribers.get(team_id, []):
+            for sub in self._team_subscribers.get(team_id, []):
                 try:
                     orchestrator_proxy.unsubscribe(sub)
                 except Exception:
@@ -263,8 +253,7 @@ class TeamManager:
                     )
         except Exception:
             logger.warning(
-                "Failed to get orchestrator proxy for team %s — "
-                "skipping unsubscribe",
+                "Failed to get orchestrator proxy for team %s — skipping unsubscribe",
                 team_id,
                 exc_info=True,
             )
@@ -350,6 +339,6 @@ class TeamManager:
 
         # Cleanup runtime tracking
         self._runtimes.pop(team_id, None)
-        self._subscribers.pop(team_id, None)
+        self._team_subscribers.pop(team_id, None)
 
         logger.info("Team %s stopped successfully", team_id)

--- a/src/akgentic/team/restorer.py
+++ b/src/akgentic/team/restorer.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import uuid
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -30,7 +29,6 @@ from akgentic.team.models import (
     TeamRuntime,
 )
 from akgentic.team.ports import EventStore
-from akgentic.team.subscriber import PersistenceSubscriber
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +39,6 @@ class _RebuildResult:
 
     orchestrator_addr: ActorAddress
     orchestrator_proxy: Orchestrator
-    persistence_sub: PersistenceSubscriber
     addrs: dict[str, ActorAddress] = field(default_factory=dict)
 
 
@@ -61,30 +58,32 @@ class TeamRestorer:
         self,
         actor_system: ActorSystem,
         event_store: EventStore,
-        subscriber_factory: Callable[[uuid.UUID], list[EventSubscriber]] | None = None,
     ) -> None:
         """Initialize the restorer with injected dependencies.
 
         Args:
             actor_system: The actor system to host rebuilt actors.
             event_store: Persistence backend containing events and states.
-            subscriber_factory: Optional callable returning additional
-                EventSubscribers to register with the orchestrator.
         """
         self._actor_system = actor_system
         self._event_store = event_store
-        self._subscriber_factory = subscriber_factory
 
-    def restore(self, process: Process) -> tuple[TeamRuntime, PersistenceSubscriber]:
+    def restore(
+        self,
+        process: Process,
+        subscribers: list[EventSubscriber] | None = None,
+    ) -> TeamRuntime:
         """Execute the 3-phase restore protocol.
 
         Args:
             process: The Process record of the STOPPED team to restore.
+            subscribers: Pre-instantiated subscribers to register with the
+                orchestrator. Created by TeamManager (includes PersistenceSubscriber
+                and shared subscribers). No subscriber creation happens inside
+                the restorer.
 
         Returns:
-            A tuple of (TeamRuntime, PersistenceSubscriber) for the rebuilt
-            team. TeamManager needs PersistenceSubscriber for restoring-flag
-            management.
+            A TeamRuntime for the rebuilt team.
 
         Raises:
             Exception: If any phase fails, all spawned actors are torn down
@@ -98,7 +97,9 @@ class TeamRestorer:
             events, agent_states = self._load_persisted_data(team_id)
 
             # Phase 2: Rebuild agents from event log
-            result = self._rebuild_agents(process, events, agent_states, spawned_addrs)
+            result = self._rebuild_agents(
+                process, events, agent_states, spawned_addrs, subscribers or []
+            )
 
             # Build address map: agent_id → live ActorAddress
             addr_map: dict[uuid.UUID, ActorAddress] = {
@@ -111,7 +112,6 @@ class TeamRestorer:
             self._replay_events(
                 team_id,
                 result.orchestrator_proxy,
-                result.persistence_sub,
                 events,
                 addr_map,
             )
@@ -126,7 +126,7 @@ class TeamRestorer:
             )
 
             logger.info("Team %s restored successfully", team_id)
-            return runtime, result.persistence_sub
+            return runtime
 
         except Exception:
             # Rollback: stop all spawned actors in reverse order
@@ -291,11 +291,12 @@ class TeamRestorer:
         events: list[PersistedEvent],
         agent_states: list[AgentStateSnapshot],
         spawned_addrs: list[ActorAddress],
+        subscribers: list[EventSubscriber],
     ) -> _RebuildResult:
         """Phase 2: Rebuild agents from the event log.
 
         Determines live agents via StartMessage/StopMessage filtering,
-        rebuilds the Orchestrator first, registers subscribers, spawns
+        rebuilds the Orchestrator first, registers passed subscribers, spawns
         remaining agents, restores agent states, and registers agent profiles.
 
         Args:
@@ -304,10 +305,12 @@ class TeamRestorer:
             agent_states: Agent state snapshots from Phase 1.
             spawned_addrs: Shared list for rollback tracking; spawned actors
                 are appended here so the caller can clean up on failure.
+            subscribers: Pre-instantiated subscribers to register with the
+                orchestrator. Passed from restore() caller.
 
         Returns:
             A _RebuildResult containing orchestrator address, proxy,
-            persistence subscriber, and agent address map.
+            and agent address map.
         """
         team_id = process.team_id
         logger.info("Restoring team %s: phase 2 -- rebuilding agents", team_id)
@@ -324,15 +327,7 @@ class TeamRestorer:
             orchestrator_start, team_id, spawned_addrs
         )
 
-        # 2c. Register subscribers (without startup replay — phase 3 handles
-        #      event replay, so TeamFactory._register_subscribers is not used here)
-        persistence_sub = PersistenceSubscriber(team_id, self._event_store)
-        persistence_sub.set_restoring(True)
-
-        subscribers: list[EventSubscriber] = [persistence_sub]
-        if self._subscriber_factory is not None:
-            subscribers.extend(self._subscriber_factory(team_id))
-
+        # 2c. Register passed subscribers directly (no internal creation)
         for sub in subscribers:
             orchestrator_proxy.subscribe(sub)
 
@@ -356,7 +351,6 @@ class TeamRestorer:
         return _RebuildResult(
             orchestrator_addr=orchestrator_addr,
             orchestrator_proxy=orchestrator_proxy,
-            persistence_sub=persistence_sub,
             addrs=addrs,
         )
 
@@ -364,7 +358,6 @@ class TeamRestorer:
         self,
         team_id: uuid.UUID,
         orchestrator_proxy: Orchestrator,
-        persistence_sub: PersistenceSubscriber,
         events: list[PersistedEvent],
         addr_map: dict[uuid.UUID, ActorAddress],
     ) -> None:
@@ -374,10 +367,12 @@ class TeamRestorer:
         before replay so that ``get_team()`` returns live ``ActorAddressImpl``
         refs instead of stale proxies.
 
+        The caller is responsible for toggling PersistenceSubscriber.set_restoring()
+        before and after calling restore().
+
         Args:
             team_id: The team identifier (used for logging context).
             orchestrator_proxy: Proxy to the restored orchestrator actor.
-            persistence_sub: The persistence subscriber to toggle restoring flag.
             events: Sorted persisted events to replay.
             addr_map: Mapping of agent_id to live ActorAddress for proxy resolution.
         """
@@ -391,7 +386,6 @@ class TeamRestorer:
             orchestrator_proxy.restore_message(pe.event)
 
         orchestrator_proxy.end_restoration()
-        persistence_sub.set_restoring(False)
 
     def _resolve_event_addresses(
         self,

--- a/tests/integration/test_llm_lifecycle.py
+++ b/tests/integration/test_llm_lifecycle.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import os
 import time
-import uuid
 from pathlib import Path
 from typing import Any
 
@@ -189,13 +188,10 @@ def llm_team_infrastructure(tmp_path: Path) -> dict[str, Any]:
     event_store = YamlEventStore(tmp_path / "team-data")
     collector = EventCollector()
 
-    def subscriber_factory(_team_id: uuid.UUID) -> list[EventCollector]:
-        return [collector]
-
     team_manager = TeamManager(
         actor_system=actor_system,
         event_store=event_store,
-        subscriber_factory=subscriber_factory,
+        subscribers=[collector],
     )
 
     yield {

--- a/tests/services/test_manager.py
+++ b/tests/services/test_manager.py
@@ -616,7 +616,7 @@ class TestTeamManagerResume:
         actor_system: ActorSystem,
         event_store: InMemoryEventStore,
     ) -> None:
-        """AC 5,6: stop_team after resume correctly unsubscribes the same subscriber objects."""
+        """AC 5,6: stop_team after resume cleans up tracking and transitions to STOPPED."""
         recording = RecordingSubscriber()
 
         mgr = TeamManager(

--- a/tests/services/test_manager.py
+++ b/tests/services/test_manager.py
@@ -167,21 +167,18 @@ class TestTeamManagerCreate:
         assert before - timedelta(seconds=1) <= process.created_at <= after + timedelta(seconds=1)
         assert process.created_at == process.updated_at
 
-    def test_create_team_with_subscriber_factory(
+    def test_create_team_with_shared_subscribers(
         self,
         actor_system: ActorSystem,
         event_store: InMemoryEventStore,
     ) -> None:
-        """AC 2,3: subscriber_factory results appended after PersistenceSubscriber."""
+        """AC 2,3: shared subscribers appended after PersistenceSubscriber."""
         recording = RecordingSubscriber()
-
-        def factory(team_id: uuid.UUID) -> list[EventSubscriber]:
-            return [recording]
 
         mgr = TeamManager(
             actor_system=actor_system,
             event_store=event_store,
-            subscriber_factory=factory,
+            subscribers=[recording],
         )
         tc = _make_team_card()
         runtime = mgr.create_team(tc)
@@ -582,6 +579,70 @@ class TestTeamManagerResume:
 
         mock_registry.register_team.assert_called_once_with(instance_id, team_id)
 
+    def test_resume_no_duplicate_subscriber_creation(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 3,6: resume_team creates each subscriber exactly once (no double-creation)."""
+        recording = RecordingSubscriber()
+
+        mgr = TeamManager(
+            actor_system=actor_system,
+            event_store=event_store,
+            subscribers=[recording],
+        )
+        team_id = _create_and_stop_team(mgr, event_store)
+
+        mgr.resume_team(team_id)
+
+        # The shared subscriber should appear exactly once in per-team tracking
+        team_subs = mgr._team_subscribers[team_id]
+        shared_count = sum(1 for s in team_subs if s is recording)
+        assert shared_count == 1, (
+            f"Shared subscriber appeared {shared_count} times, expected 1"
+        )
+
+        # PersistenceSubscriber should also appear exactly once
+        from akgentic.team.subscriber import PersistenceSubscriber
+
+        persistence_count = sum(1 for s in team_subs if isinstance(s, PersistenceSubscriber))
+        assert persistence_count == 1, (
+            f"PersistenceSubscriber appeared {persistence_count} times, expected 1"
+        )
+
+    def test_stop_after_resume_unsubscribes_same_objects(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 5,6: stop_team after resume correctly unsubscribes the same subscriber objects."""
+        recording = RecordingSubscriber()
+
+        mgr = TeamManager(
+            actor_system=actor_system,
+            event_store=event_store,
+            subscribers=[recording],
+        )
+        team_id = _create_and_stop_team(mgr, event_store)
+
+        mgr.resume_team(team_id)
+
+        # Capture the tracked subscriber objects before stop
+        team_subs = list(mgr._team_subscribers[team_id])
+        assert len(team_subs) == 2  # PersistenceSubscriber + recording
+
+        mgr.stop_team(team_id)
+
+        # After stop, tracking should be cleaned up
+        assert team_id not in mgr._team_subscribers
+        assert team_id not in mgr._runtimes
+
+        # Process should be STOPPED
+        process = event_store.load_team(team_id)
+        assert process is not None
+        assert process.status == TeamStatus.STOPPED
+
 
 # ---------------------------------------------------------------------------
 # Tests: delete data purge verification
@@ -683,27 +744,24 @@ class TestTeamManagerStop:
         """AC 1: stop_team unsubscribes all subscribers from orchestrator."""
         recording = RecordingSubscriber()
 
-        def factory(team_id: uuid.UUID) -> list[EventSubscriber]:
-            return [recording]
-
         mgr = TeamManager(
             actor_system=actor_system,
             event_store=event_store,
-            subscriber_factory=factory,
+            subscribers=[recording],
         )
         tc = _make_team_card()
         runtime = mgr.create_team(tc)
         team_id = runtime.id
 
         # Verify subscribers are tracked before stop
-        assert team_id in mgr._subscribers
-        assert len(mgr._subscribers[team_id]) == 2  # PersistenceSubscriber + recording
+        assert team_id in mgr._team_subscribers
+        assert len(mgr._team_subscribers[team_id]) == 2  # PersistenceSubscriber + recording
 
         mgr.stop_team(team_id)
 
         # After stop, actors are dead and tracking is cleaned up
         assert not runtime.orchestrator_addr.is_alive()
-        assert team_id not in mgr._subscribers
+        assert team_id not in mgr._team_subscribers
         assert team_id not in mgr._runtimes
 
         # Process should be STOPPED
@@ -806,7 +864,7 @@ class TestTeamManagerStop:
 
         # Simulate manager restart: clear runtime tracking
         manager._runtimes.clear()
-        manager._subscribers.clear()
+        manager._team_subscribers.clear()
 
         # stop_team should still succeed — update state and deregister
         manager.stop_team(team_id)

--- a/tests/services/test_restorer.py
+++ b/tests/services/test_restorer.py
@@ -27,7 +27,6 @@ from akgentic.team.models import (
     TeamStatus,
 )
 from akgentic.team.restorer import TeamRestorer
-from akgentic.team.subscriber import PersistenceSubscriber
 from tests.services.conftest import InMemoryEventStore
 
 # ---------------------------------------------------------------------------
@@ -279,14 +278,13 @@ class TestTeamRestorerRestore:
         team_id, process = _populate_stopped_team(event_store)
 
         restorer = TeamRestorer(actor_system, event_store)
-        runtime, persistence_sub = restorer.restore(process)
+        runtime = restorer.restore(process)
 
         assert isinstance(runtime, TeamRuntime)
         assert runtime.id == team_id
         assert runtime.orchestrator_addr.is_alive()
         assert runtime.entry_addr.is_alive()
         assert "lead" in runtime.addrs
-        assert isinstance(persistence_sub, PersistenceSubscriber)
 
     def test_restore_with_multiple_agents(
         self,
@@ -300,7 +298,7 @@ class TestTeamRestorerRestore:
         team_id, process = _populate_stopped_team(event_store, tc)
 
         restorer = TeamRestorer(actor_system, event_store)
-        runtime, _ = restorer.restore(process)
+        runtime = restorer.restore(process)
 
         assert "lead" in runtime.addrs
         assert "worker" in runtime.addrs
@@ -319,7 +317,7 @@ class TestTeamRestorerRestore:
         team_id, process = _populate_stopped_team(event_store, tc)
 
         restorer = TeamRestorer(actor_system, event_store)
-        runtime, _ = restorer.restore(process)
+        runtime = restorer.restore(process)
 
         # Orchestrator should be alive and functional
         assert runtime.orchestrator_addr.is_alive()
@@ -340,7 +338,7 @@ class TestTeamRestorerRestore:
         assert events_before > 0
 
         restorer = TeamRestorer(actor_system, event_store)
-        runtime, _ = restorer.restore(process)
+        runtime = restorer.restore(process)
 
         # Team is functional after restore
         assert runtime.orchestrator_addr.is_alive()
@@ -357,7 +355,7 @@ class TestTeamRestorerRestore:
         team_id, process = _populate_stopped_team(event_store, tc)
 
         restorer = TeamRestorer(actor_system, event_store)
-        runtime, _ = restorer.restore(process)
+        runtime = restorer.restore(process)
 
         team = runtime.orchestrator_proxy.get_team()
         team_names = {addr.name for addr in team}
@@ -378,7 +376,7 @@ class TestTeamRestorerRestore:
         team_id, process = _populate_stopped_team(event_store, tc)
 
         restorer = TeamRestorer(actor_system, event_store)
-        runtime, _ = restorer.restore(process)
+        runtime = restorer.restore(process)
 
         # lead is a supervisor (has subordinates)
         assert "lead" in runtime.supervisor_addrs
@@ -426,7 +424,7 @@ class TestTeamRestorerRestore:
             return proxy
 
         with mock_patch.object(actor_system, "proxy_ask", side_effect=tracking_proxy_ask):
-            runtime, _ = restorer.restore(process)
+            runtime = restorer.restore(process)
 
         # Verify init_state was called for the agent with snapshot
         assert "lead" in init_state_calls
@@ -446,7 +444,7 @@ class TestTeamRestorerRestore:
         team_id, process = _populate_stopped_team(event_store, tc)
 
         restorer = TeamRestorer(actor_system, event_store)
-        runtime, _ = restorer.restore(process)
+        runtime = restorer.restore(process)
 
         catalog = runtime.orchestrator_proxy.get_agent_catalog()
         roles = {c.role for c in catalog}
@@ -466,7 +464,7 @@ class TestTeamRestorerRestore:
         team_id, process = _populate_stopped_team(event_store, tc)
 
         restorer = TeamRestorer(actor_system, event_store)
-        runtime, _ = restorer.restore(process)
+        runtime = restorer.restore(process)
 
         catalog = runtime.orchestrator_proxy.get_agent_catalog()
         assert len(catalog) == 0
@@ -495,7 +493,7 @@ class TestTeamRestorerAgentFiltering:
         )
 
         restorer = TeamRestorer(actor_system, event_store)
-        runtime, _ = restorer.restore(process)
+        runtime = restorer.restore(process)
 
         # Fired agent should NOT be in the restored team
         assert "fired-agent" not in runtime.addrs
@@ -521,7 +519,7 @@ class TestTeamRestorerAgentFiltering:
         )
 
         restorer = TeamRestorer(actor_system, event_store)
-        runtime, _ = restorer.restore(process)
+        runtime = restorer.restore(process)
 
         assert "fired1" not in runtime.addrs
         assert "fired2" not in runtime.addrs
@@ -541,14 +539,25 @@ class TestTeamRestorerRestoringFlag:
         actor_system: ActorSystem,
         event_store: InMemoryEventStore,
     ) -> None:
-        """AC 12: PersistenceSubscriber restoring=True before replay, False after."""
+        """AC 12: PersistenceSubscriber restoring=True before replay, False after.
+
+        The caller (TeamManager) is now responsible for toggling the restoring flag.
+        This test validates the pattern: set_restoring(True) before restore(),
+        set_restoring(False) after restore().
+        """
+        from akgentic.team.subscriber import PersistenceSubscriber
+
         tc = _make_team_card()
         team_id, process = _populate_stopped_team(event_store, tc)
 
-        restorer = TeamRestorer(actor_system, event_store)
-        runtime, persistence_sub = restorer.restore(process)
+        persistence_sub = PersistenceSubscriber(team_id, event_store)
+        persistence_sub.set_restoring(True)
 
-        # After restore, restoring flag should be False
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime = restorer.restore(process, subscribers=[persistence_sub])
+
+        # Caller sets restoring=False after restore (simulating TeamManager)
+        persistence_sub.set_restoring(False)
         assert persistence_sub._restoring is False
 
     def test_no_duplicate_events_during_replay(
@@ -557,14 +566,21 @@ class TestTeamRestorerRestoringFlag:
         event_store: InMemoryEventStore,
     ) -> None:
         """AC 12: Replayed events are not re-persisted (restoring flag prevents it)."""
+        from akgentic.team.subscriber import PersistenceSubscriber
+
         tc = _make_team_card()
         team_id, process = _populate_stopped_team(event_store, tc)
 
         original_events = event_store.load_events(team_id)
         original_sequences = {e.sequence for e in original_events}
 
+        persistence_sub = PersistenceSubscriber(team_id, event_store)
+        persistence_sub.set_restoring(True)
+
         restorer = TeamRestorer(actor_system, event_store)
-        runtime, _ = restorer.restore(process)
+        runtime = restorer.restore(process, subscribers=[persistence_sub])
+
+        persistence_sub.set_restoring(False)
 
         # Check no events with original sequences were duplicated
         all_events = event_store.load_events(team_id)
@@ -613,22 +629,19 @@ class TestTeamRestorerRollback:
             f"Rollback failed: {actors_after - actors_before} actor(s) leaked"
         )
 
-    def test_subscriber_factory_called(
+    def test_subscribers_registered_with_orchestrator(
         self,
         actor_system: ActorSystem,
         event_store: InMemoryEventStore,
     ) -> None:
-        """subscriber_factory results registered with orchestrator."""
+        """Pre-instantiated subscribers are registered with orchestrator."""
         tc = _make_team_card()
         team_id, process = _populate_stopped_team(event_store, tc)
 
         recording = RecordingSubscriber()
 
-        def factory(tid: uuid.UUID) -> list[EventSubscriber]:
-            return [recording]
-
-        restorer = TeamRestorer(actor_system, event_store, subscriber_factory=factory)
-        runtime, _ = restorer.restore(process)
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime = restorer.restore(process, subscribers=[recording])
 
         # Recording subscriber should have received replayed events
         assert len(recording.messages) > 0
@@ -658,7 +671,7 @@ class TestRestorerHierarchyPropagation:
         team_id, process = _populate_stopped_team(event_store, tc)
 
         restorer = TeamRestorer(actor_system, event_store)
-        runtime, _ = restorer.restore(process)
+        runtime = restorer.restore(process)
 
         for name, addr in runtime.addrs.items():
             proxy: Akgent[Any, Any] = actor_system.proxy_ask(addr, Akgent)
@@ -680,7 +693,7 @@ class TestRestorerHierarchyPropagation:
         team_id, process = _populate_stopped_team(event_store, tc)
 
         restorer = TeamRestorer(actor_system, event_store)
-        runtime, _ = restorer.restore(process)
+        runtime = restorer.restore(process)
 
         # All restored agents should have orchestrator as parent
         for name, addr in runtime.addrs.items():
@@ -715,7 +728,7 @@ class TestRestorerAddressResolution:
         team_id, process = _populate_stopped_team(event_store, tc)
 
         restorer = TeamRestorer(actor_system, event_store)
-        runtime, _ = restorer.restore(process)
+        runtime = restorer.restore(process)
 
         team = runtime.orchestrator_proxy.get_team()
         for addr in team:
@@ -741,7 +754,7 @@ class TestRestorerAddressResolution:
         team_id, process = _populate_stopped_team(event_store, tc)
 
         restorer = TeamRestorer(actor_system, event_store)
-        runtime, _ = restorer.restore(process)
+        runtime = restorer.restore(process)
 
         lead_addr = runtime.orchestrator_proxy.get_team_member("lead")
         assert lead_addr is not None
@@ -765,7 +778,7 @@ class TestRestorerAddressResolution:
         team_id, process = _populate_stopped_team(event_store, tc)
 
         restorer = TeamRestorer(actor_system, event_store)
-        runtime, _ = restorer.restore(process)
+        runtime = restorer.restore(process)
 
         # The entry agent should have a live address matching the spawned actor
         lead_from_roster = runtime.orchestrator_proxy.get_team_member("lead")
@@ -797,7 +810,7 @@ class TestRestorerProxySpawning:
         team_id, process = _populate_stopped_team(event_store, tc)
 
         restorer = TeamRestorer(actor_system, event_store)
-        runtime, _ = restorer.restore(process)
+        runtime = restorer.restore(process)
 
         team = runtime.orchestrator_proxy.get_team()
         team_names = {addr.name for addr in team}
@@ -818,7 +831,7 @@ class TestRestorerProxySpawning:
         team_id, process = _populate_stopped_team(event_store, tc)
 
         restorer = TeamRestorer(actor_system, event_store)
-        runtime, _ = restorer.restore(process)
+        runtime = restorer.restore(process)
 
         team = runtime.orchestrator_proxy.get_team()
         agent_ids = [addr.agent_id for addr in team]


### PR DESCRIPTION
## Summary

- Replace `subscriber_factory: Callable` with `subscribers: list[EventSubscriber] | None` in `TeamManager` and `TeamRestorer`
- Eliminate the double-creation bug in `resume_team()` where subscriber_factory was called in both `TeamRestorer._rebuild_agents()` and `TeamManager.resume_team()`, creating different object instances
- PersistenceSubscriber is now created once in TeamManager and passed to the restorer, ensuring same object identity for subscribe/unsubscribe
- Code review: added try/finally guard for `set_restoring(False)`, documented thread-safety requirement for shared subscribers

Closes #59