### PR TITLE
Replace Address stop() with Proxy-Based stop()

### DIFF
--- a/src/akgentic/team/factory.py
+++ b/src/akgentic/team/factory.py
@@ -128,10 +128,10 @@ class TeamFactory:
             )
 
         except Exception:
-            # Rollback: stop all already-spawned actors
+            # Rollback: stop all already-spawned actors via proxy API
             for addr in reversed(spawned_addrs):
                 try:
-                    addr.stop()
+                    actor_system.proxy_ask(addr, Akgent).stop()
                 except Exception:
                     logger.warning("Failed to stop actor during rollback: %s", addr)
             raise

--- a/src/akgentic/team/manager.py
+++ b/src/akgentic/team/manager.py
@@ -244,7 +244,9 @@ class TeamManager:
             team_id: The team identifier being stopped.
             runtime: The active TeamRuntime containing actor addresses.
         """
-        # Unsubscribe all tracked subscribers
+        # Unsubscribe all tracked subscribers and stop orchestrator via proxy.
+        # Using proxy_ask ensures Orchestrator.stop() is invoked (cancels timer,
+        # recursive child teardown) instead of bypassing via raw Pykka stop.
         try:
             orchestrator_proxy: Orchestrator = self._actor_system.proxy_ask(
                 runtime.orchestrator_addr, Orchestrator
@@ -259,33 +261,13 @@ class TeamManager:
                         team_id,
                         exc_info=True,
                     )
+            orchestrator_proxy.stop()
         except Exception:
             logger.warning(
-                "Failed to get orchestrator proxy for team %s — skipping unsubscribe",
+                "Failed to teardown orchestrator for team %s",
                 team_id,
                 exc_info=True,
             )
-
-        # Tear down actors: orchestrator first, then remaining agents
-        try:
-            runtime.orchestrator_addr.stop()
-        except Exception:
-            logger.warning(
-                "Failed to stop orchestrator for team %s",
-                team_id,
-                exc_info=True,
-            )
-
-        for name, addr in runtime.addrs.items():
-            try:
-                addr.stop()
-            except Exception:
-                logger.warning(
-                    "Failed to stop agent '%s' for team %s",
-                    name,
-                    team_id,
-                    exc_info=True,
-                )
 
     def stop_team(self, team_id: uuid.UUID) -> None:
         """Gracefully stop a running team.

--- a/src/akgentic/team/manager.py
+++ b/src/akgentic/team/manager.py
@@ -272,9 +272,9 @@ class TeamManager:
     def stop_team(self, team_id: uuid.UUID) -> None:
         """Gracefully stop a running team.
 
-        Unsubscribes all subscribers from the Orchestrator, tears down actors
-        (orchestrator first, then agents), persists Process with STOPPED status,
-        and deregisters from ServiceRegistry.
+        Unsubscribes all subscribers from the Orchestrator, stops the
+        orchestrator via proxy (which recursively tears down all child actors),
+        persists Process with STOPPED status, and deregisters from ServiceRegistry.
 
         Idempotent: calling stop on an already-STOPPED team is a no-op.
 

--- a/src/akgentic/team/restorer.py
+++ b/src/akgentic/team/restorer.py
@@ -134,10 +134,10 @@ class TeamRestorer:
             return runtime
 
         except Exception:
-            # Rollback: stop all spawned actors in reverse order
+            # Rollback: stop all spawned actors in reverse order via proxy API
             for addr in reversed(spawned_addrs):
                 try:
-                    addr.stop()
+                    self._actor_system.proxy_ask(addr, Akgent).stop()
                 except Exception:
                     logger.warning("Failed to stop actor during rollback: %s", addr)
             raise

--- a/tests/services/test_factory.py
+++ b/tests/services/test_factory.py
@@ -7,7 +7,6 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
-from akgentic.core.actor_address import ActorAddress
 from akgentic.core.actor_system_impl import ActorSystem
 from akgentic.core.agent import Akgent
 from akgentic.core.agent_card import AgentCard
@@ -173,9 +172,16 @@ class TestTeamFactoryBuild:
 
         runtime = TeamFactory.build(tc, actor_system, subscribers=[sub])
 
-        # Verify subscriber is registered by stopping the orchestrator,
+        # Verify subscriber is registered by stopping the orchestrator via proxy,
         # which calls on_stop on all subscribers.
-        runtime.orchestrator_addr.stop()
+        runtime.orchestrator_proxy.stop()
+        # on_stop() fires asynchronously after the proxy stop() call returns;
+        # wait for the actor thread to finish so on_stop() has been invoked.
+        import time
+
+        deadline = time.monotonic() + 2.0
+        while runtime.orchestrator_addr.is_alive() and time.monotonic() < deadline:
+            time.sleep(0.01)
         assert sub.stopped is True
 
     # -- 3.5: routes_to wiring ------------------------------------------
@@ -285,7 +291,7 @@ class TestTeamFactoryBuild:
         failing = _make_member("failing", "Failing", agent_class=FailingAgent)
         tc = _make_team_card(members=[failing])
 
-        with patch.object(ActorAddress, "stop", side_effect=RuntimeError("stop failed")):
+        with patch.object(Akgent, "stop", side_effect=RuntimeError("stop failed")):
             with pytest.raises(RuntimeError, match="Failed to spawn agent"):
                 TeamFactory.build(tc, actor_system)
 

--- a/tests/services/test_factory.py
+++ b/tests/services/test_factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 import uuid
 from typing import Any
 from unittest.mock import patch
@@ -177,8 +178,6 @@ class TestTeamFactoryBuild:
         runtime.orchestrator_proxy.stop()
         # on_stop() fires asynchronously after the proxy stop() call returns;
         # wait for the actor thread to finish so on_stop() has been invoked.
-        import time
-
         deadline = time.monotonic() + 2.0
         while runtime.orchestrator_addr.is_alive() and time.monotonic() < deadline:
             time.sleep(0.01)

--- a/tests/services/test_manager.py
+++ b/tests/services/test_manager.py
@@ -186,8 +186,15 @@ class TestTeamManagerCreate:
         tc = _make_team_card()
         runtime = mgr.create_team(tc)
 
-        # Verify recording subscriber is registered by stopping orchestrator
-        runtime.orchestrator_addr.stop()
+        # Verify recording subscriber is registered by stopping orchestrator via proxy
+        runtime.orchestrator_proxy.stop()
+        # on_stop() fires asynchronously after the proxy stop() call returns;
+        # wait for the actor thread to finish so on_stop() has been invoked.
+        import time
+
+        deadline = time.monotonic() + 2.0
+        while runtime.orchestrator_addr.is_alive() and time.monotonic() < deadline:
+            time.sleep(0.01)
         assert recording.stopped is True
 
     def test_create_team_rollback_on_build_failure(
@@ -472,25 +479,8 @@ def _create_and_stop_team(
     for member in tc.members:
         _inject_member(member)
 
-    # Stop all actors
-    runtime.orchestrator_addr.stop()
-    for addr in runtime.addrs.values():
-        if addr.is_alive():
-            addr.stop()
-
-    # Transition Process to STOPPED
-    process = event_store.load_team(team_id)
-    assert process is not None
-    stopped_process = Process(
-        team_id=process.team_id,
-        team_card=process.team_card,
-        status=TeamStatus.STOPPED,
-        user_id=process.user_id,
-        user_email=process.user_email,
-        created_at=process.created_at,
-        updated_at=process.updated_at,
-    )
-    event_store.save_team(stopped_process)
+    # Stop team via manager (uses proxy-based stop, transitions to STOPPED)
+    manager.stop_team(team_id)
 
     return team_id
 

--- a/tests/services/test_manager.py
+++ b/tests/services/test_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 import uuid
 from typing import Any
 from unittest.mock import MagicMock
@@ -190,8 +191,6 @@ class TestTeamManagerCreate:
         runtime.orchestrator_proxy.stop()
         # on_stop() fires asynchronously after the proxy stop() call returns;
         # wait for the actor thread to finish so on_stop() has been invoked.
-        import time
-
         deadline = time.monotonic() + 2.0
         while runtime.orchestrator_addr.is_alive() and time.monotonic() < deadline:
             time.sleep(0.01)

--- a/tests/services/test_restorer.py
+++ b/tests/services/test_restorer.py
@@ -715,8 +715,15 @@ class TestTeamRestorerRollback:
         # Recording subscriber should have received replayed events
         assert len(recording.messages) > 0
 
-        # Stop and verify on_stop called
-        runtime.orchestrator_addr.stop()
+        # Stop via proxy and wait for full shutdown before asserting on_stop
+        runtime.orchestrator_proxy.stop()
+        # on_stop() fires asynchronously after the proxy stop() call returns;
+        # wait for the actor thread to finish so on_stop() has been invoked.
+        import time
+
+        deadline = time.monotonic() + 2.0
+        while runtime.orchestrator_addr.is_alive() and time.monotonic() < deadline:
+            time.sleep(0.01)
         assert recording.stopped is True
 
 

--- a/tests/services/test_restorer.py
+++ b/tests/services/test_restorer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 import uuid
 from datetime import UTC, datetime
 from typing import Any
@@ -719,8 +720,6 @@ class TestTeamRestorerRollback:
         runtime.orchestrator_proxy.stop()
         # on_stop() fires asynchronously after the proxy stop() call returns;
         # wait for the actor thread to finish so on_stop() has been invoked.
-        import time
-
         deadline = time.monotonic() + 2.0
         while runtime.orchestrator_addr.is_alive() and time.monotonic() < deadline:
             time.sleep(0.01)


### PR DESCRIPTION
## Summary

Replace all direct `addr.stop()` calls in akgentic-team with proxy-based `actor_system.proxy_ask(addr, Akgent).stop()` to comply with the actor internals boundary rule (CLAUDE.md). This ensures `Akgent.stop()` / `Orchestrator.stop()` is invoked through the Pykka proxy, guaranteeing recursive child teardown and proper timer cancellation.

### Changes
- **manager.py**: Replaced `runtime.orchestrator_addr.stop()` with `orchestrator_proxy.stop()` in `_teardown_team()`, removed redundant per-agent stop loop (children are stopped recursively by Orchestrator.stop())
- **factory.py**: Replaced rollback `addr.stop()` with `actor_system.proxy_ask(addr, Akgent).stop()`
- **restorer.py**: Replaced rollback `addr.stop()` with `self._actor_system.proxy_ask(addr, Akgent).stop()`
- **test_factory.py**: Updated mock target from `ActorAddress.stop` to `Akgent.stop`, fixed subscriber test async timing
- **test_manager.py**: Fixed subscriber test async timing, simplified `_create_and_stop_team` to use `manager.stop_team()`
- **test_restorer.py**: Fixed subscriber test async timing

### Code Review Fixes
- Fixed stale `stop_team()` docstring to reflect proxy-based recursive teardown
- Moved inline `import time` to module top-level in 3 test files (PEP 8)

Closes #77