### PR TITLE
Event stream parity on restore

### DIFF
--- a/src/akgentic/team/restorer.py
+++ b/src/akgentic/team/restorer.py
@@ -369,8 +369,11 @@ class TeamRestorer:
         """Phase 2: Rebuild agents from the event log.
 
         Determines live agents via StartMessage/StopMessage filtering,
-        rebuilds the Orchestrator first, registers passed subscribers, spawns
-        remaining agents, restores agent states, and registers agent profiles.
+        rebuilds the Orchestrator first, spawns remaining agents, restores
+        agent states and LLM contexts, registers agent profiles, and
+        finally registers subscribers. Subscribers are registered last
+        so they only start receiving events during Phase 3 replay,
+        ensuring event stream parity with freshly started teams (ADR-014).
 
         Args:
             process: The Process record containing the team card.
@@ -411,10 +414,6 @@ class TeamRestorer:
             orchestrator_start, team_id, spawned_addrs
         )
 
-        # 2c. Register passed subscribers directly (no internal creation)
-        for sub in subscribers:
-            orchestrator_proxy.subscribe(sub)
-
         # 2d. Spawn remaining agents through resolved parents
         addrs = self._spawn_agents(agent_starts, orchestrator_addr, spawned_addrs)
 
@@ -438,6 +437,11 @@ class TeamRestorer:
         # would cause the LLM to hire duplicates via role names.
         if process.team_card.agent_profiles:
             orchestrator_proxy.register_agent_profiles(process.team_card.agent_profiles)
+
+        # 2h. Register subscribers last — ensures they only receive events
+        # during Phase 3 replay, matching fresh-team event stream (ADR-014).
+        for sub in subscribers:
+            orchestrator_proxy.subscribe(sub)
 
         return _RebuildResult(
             orchestrator_addr=orchestrator_addr,
@@ -472,8 +476,6 @@ class TeamRestorer:
         self._resolve_event_addresses(events, addr_map)
 
         for pe in events:
-            if isinstance(pe.event, StartMessage):
-                continue  # Already registered during Phase 2 spawn
             orchestrator_proxy.restore_message(pe.event)
 
         orchestrator_proxy.end_restoration()

--- a/src/akgentic/team/restorer.py
+++ b/src/akgentic/team/restorer.py
@@ -368,12 +368,16 @@ class TeamRestorer:
     ) -> _RebuildResult:
         """Phase 2: Rebuild agents from the event log.
 
-        Determines live agents via StartMessage/StopMessage filtering,
-        rebuilds the Orchestrator first, spawns remaining agents, restores
-        agent states and LLM contexts, registers agent profiles, and
-        finally registers subscribers. Subscribers are registered last
-        so they only start receiving events during Phase 3 replay,
-        ensuring event stream parity with freshly started teams (ADR-014).
+        Steps 2a-2g:
+          a. Determine live agents (StartMessage/StopMessage filtering)
+          b. Rebuild Orchestrator first
+          c. Spawn remaining agents through resolved parents
+          d. Restore agent states from snapshots
+          e. Restore LLM contexts from persisted EventMessages
+          f. Register hireable agent profiles with orchestrator
+          g. Register subscribers (last — so they only receive events during
+             Phase 3 replay, ensuring event stream parity with freshly
+             started teams; see ADR-014)
 
         Args:
             process: The Process record containing the team card.
@@ -414,31 +418,31 @@ class TeamRestorer:
             orchestrator_start, team_id, spawned_addrs
         )
 
-        # 2d. Spawn remaining agents through resolved parents
+        # 2c. Spawn remaining agents through resolved parents
         addrs = self._spawn_agents(agent_starts, orchestrator_addr, spawned_addrs)
 
-        # 2e. Restore agent states
+        # 2d. Restore agent states
         state_map: dict[str, AgentStateSnapshot] = {snap.agent_id: snap for snap in agent_states}
         for agent_name, addr in addrs.items():
             if agent_name in state_map:
                 proxy: Akgent[Any, Any] = self._actor_system.proxy_ask(addr, Akgent)
                 proxy.init_state(state_map[agent_name].state)
 
-        # 2f. Restore LLM context from persisted events
+        # 2e. Restore LLM context from persisted events
         for agent_name, addr in addrs.items():
             agent_events = self._filter_event_messages(events, addr.agent_id)
             if agent_events:
                 proxy_llm: Akgent[Any, Any] = self._actor_system.proxy_ask(addr, Akgent)
                 proxy_llm.init_llm_context(agent_events)
 
-        # 2g. Register hireable agent profiles with orchestrator
+        # 2f. Register hireable agent profiles with orchestrator
         # Only profiles listed in agent_profiles are available for runtime
         # hiring. Instantiated members are already live — registering them
         # would cause the LLM to hire duplicates via role names.
         if process.team_card.agent_profiles:
             orchestrator_proxy.register_agent_profiles(process.team_card.agent_profiles)
 
-        # 2h. Register subscribers last — ensures they only receive events
+        # 2g. Register subscribers last — ensures they only receive events
         # during Phase 3 replay, matching fresh-team event stream (ADR-014).
         for sub in subscribers:
             orchestrator_proxy.subscribe(sub)

--- a/tests/services/test_restorer.py
+++ b/tests/services/test_restorer.py
@@ -725,6 +725,47 @@ class TestTeamRestorerRollback:
             time.sleep(0.01)
         assert recording.stopped is True
 
+    def test_subscriber_receives_start_messages_during_replay(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """Subscriber receives StartMessage events for all agents during Phase 3 replay.
+
+        Story 14.9 AC 4: Given a team with 3 agents that is stopped and resumed,
+        when a subscriber is registered during restore, then the subscriber
+        receives StartMessage events for all 3 agents during Phase 3 replay.
+        """
+        worker1 = _make_member("worker1", "Worker")
+        worker2 = _make_member("worker2", "Worker")
+        tc = _make_team_card(members=[worker1, worker2])
+
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        recording = RecordingSubscriber()
+
+        restorer = TeamRestorer(actor_system, event_store)
+        restorer.restore(process, subscribers=[recording])
+
+        # Filter StartMessage events received by the subscriber
+        start_messages = [
+            m for m in recording.messages if isinstance(m, StartMessage)
+        ]
+
+        # Should receive StartMessages for orchestrator + lead + worker1 + worker2
+        start_names = {
+            m.sender.name for m in start_messages if m.sender is not None
+        }
+        assert "lead" in start_names, (
+            f"Missing StartMessage for 'lead'; received: {start_names}"
+        )
+        assert "worker1" in start_names, (
+            f"Missing StartMessage for 'worker1'; received: {start_names}"
+        )
+        assert "worker2" in start_names, (
+            f"Missing StartMessage for 'worker2'; received: {start_names}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Tests: Hierarchy propagation during restore (Story 10-1, AC 3, 5)


### PR DESCRIPTION
## Summary

- Move subscriber registration from step 2c to end of `_rebuild_agents()` so subscribers only observe events during Phase 3 replay, matching fresh-team event stream
- Remove `StartMessage` skip filter from `_replay_events()` so all events are replayed including `StartMessage`
- Update `_rebuild_agents` docstring with explicit step listing (2a-2g)

## Code Review Fixes Applied

- Renumbered `_rebuild_agents()` steps 2d-2h to 2c-2g (closed gap left by removed step)
- Updated docstring with explicit step listing for clarity
- Added `test_subscriber_receives_start_messages_during_replay` covering AC 4

Closes #91
