### PR TITLE
feat: add send_from_to() to TeamRuntime

### DIFF
--- a/src/akgentic/team/models.py
+++ b/src/akgentic/team/models.py
@@ -236,6 +236,52 @@ class TeamRuntime(SerializableBaseModel):
         for addr in self.supervisor_addrs.values():
             self._entry_proxy.send(addr, self._make_message(content))
 
+    def _resolve_addr(self, agent_name: str, addr: ActorAddress) -> ActorAddress:
+        """Resolve a potentially stale proxy address to a live address.
+
+        If the address is an ``ActorAddressProxy`` (from deserialized data),
+        looks up the live address in ``_addr_map``.  Returns the address
+        unchanged if it is already live.
+
+        Args:
+            agent_name: Name of the agent (used in error messages).
+            addr: The address to resolve.
+
+        Returns:
+            A live ``ActorAddress``.
+
+        Raises:
+            ValueError: If the address is a stale proxy with no live mapping.
+        """
+        if isinstance(addr, ActorAddressProxy):
+            live = self._addr_map.get(addr.agent_id)
+            if live is None:
+                msg = (
+                    f"Agent '{agent_name}' has stale proxy address"
+                    " — no live mapping available"
+                )
+                raise ValueError(msg)
+            return live
+        return addr
+
+    def _lookup_member(self, agent_name: str) -> ActorAddress:
+        """Look up a team member by name and resolve stale proxies.
+
+        Args:
+            agent_name: Name of the agent to look up.
+
+        Returns:
+            A live ``ActorAddress`` for the agent.
+
+        Raises:
+            ValueError: If the agent is not found or has a stale proxy.
+        """
+        addr = self._orchestrator_proxy.get_team_member(agent_name)
+        if addr is None:
+            msg = f"Agent '{agent_name}' not found in team '{self.team.name}'"
+            raise ValueError(msg)
+        return self._resolve_addr(agent_name, addr)
+
     def send_to(self, agent_name: str, content: str) -> None:
         """Send a directed message to a specific agent by name.
 
@@ -250,19 +296,35 @@ class TeamRuntime(SerializableBaseModel):
         Raises:
             ValueError: If the agent is not found or has a stale proxy address.
         """
-        actor_addr = self._orchestrator_proxy.get_team_member(agent_name)
-        if actor_addr is None:
-            msg = f"Agent '{agent_name}' not found in team '{self.team.name}'"
-            raise ValueError(msg)
-        # Safety net: resolve proxy if it leaked through after restore
-        if isinstance(actor_addr, ActorAddressProxy):
-            live = self._addr_map.get(actor_addr.agent_id)
-            if live is None:
-                msg = f"Agent '{agent_name}' has stale proxy address — no live mapping available"
-                raise ValueError(msg)
-            actor_addr = live
+        actor_addr = self._lookup_member(agent_name)
         message = self._make_message(content)
         self._entry_proxy.send(actor_addr, message)
+
+    def send_from_to(
+        self,
+        sender_name: str,
+        recipient_name: str,
+        content: str,
+    ) -> None:
+        """Send a message from a specified agent to another agent.
+
+        Unlike ``send_to()`` which always sends via the entry proxy (so
+        the sender is the entry agent), this method obtains a proxy for
+        the *sender* agent and calls ``send()`` on it, so the message's
+        ``sender`` field is set to the specified sender's address.
+
+        Args:
+            sender_name: Name of the agent to send from.
+            recipient_name: Name of the agent to send to.
+            content: The message content.
+
+        Raises:
+            ValueError: If sender or recipient is not found or has a stale proxy.
+        """
+        sender_addr = self._lookup_member(sender_name)
+        recipient_addr = self._lookup_member(recipient_name)
+        sender_proxy = self.actor_system.proxy_tell(sender_addr, Akgent)
+        sender_proxy.send(recipient_addr, self._make_message(content))
 
     @property
     def orchestrator_proxy(self) -> Orchestrator:

--- a/tests/models/test_team_runtime.py
+++ b/tests/models/test_team_runtime.py
@@ -291,3 +291,124 @@ class TestTeamRuntimeSendToResolution:
 
         with pytest.raises(ValueError, match="stale proxy address"):
             runtime.send_to("ghost", "hello")
+
+
+class TestTeamRuntimeSendFromTo:
+    """send_from_to() sends a message with the correct sender identity."""
+
+    def test_send_from_to_valid_sender_and_recipient(self) -> None:
+        """AC1: sender proxy is obtained via proxy_tell and used to send."""
+        sender_addr = make_stub_addr("developer")
+        recipient_addr = make_stub_addr("manager")
+        runtime = make_team_runtime(message_types=[UserMessage])
+        runtime._orchestrator_proxy.get_team_member = MagicMock(
+            side_effect=lambda name: sender_addr if name == "developer" else recipient_addr,
+        )
+        runtime.actor_system.proxy_tell.reset_mock()
+
+        runtime.send_from_to("developer", "manager", "hello")
+
+        runtime.actor_system.proxy_tell.assert_called_once_with(sender_addr, Akgent)
+        sender_proxy = runtime.actor_system.proxy_tell.return_value
+        sender_proxy.send.assert_called_once()
+        call_args = sender_proxy.send.call_args
+        assert call_args.args[0] is recipient_addr
+        assert isinstance(call_args.args[1], UserMessage)
+        assert call_args.args[1].content == "hello"
+
+    def test_send_from_to_unknown_sender(self) -> None:
+        """AC2: ValueError when sender is not found."""
+        runtime = make_team_runtime(message_types=[UserMessage])
+        runtime._orchestrator_proxy.get_team_member = MagicMock(return_value=None)
+
+        with pytest.raises(ValueError, match="not found"):
+            runtime.send_from_to("unknown", "manager", "hello")
+
+    def test_send_from_to_unknown_recipient(self) -> None:
+        """AC3: ValueError when recipient is not found."""
+        sender_addr = make_stub_addr("developer")
+        runtime = make_team_runtime(message_types=[UserMessage])
+        runtime._orchestrator_proxy.get_team_member = MagicMock(
+            side_effect=lambda name: sender_addr if name == "developer" else None,
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            runtime.send_from_to("developer", "unknown", "hello")
+
+    def test_send_from_to_resolves_stale_sender_proxy(self) -> None:
+        """AC4: stale sender proxy is resolved via _addr_map."""
+        from akgentic.core.actor_address_impl import ActorAddressProxy
+        from akgentic.core.utils.deserializer import ActorAddressDict
+
+        agent_id = uuid.uuid4()
+        addr_dict: ActorAddressDict = {
+            "__actor_address__": True,
+            "__actor_type__": "akgentic.core.agent.Akgent",
+            "agent_id": str(agent_id),
+            "name": "developer",
+            "role": "Developer",
+            "team_id": str(uuid.uuid4()),
+            "squad_id": str(uuid.uuid4()),
+            "user_message": False,
+        }
+        proxy_addr = ActorAddressProxy(addr_dict)
+        live_sender = make_stub_addr("developer")
+        live_sender.agent_id = agent_id
+        recipient_addr = make_stub_addr("manager")
+
+        runtime = make_team_runtime(message_types=[UserMessage])
+        runtime._orchestrator_proxy.get_team_member = MagicMock(
+            side_effect=lambda name: proxy_addr if name == "developer" else recipient_addr,
+        )
+        runtime._addr_map = {agent_id: live_sender}
+        runtime.actor_system.proxy_tell.reset_mock()
+
+        runtime.send_from_to("developer", "manager", "hello")
+
+        runtime.actor_system.proxy_tell.assert_called_once_with(live_sender, Akgent)
+
+    def test_send_from_to_resolves_stale_recipient_proxy(self) -> None:
+        """AC4: stale recipient proxy is resolved via _addr_map."""
+        from akgentic.core.actor_address_impl import ActorAddressProxy
+        from akgentic.core.utils.deserializer import ActorAddressDict
+
+        agent_id = uuid.uuid4()
+        addr_dict: ActorAddressDict = {
+            "__actor_address__": True,
+            "__actor_type__": "akgentic.core.agent.Akgent",
+            "agent_id": str(agent_id),
+            "name": "manager",
+            "role": "Manager",
+            "team_id": str(uuid.uuid4()),
+            "squad_id": str(uuid.uuid4()),
+            "user_message": False,
+        }
+        proxy_addr = ActorAddressProxy(addr_dict)
+        live_recipient = make_stub_addr("manager")
+        live_recipient.agent_id = agent_id
+        sender_addr = make_stub_addr("developer")
+
+        runtime = make_team_runtime(message_types=[UserMessage])
+        runtime._orchestrator_proxy.get_team_member = MagicMock(
+            side_effect=lambda name: sender_addr if name == "developer" else proxy_addr,
+        )
+        runtime._addr_map = {agent_id: live_recipient}
+
+        runtime.send_from_to("developer", "manager", "hello")
+
+        sender_proxy = runtime.actor_system.proxy_tell.return_value
+        call_args = sender_proxy.send.call_args
+        assert call_args.args[0] is live_recipient
+
+    def test_send_to_still_works_after_refactor(self) -> None:
+        """AC6: existing send_to() is not broken by the refactoring."""
+        target_addr = make_stub_addr("worker")
+        runtime = make_team_runtime(message_types=[UserMessage])
+        runtime._orchestrator_proxy.get_team_member = MagicMock(return_value=target_addr)
+        runtime.send_to("worker", "hello")
+        runtime._orchestrator_proxy.get_team_member.assert_called_once_with("worker")
+        runtime._entry_proxy.send.assert_called_once()
+        call_args = runtime._entry_proxy.send.call_args
+        assert call_args.args[0] is target_addr
+        assert isinstance(call_args.args[1], UserMessage)
+        assert call_args.args[1].content == "hello"


### PR DESCRIPTION
## Summary

- Add `send_from_to(sender_name, recipient_name, content)` method to `TeamRuntime` enabling agent-to-agent messaging with correct sender identity
- Extract `_resolve_addr()` and `_lookup_member()` private helpers from `send_to()` for DRY code, keeping all methods well under the 50-line limit
- 6 new tests covering valid send, unknown sender/recipient, stale proxy resolution for both sides, and regression safety for existing `send_to()`

Closes #83

## Test plan

- [x] All 258 tests pass (`pytest packages/akgentic-team/tests/`)
- [x] Ruff lint clean
- [x] mypy strict clean
- [x] Existing `send_to()` and `send()` tests unchanged and passing (no regression)