### PR TITLE
fix: rename orchestrator to @Orchestrator

### DIFF
--- a/src/akgentic/team/factory.py
+++ b/src/akgentic/team/factory.py
@@ -66,7 +66,7 @@ class TeamFactory:
             # 1. Create Orchestrator
             orchestrator_addr = actor_system.createActor(
                 Orchestrator,
-                config=BaseConfig(name="orchestrator", role="Orchestrator"),
+                config=BaseConfig(name="@Orchestrator", role="Orchestrator"),
                 team_id=team_id,
             )
             spawned_addrs.append(orchestrator_addr)

--- a/src/akgentic/team/restorer.py
+++ b/src/akgentic/team/restorer.py
@@ -233,7 +233,7 @@ class TeamRestorer:
             restoring=True,
             agent_id=orchestrator_start.sender.agent_id,
             team_id=team_id,
-            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+            config=BaseConfig(name="@Orchestrator", role="Orchestrator"),
         )
         spawned_addrs.append(orchestrator_addr)
 

--- a/tests/services/test_manager.py
+++ b/tests/services/test_manager.py
@@ -438,7 +438,7 @@ def _create_and_stop_team(
         "user_message": False,
     }
     orch_start = StartMessage(
-        config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        config=BaseConfig(name="@Orchestrator", role="Orchestrator"),
     )
     orch_start.sender = ActorAddressProxy(orch_addr_dict)
     orch_start.team_id = team_id

--- a/tests/services/test_restorer.py
+++ b/tests/services/test_restorer.py
@@ -213,7 +213,7 @@ def _populate_stopped_team(
         "Orchestrator",
         team_id,
         agent_class=Orchestrator,
-        config=BaseConfig(name="orchestrator", role="Orchestrator"),
+        config=BaseConfig(name="@Orchestrator", role="Orchestrator"),
     )
     event_store.save_event(
         PersistedEvent(
@@ -937,7 +937,7 @@ class TestRestorerOrphanFallback:
             "Orchestrator",
             team_id,
             agent_class=Orchestrator,
-            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+            config=BaseConfig(name="@Orchestrator", role="Orchestrator"),
         )
         event_store.save_event(
             PersistedEvent(
@@ -1300,7 +1300,7 @@ class TestRestorerToolActorSpawnOrder:
                 "Orchestrator",
                 team_id,
                 agent_class=Orchestrator,
-                config=BaseConfig(name="orchestrator", role="Orchestrator"),
+                config=BaseConfig(name="@Orchestrator", role="Orchestrator"),
             )
             event_store.save_event(
                 PersistedEvent(
@@ -1404,7 +1404,7 @@ class TestRestorerToolActorSpawnOrder:
                 "Orchestrator",
                 team_id,
                 agent_class=Orchestrator,
-                config=BaseConfig(name="orchestrator", role="Orchestrator"),
+                config=BaseConfig(name="@Orchestrator", role="Orchestrator"),
             )
             event_store.save_event(
                 PersistedEvent(
@@ -1478,7 +1478,7 @@ class TestRestorerToolActorSpawnOrder:
             "Orchestrator",
             team_id,
             agent_class=Orchestrator,
-            config=BaseConfig(name="orchestrator", role="Orchestrator"),
+            config=BaseConfig(name="@Orchestrator", role="Orchestrator"),
         )
         event_store.save_event(
             PersistedEvent(


### PR DESCRIPTION
## Summary

- Rename `BaseConfig(name="orchestrator")` to `BaseConfig(name="@Orchestrator")` in `TeamFactory.build()` and `TeamRestorer._create_orchestrator()`
- Update test expectations in `test_manager.py` and `test_restorer.py`

Aligns with the naming convention: `@` prefix for agents, `#` prefix for tool actors.

Closes #79