### PR TITLE
fix: unify set_restoring toggle for all subscribers during resume

### DIFF
--- a/src/akgentic/team/manager.py
+++ b/src/akgentic/team/manager.py
@@ -202,12 +202,21 @@ class TeamManager:
         persistence_sub = PersistenceSubscriber(team_id, self._event_store)
         persistence_sub.set_restoring(True)
 
+        # Toggle restoring guard on shared subscribers that support it
+        # (e.g. EventStreamSubscriber) to prevent replay flooding
+        for sub in self._shared_subscribers:
+            if hasattr(sub, "set_restoring"):
+                sub.set_restoring(True)
+
         all_subs: list[EventSubscriber] = [persistence_sub] + list(self._shared_subscribers)
 
         try:
             runtime = restorer.restore(process, subscribers=all_subs)
         finally:
             persistence_sub.set_restoring(False)
+            for sub in self._shared_subscribers:
+                if hasattr(sub, "set_restoring"):
+                    sub.set_restoring(False)
 
         # Track runtime and subscribers for stop_team
         self._runtimes[team_id] = runtime

--- a/src/akgentic/team/manager.py
+++ b/src/akgentic/team/manager.py
@@ -200,23 +200,18 @@ class TeamManager:
 
         # Create PersistenceSubscriber once — passed to restorer and tracked for stop
         persistence_sub = PersistenceSubscriber(team_id, self._event_store)
-        persistence_sub.set_restoring(True)
-
-        # Toggle restoring guard on shared subscribers that support it
-        # (e.g. EventStreamSubscriber) to prevent replay flooding
-        for sub in self._shared_subscribers:
-            if hasattr(sub, "set_restoring"):
-                sub.set_restoring(True)
-
         all_subs: list[EventSubscriber] = [persistence_sub] + list(self._shared_subscribers)
+
+        # Toggle restoring guard on all subscribers.
+        # Each subscriber decides independently whether to skip during restore.
+        for sub in all_subs:
+            sub.set_restoring(True)
 
         try:
             runtime = restorer.restore(process, subscribers=all_subs)
         finally:
-            persistence_sub.set_restoring(False)
-            for sub in self._shared_subscribers:
-                if hasattr(sub, "set_restoring"):
-                    sub.set_restoring(False)
+            for sub in all_subs:
+                sub.set_restoring(False)
 
         # Track runtime and subscribers for stop_team
         self._runtimes[team_id] = runtime


### PR DESCRIPTION
## Summary
- Unify `set_restoring()` toggle for all subscribers (including shared ones) during team resume
- Ensures shared subscribers correctly skip duplicate processing during event replay

## Related PRs (merge in order)
1. **akgentic-core** — b12consulting/akgentic-core#34
2. **akgentic-team** — b12consulting/akgentic-team#74 ← this PR
3. **akgentic-infra** — b12consulting/akgentic-infra#174
4. **akgentic-frontend** — b12consulting/akgentic-frontend#12