### PR TITLE
feat: rehydrate incoming messages and route by recipient

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
           git fetch origin ${{ github.head_ref || github.ref_name }}
           git checkout FETCH_HEAD
 
+      - name: Bump akgentic-core to include hydrate_addresses (epic-13 PR 45)
+        working-directory: packages/akgentic-core
+        run: |
+          git fetch origin master
+          git checkout FETCH_HEAD
+
       - name: Ensure team package in workspace
         run: |
           if ! grep -q 'akgentic-team' pyproject.toml; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,6 @@ jobs:
           git fetch origin ${{ github.head_ref || github.ref_name }}
           git checkout FETCH_HEAD
 
-      - name: Bump akgentic-core to include hydrate_addresses (epic-13 PR 45)
-        working-directory: packages/akgentic-core
-        run: |
-          git fetch origin master
-          git checkout FETCH_HEAD
-
       - name: Ensure team package in workspace
         run: |
           if ! grep -q 'akgentic-team' pyproject.toml; then

--- a/src/akgentic/team/models.py
+++ b/src/akgentic/team/models.py
@@ -22,7 +22,8 @@ from akgentic.core.agent_state import BaseState
 from akgentic.core.messages.message import Message
 from akgentic.core.orchestrator import Orchestrator
 from akgentic.core.user_proxy import UserProxy
-from akgentic.core.utils.serializer import SerializableBaseModel, hydrate_addresses
+from akgentic.core.utils import hydrate_addresses
+from akgentic.core.utils.serializer import SerializableBaseModel
 
 
 class TeamCardMember(SerializableBaseModel):

--- a/src/akgentic/team/models.py
+++ b/src/akgentic/team/models.py
@@ -352,7 +352,7 @@ class TeamRuntime(SerializableBaseModel):
             if live is None:
                 err = (
                     f"Cannot rehydrate address for agent '{proxy.name}': "
-                    f"not found in team"
+                    "not found in team"
                 )
                 raise ValueError(err)
             return live

--- a/src/akgentic/team/models.py
+++ b/src/akgentic/team/models.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 from enum import StrEnum
-from typing import Any
+from typing import Any, cast
 
 from pydantic import Field, PrivateAttr
 
@@ -22,7 +22,7 @@ from akgentic.core.agent_state import BaseState
 from akgentic.core.messages.message import Message
 from akgentic.core.orchestrator import Orchestrator
 from akgentic.core.user_proxy import UserProxy
-from akgentic.core.utils.serializer import SerializableBaseModel
+from akgentic.core.utils.serializer import SerializableBaseModel, hydrate_addresses
 
 
 class TeamCardMember(SerializableBaseModel):
@@ -328,31 +328,46 @@ class TeamRuntime(SerializableBaseModel):
         sender_proxy.send(recipient_addr, self._make_message(content))
 
     def process_human_input(self, content: str, message: Message) -> None:
-        """Route human input to the team's UserProxy agent.
+        """Route human input to the correct UserProxy by recipient name.
 
-        Walks the team's agent cards to find the agent whose class is a
-        ``UserProxy`` subclass, resolves its address, obtains a typed proxy,
-        and delegates the call.
+        Validates that the message has a recipient, rehydrates any
+        ``ActorAddressProxy`` references via the orchestrator, then
+        routes by ``message.recipient.name`` to the correct ``UserProxy``.
 
         Args:
             content: The human's text response.
             message: The original message from the requesting agent.
 
         Raises:
-            ValueError: If no UserProxy agent is found in the team or the
-                found agent has no resolved address.
+            ValueError: If the message has no recipient, the recipient
+                cannot be rehydrated, or the target is not a UserProxy.
         """
-        for name, card in self.team.agent_cards.items():
-            if issubclass(card.get_agent_class(), UserProxy):
-                addr = self.addrs.get(name)
-                if addr is None:
-                    msg = f"UserProxy '{name}' found but has no resolved address"
-                    raise ValueError(msg)
-                proxy = self.actor_system.proxy_ask(addr, UserProxy)
-                proxy.process_human_input(content, message)
-                return
-        msg = "No UserProxy found in team"
-        raise ValueError(msg)
+        if message.recipient is None:
+            msg = "Cannot route human input: message has no recipient"
+            raise ValueError(msg)
+
+        def _resolve(proxy: ActorAddressProxy) -> ActorAddress:
+            live = self._orchestrator_proxy.get_team_member(proxy.name)
+            if live is None:
+                err = (
+                    f"Cannot rehydrate address for agent '{proxy.name}': "
+                    f"not found in team"
+                )
+                raise ValueError(err)
+            return live
+
+        live_message = cast(Message, hydrate_addresses(message, _resolve))
+
+        target_name = live_message.recipient.name  # type: ignore[union-attr]
+        target_addr = self._lookup_member(target_name)
+
+        card = self.team.agent_cards.get(target_name)
+        if card is None or not issubclass(card.get_agent_class(), UserProxy):
+            msg = f"Agent '{target_name}' is not a UserProxy"
+            raise ValueError(msg)
+
+        proxy = self.actor_system.proxy_ask(target_addr, UserProxy)
+        proxy.process_human_input(content, live_message)
 
     @property
     def orchestrator_proxy(self) -> Orchestrator:

--- a/tests/integration/test_process_human_input.py
+++ b/tests/integration/test_process_human_input.py
@@ -1,0 +1,212 @@
+"""Integration tests for process_human_input: rehydration and recipient-based routing.
+
+Tests use real Akgent subclasses, real orchestrators, and the InMemoryEventStore
+to verify that messages with ActorAddressProxy sender/recipient are rehydrated
+and routed to the correct UserProxy agent.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any
+
+import pykka
+import pytest
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_address_impl import ActorAddressImpl, ActorAddressProxy
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.agent_state import BaseState
+from akgentic.core.messages.message import ResultMessage, UserMessage
+from akgentic.core.user_proxy import UserProxy
+from akgentic.core.utils.deserializer import ActorAddressDict
+
+from akgentic.team.manager import TeamManager
+from akgentic.team.models import TeamCard, TeamCardMember
+from tests.integration.conftest import (
+    RecordingAgent,
+    make_integration_agent_card,
+    wait_for_agent_state,
+)
+from tests.services.conftest import InMemoryEventStore
+
+
+# ---------------------------------------------------------------------------
+# Agent classes for this test
+# ---------------------------------------------------------------------------
+
+
+class RecordingUserProxy(UserProxy):
+    """UserProxy that records process_human_input calls for test verification."""
+
+    def on_start(self) -> None:
+        """Initialize recording state."""
+        self.state = RecordingProxyState()
+
+    def process_human_input(self, content: str, message: UserMessage) -> None:
+        """Record the call and send reply to sender (exercises live address invariant)."""
+        self.state.received_contents = [*self.state.received_contents, content]
+        self.state.call_count += 1
+        # This call will crash if message.sender is ActorAddressProxy
+        super().process_human_input(content, message)
+
+
+class RecordingProxyState(BaseState):
+    """State for RecordingUserProxy."""
+
+    received_contents: list[str] = []
+    call_count: int = 0
+
+
+class ManagerAgent(Akgent[BaseConfig, BaseState]):
+    """Simple agent that records received messages for verification."""
+
+    def on_start(self) -> None:
+        """Initialize recording state."""
+        self.state = _ManagerState()
+
+    def receiveMsg_UserMessage(  # noqa: N802
+        self, msg: UserMessage, sender: ActorAddress
+    ) -> None:
+        """Record message and sender for test assertions."""
+        self.state.messages = [*self.state.messages, msg.content]
+        self.state.counter += 1
+        self.notify_state_change(self.state)
+
+    def receiveMsg_ResultMessage(  # noqa: N802
+        self, msg: ResultMessage, sender: ActorAddress
+    ) -> None:
+        """Record ResultMessage replies from UserProxy agents."""
+        self.state.messages = [*self.state.messages, msg.content]
+        self.state.counter += 1
+        self.notify_state_change(self.state)
+
+
+class _ManagerState(BaseState):
+    """State for ManagerAgent."""
+
+    messages: list[str] = []
+    counter: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def actor_system() -> ActorSystem:
+    """Create an ActorSystem, yield it, tear down all actors after test."""
+    system = ActorSystem()
+    yield system  # type: ignore[misc]
+    pykka.ActorRegistry.stop_all()
+
+
+def _make_multi_human_team_card() -> TeamCard:
+    """Team with @Human (entry, RecordingUserProxy), @Manager, @Support (RecordingUserProxy)."""
+    entry = TeamCardMember(
+        card=make_integration_agent_card(
+            name="@Human",
+            role="Human",
+            agent_class=RecordingUserProxy,
+        ),
+    )
+    manager = TeamCardMember(
+        card=make_integration_agent_card(
+            name="@Manager",
+            role="Manager",
+            agent_class=ManagerAgent,
+        ),
+    )
+    support = TeamCardMember(
+        card=make_integration_agent_card(
+            name="@Support",
+            role="Support",
+            agent_class=RecordingUserProxy,
+        ),
+    )
+    return TeamCard(
+        name="multi-human-team",
+        description="Team with @Human, @Manager, @Support for process_human_input tests",
+        entry_point=entry,
+        members=[manager, support],
+        message_types=[UserMessage],
+    )
+
+
+def _addr_to_proxy(addr: ActorAddress) -> ActorAddressProxy:
+    """Convert a live ActorAddressImpl to an ActorAddressProxy (simulating deserialization)."""
+    impl: ActorAddressImpl = addr  # type: ignore[assignment]
+    addr_dict: ActorAddressDict = {
+        "__actor_address__": True,
+        "__actor_type__": "akgentic.core.agent.Akgent",
+        "agent_id": str(impl.agent_id),
+        "name": impl.name,
+        "role": impl.role,
+        "team_id": str(impl.team_id) if impl.team_id else str(uuid.uuid4()),
+        "squad_id": str(uuid.uuid4()),
+        "user_message": False,
+    }
+    return ActorAddressProxy(addr_dict)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestProcessHumanInputIntegration:
+    """AC8: End-to-end multi-human integration test."""
+
+    def test_rehydrate_and_route_to_support(
+        self,
+        actor_system: ActorSystem,
+    ) -> None:
+        """Full flow: create team, build message with proxy addrs, call process_human_input.
+
+        Verifies:
+        - @Support (not @Human) receives the call
+        - @Support successfully sends a reply back to @Manager (live address invariant)
+        - @Manager receives the reply
+        """
+        event_store = InMemoryEventStore()
+        manager = TeamManager(actor_system, event_store)
+        team_card = _make_multi_human_team_card()
+
+        runtime = manager.create_team(team_card)
+
+        # Get live addresses for @Manager and @Support
+        manager_addr = runtime._orchestrator_proxy.get_team_member("@Manager")
+        support_addr = runtime._orchestrator_proxy.get_team_member("@Support")
+        assert manager_addr is not None
+        assert support_addr is not None
+
+        # Simulate what YamlEventStore.load_events() produces: proxy addresses
+        proxy_sender = _addr_to_proxy(manager_addr)
+        proxy_recipient = _addr_to_proxy(support_addr)
+
+        # Build a message with proxy addresses (as would come from event store reload)
+        message = UserMessage(content="@Support describe your role")
+        message.sender = proxy_sender
+        message.recipient = proxy_recipient
+
+        # This is the method under test
+        runtime.process_human_input("I coordinate user onboarding", message)
+
+        # Wait for @Support to process the call
+        reached = wait_for_agent_state(
+            support_addr,
+            lambda state: getattr(state, "call_count", 0) >= 1,
+            timeout=3.0,
+        )
+        assert reached, "@Support did not receive process_human_input call"
+
+        # Wait for @Manager to receive the reply from @Support
+        reached = wait_for_agent_state(
+            manager_addr,
+            lambda state: getattr(state, "counter", 0) >= 1,
+            timeout=3.0,
+        )
+        assert reached, "@Manager did not receive reply from @Support (live address invariant)"

--- a/tests/integration/test_process_human_input.py
+++ b/tests/integration/test_process_human_input.py
@@ -7,9 +7,7 @@ and routed to the correct UserProxy agent.
 
 from __future__ import annotations
 
-import time
 import uuid
-from typing import Any
 
 import pykka
 import pytest
@@ -26,12 +24,10 @@ from akgentic.core.utils.deserializer import ActorAddressDict
 from akgentic.team.manager import TeamManager
 from akgentic.team.models import TeamCard, TeamCardMember
 from tests.integration.conftest import (
-    RecordingAgent,
     make_integration_agent_card,
     wait_for_agent_state,
 )
 from tests.services.conftest import InMemoryEventStore
-
 
 # ---------------------------------------------------------------------------
 # Agent classes for this test

--- a/tests/models/test_team_runtime.py
+++ b/tests/models/test_team_runtime.py
@@ -238,7 +238,6 @@ class TestTeamRuntimeSendToResolution:
     def test_send_to_resolves_proxy_address(self) -> None:
         """If orchestrator returns a proxy, send_to() resolves it via addr_map."""
         from akgentic.core.actor_address_impl import ActorAddressProxy
-        from akgentic.core.utils.deserializer import ActorAddressDict
 
         agent_id = uuid.uuid4()
         team_id = uuid.uuid4()
@@ -275,7 +274,6 @@ class TestTeamRuntimeSendToResolution:
     def test_send_to_raises_for_unmapped_proxy(self) -> None:
         """If proxy has no mapping in addr_map, raise ValueError."""
         from akgentic.core.actor_address_impl import ActorAddressProxy
-        from akgentic.core.utils.deserializer import ActorAddressDict
 
         addr_dict: ActorAddressDict = {
             "__actor_address__": True,
@@ -342,7 +340,6 @@ class TestTeamRuntimeSendFromTo:
     def test_send_from_to_resolves_stale_sender_proxy(self) -> None:
         """AC4: stale sender proxy is resolved via _addr_map."""
         from akgentic.core.actor_address_impl import ActorAddressProxy
-        from akgentic.core.utils.deserializer import ActorAddressDict
 
         agent_id = uuid.uuid4()
         addr_dict: ActorAddressDict = {
@@ -374,7 +371,6 @@ class TestTeamRuntimeSendFromTo:
     def test_send_from_to_resolves_stale_recipient_proxy(self) -> None:
         """AC4: stale recipient proxy is resolved via _addr_map."""
         from akgentic.core.actor_address_impl import ActorAddressProxy
-        from akgentic.core.utils.deserializer import ActorAddressDict
 
         agent_id = uuid.uuid4()
         addr_dict: ActorAddressDict = {

--- a/tests/models/test_team_runtime.py
+++ b/tests/models/test_team_runtime.py
@@ -6,9 +6,12 @@ import uuid
 from unittest.mock import MagicMock
 
 import pytest
+from akgentic.core.actor_address import ActorAddress
+from akgentic.core.actor_address_impl import ActorAddressProxy
 from akgentic.core.agent import Akgent
 from akgentic.core.messages.message import UserMessage
 from akgentic.core.user_proxy import UserProxy
+from akgentic.core.utils.deserializer import ActorAddressDict
 from pydantic import ValidationError
 
 from akgentic.team.models import TeamCard, TeamCardMember, TeamRuntime
@@ -415,127 +418,235 @@ class TestTeamRuntimeSendFromTo:
         assert call_args.args[1].content == "hello"
 
 
+def _make_proxy_addr(name: str, role: str = "Agent") -> ActorAddressProxy:
+    """Create an ActorAddressProxy for testing."""
+    addr_dict: ActorAddressDict = {
+        "__actor_address__": True,
+        "__actor_type__": "akgentic.core.agent.Akgent",
+        "agent_id": str(uuid.uuid4()),
+        "name": name,
+        "role": role,
+        "team_id": str(uuid.uuid4()),
+        "squad_id": str(uuid.uuid4()),
+        "user_message": False,
+    }
+    return ActorAddressProxy(addr_dict)
+
+
+def _make_multi_human_runtime(
+    *,
+    human_class: type = UserProxy,
+    support_class: type = UserProxy,
+) -> TeamRuntime:
+    """Build a TeamRuntime with @Human and @Support both as UserProxy."""
+    human_card = make_agent_card(name="@Human", role="Human", agent_class=human_class)
+    support_card = make_agent_card(
+        name="@Support", role="Support", agent_class=support_class
+    )
+    manager_card = make_agent_card(name="@Manager", role="Manager", agent_class=Akgent)
+    entry_card = make_agent_card(name="lead", role="Lead", agent_class=Akgent)
+
+    tc = TeamCard(
+        name="multi-human-team",
+        description="Team with two UserProxy agents",
+        entry_point=TeamCardMember(card=entry_card),
+        members=[
+            TeamCardMember(card=human_card),
+            TeamCardMember(card=support_card),
+            TeamCardMember(card=manager_card),
+        ],
+        message_types=[UserMessage],
+    )
+    return make_team_runtime(team_card=tc)
+
+
 class TestTeamRuntimeProcessHumanInput:
-    """AC 1-4 (Story 17.1): process_human_input() routes to UserProxy agent."""
+    """AC 1-7 (Story 16.1): process_human_input rehydrates and routes by recipient."""
 
-    def _make_runtime_with_userproxy(
-        self,
-        *,
-        include_addr: bool = True,
-    ) -> tuple[TeamRuntime, MagicMock]:
-        """Build a TeamRuntime whose team includes a UserProxy agent card.
-
-        Args:
-            include_addr: Whether to populate addrs with the UserProxy address.
-
-        Returns:
-            Tuple of (runtime, user_proxy_addr).
-        """
-        user_proxy_card = make_agent_card(
-            name="human", role="UserProxy", agent_class=UserProxy
-        )
-        worker_card = make_agent_card(name="worker", role="Worker", agent_class=Akgent)
-        entry_card = make_agent_card(name="lead", role="Lead", agent_class=Akgent)
-
-        entry_member = TeamCardMember(card=entry_card)
-        tc = TeamCard(
-            name="team-with-human",
-            description="A team with a UserProxy",
-            entry_point=entry_member,
-            members=[
-                TeamCardMember(card=user_proxy_card),
-                TeamCardMember(card=worker_card),
-            ],
-            message_types=[UserMessage],
-        )
-
-        proxy_addr = make_stub_addr("human")
-        addrs: dict[str, MagicMock] = {}
-        if include_addr:
-            addrs["human"] = proxy_addr
-
-        runtime = make_team_runtime(team_card=tc, addrs=addrs)
-        return runtime, proxy_addr
-
-    def test_happy_path(self) -> None:
-        """AC1-2: process_human_input routes to UserProxy via proxy_ask."""
-        runtime, proxy_addr = self._make_runtime_with_userproxy()
-        message = UserMessage(content="What should I do?")
-
-        runtime.process_human_input("Continue with plan A", message)
-
-        runtime.actor_system.proxy_ask.assert_any_call(proxy_addr, UserProxy)
-        proxy = runtime.actor_system.proxy_ask.return_value
-        proxy.process_human_input.assert_called_once_with(
-            "Continue with plan A", message
-        )
-
-    def test_no_userproxy_in_team(self) -> None:
-        """AC3: ValueError when no UserProxy agent exists in team."""
-        runtime = make_team_runtime(message_types=[UserMessage])
+    def test_recipient_none_raises_valueerror(self) -> None:
+        """AC1: ValueError when message.recipient is None; resolver never called."""
+        runtime = _make_multi_human_runtime()
         message = UserMessage(content="hello")
+        assert message.recipient is None
 
-        with pytest.raises(ValueError, match="No UserProxy found in team"):
+        with pytest.raises(ValueError, match="no recipient"):
             runtime.process_human_input("response", message)
 
-    def test_userproxy_with_missing_address(self) -> None:
-        """AC4: ValueError when UserProxy has no resolved address."""
-        runtime, _ = self._make_runtime_with_userproxy(include_addr=False)
-        message = UserMessage(content="hello")
+        # Orchestrator should never be consulted
+        runtime._orchestrator_proxy.get_team_member.assert_not_called()
 
-        with pytest.raises(ValueError, match="has no resolved address"):
-            runtime.process_human_input("response", message)
+    def test_rehydration_replaces_proxy_addresses(self) -> None:
+        """AC2: ActorAddressProxy sender/recipient are replaced with live addresses."""
+        proxy_sender = _make_proxy_addr("@Manager", "Manager")
+        proxy_recipient = _make_proxy_addr("@Support", "Support")
 
-    def test_empty_agent_cards(self) -> None:
-        """AC3: ValueError when team has no members at all."""
-        entry_card = make_agent_card(name="lead", role="Lead", agent_class=Akgent)
-        tc = TeamCard(
-            name="empty-team",
-            description="A team with no members",
-            entry_point=TeamCardMember(card=entry_card),
-            members=[],
-            message_types=[UserMessage],
-        )
-        runtime = make_team_runtime(team_card=tc)
-        message = UserMessage(content="hello")
+        live_sender = make_stub_addr("@Manager")
+        live_recipient = make_stub_addr("@Support")
+        target_addr = make_stub_addr("@Support")
 
-        with pytest.raises(ValueError, match="No UserProxy found in team"):
-            runtime.process_human_input("response", message)
+        runtime = _make_multi_human_runtime()
+        runtime._orchestrator_proxy.get_team_member = MagicMock(
+            side_effect=lambda name: {
+                "@Manager": live_sender,
+                "@Support": live_recipient,
+            }.get(name)
+        )
+        # _lookup_member also calls get_team_member, return target_addr for it
+        original_get = runtime._orchestrator_proxy.get_team_member.side_effect
 
-    def test_multiple_agents_only_userproxy_matched(self) -> None:
-        """AC2: Only the UserProxy agent is called among multiple agents."""
-        user_proxy_card = make_agent_card(
-            name="human", role="UserProxy", agent_class=UserProxy
-        )
-        worker1_card = make_agent_card(
-            name="worker1", role="Worker1", agent_class=Akgent
-        )
-        worker2_card = make_agent_card(
-            name="worker2", role="Worker2", agent_class=Akgent
-        )
-        entry_card = make_agent_card(name="lead", role="Lead", agent_class=Akgent)
+        def combined_get(name: str) -> ActorAddress | None:
+            result = original_get(name)
+            return result if result is not None else target_addr if name == "@Support" else None
 
-        tc = TeamCard(
-            name="multi-agent-team",
-            description="Team with 3+ agents, only one UserProxy",
-            entry_point=TeamCardMember(card=entry_card),
-            members=[
-                TeamCardMember(card=worker1_card),
-                TeamCardMember(card=user_proxy_card),
-                TeamCardMember(card=worker2_card),
-            ],
-            message_types=[UserMessage],
-        )
+        runtime._orchestrator_proxy.get_team_member = MagicMock(side_effect=combined_get)
 
-        proxy_addr = make_stub_addr("human")
-        runtime = make_team_runtime(
-            team_card=tc,
-            addrs={"human": proxy_addr},
-        )
         message = UserMessage(content="question")
+        message.sender = proxy_sender
+        message.recipient = proxy_recipient
+
+        runtime.process_human_input("I coordinate onboarding", message)
+
+        # Verify the downstream proxy received a message with live addresses
+        proxy = runtime.actor_system.proxy_ask.return_value
+        proxy.process_human_input.assert_called_once()
+        call_args = proxy.process_human_input.call_args
+        live_msg = call_args.args[1]
+        # The rehydrated message should NOT be the original
+        assert live_msg is not message
+        # Sender and recipient should be live (not ActorAddressProxy)
+        assert not isinstance(live_msg.sender, ActorAddressProxy)
+        assert not isinstance(live_msg.recipient, ActorAddressProxy)
+
+    def test_orchestrator_lookup_miss_raises_valueerror(self) -> None:
+        """AC3: ValueError with 'not found in team' when resolver can't find agent."""
+        proxy_sender = _make_proxy_addr("@Ghost", "Ghost")
+        proxy_recipient = _make_proxy_addr("@Support", "Support")
+
+        runtime = _make_multi_human_runtime()
+        runtime._orchestrator_proxy.get_team_member = MagicMock(return_value=None)
+
+        message = UserMessage(content="question")
+        message.sender = proxy_sender
+        message.recipient = proxy_recipient
+
+        with pytest.raises(ValueError, match="not found in team"):
+            runtime.process_human_input("response", message)
+
+    def test_routes_by_recipient_name_not_first_match(self) -> None:
+        """AC4: Routes to @Support by name, not first UserProxy in dict order."""
+        live_sender = make_stub_addr("@Manager")
+        live_support = make_stub_addr("@Support")
+
+        runtime = _make_multi_human_runtime()
+        runtime._orchestrator_proxy.get_team_member = MagicMock(
+            side_effect=lambda name: {
+                "@Manager": live_sender,
+                "@Support": live_support,
+            }.get(name)
+        )
+
+        proxy_sender = _make_proxy_addr("@Manager", "Manager")
+        proxy_recipient = _make_proxy_addr("@Support", "Support")
+        message = UserMessage(content="describe your role")
+        message.sender = proxy_sender
+        message.recipient = proxy_recipient
+
+        runtime.process_human_input("I coordinate user onboarding", message)
+
+        # Verify proxy_ask was called with the @Support address
+        runtime.actor_system.proxy_ask.assert_any_call(live_support, UserProxy)
+
+    def test_target_not_userproxy_raises_valueerror(self) -> None:
+        """AC5: ValueError when target agent is not a UserProxy subclass."""
+        live_sender = make_stub_addr("@Human")
+        live_manager = make_stub_addr("@Manager")
+
+        runtime = _make_multi_human_runtime()
+        runtime._orchestrator_proxy.get_team_member = MagicMock(
+            side_effect=lambda name: {
+                "@Human": live_sender,
+                "@Manager": live_manager,
+            }.get(name)
+        )
+
+        proxy_sender = _make_proxy_addr("@Human", "Human")
+        proxy_recipient = _make_proxy_addr("@Manager", "Manager")
+        message = UserMessage(content="hello")
+        message.sender = proxy_sender
+        message.recipient = proxy_recipient
+
+        with pytest.raises(ValueError, match="is not a UserProxy"):
+            runtime.process_human_input("response", message)
+
+    def test_downstream_receives_rehydrated_message(self) -> None:
+        """AC6: The message passed downstream is the rehydrated copy, not original."""
+        live_sender = make_stub_addr("@Manager")
+        live_support = make_stub_addr("@Support")
+
+        runtime = _make_multi_human_runtime()
+        runtime._orchestrator_proxy.get_team_member = MagicMock(
+            side_effect=lambda name: {
+                "@Manager": live_sender,
+                "@Support": live_support,
+            }.get(name)
+        )
+
+        proxy_sender = _make_proxy_addr("@Manager", "Manager")
+        proxy_recipient = _make_proxy_addr("@Support", "Support")
+        message = UserMessage(content="question")
+        message.sender = proxy_sender
+        message.recipient = proxy_recipient
 
         runtime.process_human_input("answer", message)
 
-        runtime.actor_system.proxy_ask.assert_any_call(proxy_addr, UserProxy)
         proxy = runtime.actor_system.proxy_ask.return_value
-        proxy.process_human_input.assert_called_once_with("answer", message)
+        call_args = proxy.process_human_input.call_args
+        delivered_msg = call_args.args[1]
+        # Must be a different object (rehydrated copy)
+        assert delivered_msg is not message
+        assert delivered_msg.content == "question"
+
+    def test_dynamic_agent_resolved_by_orchestrator(self) -> None:
+        """AC7: Orchestrator resolves @Expert even if not in self.addrs."""
+        live_sender = make_stub_addr("@Human")
+        live_expert = make_stub_addr("@Expert")
+
+        # Build a runtime where @Expert is in agent_cards as UserProxy
+        expert_card = make_agent_card(
+            name="@Expert", role="Expert", agent_class=UserProxy
+        )
+        human_card = make_agent_card(
+            name="@Human", role="Human", agent_class=UserProxy
+        )
+        entry_card = make_agent_card(name="lead", role="Lead", agent_class=Akgent)
+
+        tc = TeamCard(
+            name="dynamic-team",
+            description="Team where @Expert is hired at runtime",
+            entry_point=TeamCardMember(card=entry_card),
+            members=[
+                TeamCardMember(card=human_card),
+                TeamCardMember(card=expert_card),
+            ],
+            message_types=[UserMessage],
+        )
+        # addrs does NOT include @Expert -- simulating runtime hiring
+        runtime = make_team_runtime(team_card=tc, addrs={})
+
+        runtime._orchestrator_proxy.get_team_member = MagicMock(
+            side_effect=lambda name: {
+                "@Human": live_sender,
+                "@Expert": live_expert,
+            }.get(name)
+        )
+
+        proxy_sender = _make_proxy_addr("@Human", "Human")
+        proxy_recipient = _make_proxy_addr("@Expert", "Expert")
+        message = UserMessage(content="question")
+        message.sender = proxy_sender
+        message.recipient = proxy_recipient
+
+        runtime.process_human_input("I am an expert", message)
+
+        # Verify _lookup_member resolved via orchestrator (not self.addrs)
+        runtime.actor_system.proxy_ask.assert_any_call(live_expert, UserProxy)


### PR DESCRIPTION
## Summary
- Replace buggy `process_human_input` in `TeamRuntime` that crashed on `ActorAddressProxy` and routed to wrong `UserProxy` in multi-human teams
- New implementation validates recipient, rehydrates proxy addresses via `hydrate_addresses` + orchestrator-backed resolver, routes by `message.recipient.name`
- 7 unit tests covering AC1-7, 1 integration test with real actors verifying end-to-end rehydration and reply delivery

Relates to #87