### PR TITLE
Fix PersistenceSubscriber Sequence Continuity Across Restore Cycles

### DIFF
--- a/src/akgentic/team/manager.py
+++ b/src/akgentic/team/manager.py
@@ -198,8 +198,14 @@ class TeamManager:
 
         restorer = TeamRestorer(self._actor_system, self._event_store)
 
+        # Compute max existing sequence so new events continue monotonically
+        existing_events = self._event_store.load_events(team_id)
+        max_seq = max((e.sequence for e in existing_events), default=0)
+
         # Create PersistenceSubscriber once — passed to restorer and tracked for stop
-        persistence_sub = PersistenceSubscriber(team_id, self._event_store)
+        persistence_sub = PersistenceSubscriber(
+            team_id, self._event_store, initial_sequence=max_seq
+        )
         all_subs: list[EventSubscriber] = [persistence_sub] + list(self._shared_subscribers)
 
         # Toggle restoring guard on all subscribers.

--- a/src/akgentic/team/manager.py
+++ b/src/akgentic/team/manager.py
@@ -199,8 +199,7 @@ class TeamManager:
         restorer = TeamRestorer(self._actor_system, self._event_store)
 
         # Compute max existing sequence so new events continue monotonically
-        existing_events = self._event_store.load_events(team_id)
-        max_seq = max((e.sequence for e in existing_events), default=0)
+        max_seq = self._event_store.get_max_sequence(team_id)
 
         # Create PersistenceSubscriber once — passed to restorer and tracked for stop
         persistence_sub = PersistenceSubscriber(

--- a/src/akgentic/team/ports.py
+++ b/src/akgentic/team/ports.py
@@ -70,6 +70,19 @@ class EventStore(Protocol):
         """
         ...
 
+    def get_max_sequence(self, team_id: uuid.UUID) -> int:
+        """Return the highest event sequence number for a team.
+
+        Used by TeamManager.resume_team() to initialize PersistenceSubscriber
+        so that new events continue monotonically after restore. Returns 0 if
+        no events exist for the given team.
+
+        Implementations backed by a database (e.g. MongoDB) SHOULD use an
+        efficient query (e.g. ``find().sort("sequence", -1).limit(1)``)
+        rather than loading all events into memory.
+        """
+        ...
+
     def load_agent_states(self, team_id: uuid.UUID) -> list[AgentStateSnapshot]:
         """Load all agent state snapshots for a team.
 

--- a/src/akgentic/team/repositories/mongo.py
+++ b/src/akgentic/team/repositories/mongo.py
@@ -157,6 +157,28 @@ class MongoEventStore:
         logger.debug("Loaded %d events for team %s", len(events), team_id)
         return events
 
+    def get_max_sequence(self, team_id: uuid.UUID) -> int:
+        """Return the highest event sequence number for a team, or 0.
+
+        Uses an efficient MongoDB query (sort + limit) to avoid loading
+        all events into memory.
+
+        Args:
+            team_id: Unique identifier of the team.
+
+        Returns:
+            The highest sequence number, or 0 if no events exist.
+        """
+        doc = self._events.find_one(
+            {"team_id": str(team_id)},
+            sort=[("sequence", -1)],
+            projection={"sequence": 1, "_id": 0},
+        )
+        if doc is None:
+            return 0
+        result: int = doc["sequence"]
+        return result
+
     def save_agent_state(self, snapshot: AgentStateSnapshot) -> None:
         """Persist an agent state snapshot via upsert.
 

--- a/src/akgentic/team/repositories/yaml.py
+++ b/src/akgentic/team/repositories/yaml.py
@@ -189,6 +189,22 @@ class YamlEventStore:
         logger.debug("Loaded %d events for team %s", len(events), team_id)
         return sorted(events, key=lambda e: e.sequence)
 
+    def get_max_sequence(self, team_id: uuid.UUID) -> int:
+        """Return the highest event sequence number for a team, or 0.
+
+        Loads all events and computes the max in Python. This is acceptable
+        for a file-based store; database-backed stores should use an
+        efficient query instead.
+
+        Args:
+            team_id: Unique identifier of the team.
+
+        Returns:
+            The highest sequence number, or 0 if no events exist.
+        """
+        events = self.load_events(team_id)
+        return max((e.sequence for e in events), default=0)
+
     def save_agent_state(self, snapshot: AgentStateSnapshot) -> None:
         """Persist an agent state snapshot to states/{agent_id}.yaml.
 

--- a/src/akgentic/team/subscriber.py
+++ b/src/akgentic/team/subscriber.py
@@ -26,16 +26,24 @@ class PersistenceSubscriber(EventSubscriber):
     BaseState) -- no imports from akgentic-llm or akgentic-agent needed.
     """
 
-    def __init__(self, team_id: uuid.UUID, event_store: EventStore) -> None:
+    def __init__(
+        self,
+        team_id: uuid.UUID,
+        event_store: EventStore,
+        initial_sequence: int = 0,
+    ) -> None:
         """Initialize the persistence subscriber.
 
         Args:
             team_id: Unique identifier of the team whose events are persisted.
             event_store: Storage backend for events and agent state snapshots.
+            initial_sequence: Starting sequence number. Use 0 (default) for new
+                teams. For resumed teams, pass the max existing sequence so that
+                new events continue monotonically without duplicating numbers.
         """
         self._team_id = team_id
         self._event_store = event_store
-        self._sequence = 0
+        self._sequence = initial_sequence
         self._restoring = False
 
     def on_message(self, msg: Message) -> None:

--- a/tests/repositories/test_yaml.py
+++ b/tests/repositories/test_yaml.py
@@ -242,6 +242,25 @@ class TestYamlEventStore:
         assert len(result) == 1
         assert result[0].team_id == p1.team_id
 
+    # --- get_max_sequence ---
+
+    def test_get_max_sequence_returns_max_sequence(
+        self, yaml_store: YamlEventStore
+    ) -> None:
+        """get_max_sequence returns the highest sequence number for a team."""
+        team_id = uuid.uuid4()
+        yaml_store.save_event(make_persisted_event(team_id=team_id, sequence=5))
+        yaml_store.save_event(make_persisted_event(team_id=team_id, sequence=3))
+        yaml_store.save_event(make_persisted_event(team_id=team_id, sequence=10))
+
+        assert yaml_store.get_max_sequence(team_id) == 10
+
+    def test_get_max_sequence_returns_zero_for_no_events(
+        self, yaml_store: YamlEventStore
+    ) -> None:
+        """get_max_sequence returns 0 when no events exist for a team."""
+        assert yaml_store.get_max_sequence(uuid.uuid4()) == 0
+
     # --- Protocol compliance ---
 
     def test_satisfies_event_store_protocol(self, tmp_path: Path) -> None:

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -77,6 +77,11 @@ class InMemoryEventStore:
         """Load all team process snapshots."""
         return list(self.teams.values())
 
+    def get_max_sequence(self, team_id: uuid.UUID) -> int:
+        """Return the highest event sequence number for a team, or 0."""
+        events = self.load_events(team_id)
+        return max((e.sequence for e in events), default=0)
+
     def load_agent_states(self, team_id: uuid.UUID) -> list[AgentStateSnapshot]:
         """Load all agent state snapshots for a team."""
         return [v for k, v in self.agent_states.items() if k[0] == team_id]

--- a/tests/services/test_manager.py
+++ b/tests/services/test_manager.py
@@ -603,6 +603,65 @@ class TestTeamManagerResume:
             f"PersistenceSubscriber appeared {persistence_count} times, expected 1"
         )
 
+    def test_resume_continues_sequence_numbering(
+        self,
+        manager: TeamManager,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 14.8: After stop/resume, new events continue from max existing sequence."""
+        from akgentic.core.messages.message import UserMessage
+
+        from akgentic.team.subscriber import PersistenceSubscriber
+
+        team_id = _create_and_stop_team(manager, event_store)
+
+        # Record max sequence before resume
+        existing_events = event_store.load_events(team_id)
+        max_seq = max(e.sequence for e in existing_events)
+        assert max_seq > 0, "Precondition: events must exist before resume"
+
+        # Resume team
+        manager.resume_team(team_id)
+
+        # Find the PersistenceSubscriber in tracked subscribers
+        team_subs = manager._team_subscribers[team_id]
+        persistence_sub = next(s for s in team_subs if isinstance(s, PersistenceSubscriber))
+
+        # Send a message via the PersistenceSubscriber directly
+        persistence_sub.on_message(UserMessage(content="post-resume message"))
+
+        # The new event must have sequence = max_seq + 1
+        all_events = event_store.load_events(team_id)
+        # Filter to events from the persistence subscriber (latest one added)
+        post_resume_events = [e for e in all_events if e.sequence > max_seq]
+        assert len(post_resume_events) == 1
+        assert post_resume_events[0].sequence == max_seq + 1
+
+    def test_create_team_uses_default_initial_sequence(
+        self,
+        manager: TeamManager,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC 14.8: create_team uses default initial_sequence=0 (no regression)."""
+        from akgentic.core.messages.message import UserMessage
+
+        from akgentic.team.subscriber import PersistenceSubscriber
+
+        tc = _make_team_card()
+        runtime = manager.create_team(tc)
+
+        # Find the PersistenceSubscriber
+        team_subs = manager._team_subscribers[runtime.id]
+        persistence_sub = next(s for s in team_subs if isinstance(s, PersistenceSubscriber))
+
+        # Send a message — sequence should start at 1
+        persistence_sub.on_message(UserMessage(content="first message"))
+
+        events = event_store.events
+        # Filter to the event we just sent (others may exist from team creation)
+        our_events = [e for e in events if e.team_id == runtime.id and e.sequence == 1]
+        assert len(our_events) == 1
+
     def test_stop_after_resume_unsubscribes_same_objects(
         self,
         actor_system: ActorSystem,

--- a/tests/services/test_subscriber.py
+++ b/tests/services/test_subscriber.py
@@ -142,3 +142,42 @@ class TestPersistenceSubscriber:
     def test_is_instance_of_event_subscriber(self) -> None:
         """AC 3: PersistenceSubscriber explicitly inherits from EventSubscriber."""
         assert EventSubscriber in PersistenceSubscriber.__mro__
+
+    # -- Story 14.8: initial_sequence parameter ------------------------------
+
+    def test_initial_sequence_continues_from_provided_value(self) -> None:
+        """AC 14.8: Sequence starts from initial_sequence, not 0."""
+        team_id = uuid.uuid4()
+        store = InMemoryEventStore()
+        sub = PersistenceSubscriber(team_id=team_id, event_store=store, initial_sequence=22)
+
+        sub.on_message(UserMessage(content="hello after resume"))
+
+        events = store.events
+        assert len(events) == 1
+        assert events[0].sequence == 23
+
+    def test_default_initial_sequence_starts_at_one(self) -> None:
+        """AC 14.8: Without initial_sequence, first event gets sequence 1 (no regression)."""
+        team_id = uuid.uuid4()
+        store = InMemoryEventStore()
+        sub = PersistenceSubscriber(team_id=team_id, event_store=store)
+
+        sub.on_message(UserMessage(content="first"))
+
+        events = store.events
+        assert len(events) == 1
+        assert events[0].sequence == 1
+
+    def test_initial_sequence_with_multiple_messages(self) -> None:
+        """AC 14.8: Multiple messages after initial_sequence continue monotonically."""
+        team_id = uuid.uuid4()
+        store = InMemoryEventStore()
+        sub = PersistenceSubscriber(team_id=team_id, event_store=store, initial_sequence=10)
+
+        sub.on_message(UserMessage(content="msg1"))
+        sub.on_message(UserMessage(content="msg2"))
+        sub.on_message(UserMessage(content="msg3"))
+
+        sequences = [e.sequence for e in store.events]
+        assert sequences == [11, 12, 13]


### PR DESCRIPTION
## Summary

- Add `initial_sequence` parameter to `PersistenceSubscriber.__init__` so sequence numbering continues monotonically after team resume instead of restarting from 1
- Add `get_max_sequence(team_id) -> int` to the `EventStore` protocol to efficiently retrieve the highest sequence number without loading all events into memory
- Implement `get_max_sequence()` in all `EventStore` implementations within akgentic-team: `InMemoryEventStore`, `YamlEventStore` (load + max), and `MongoEventStore` (efficient `find_one(sort=[("sequence", -1)])`)
- Update `TeamManager.resume_team()` to call `get_max_sequence()` instead of `load_events()` + `max()`
- 7 new tests covering `initial_sequence` parameter, resume sequence continuity, and `get_max_sequence()` for YamlEventStore

## Follow-up

- akgentic-infra's `MongoEventStore` must implement `get_max_sequence()` with an efficient DB query in a separate PR (different submodule)

Closes #81