### PR TITLE
NagraEventStore implementation — all 9 EventStore Protocol methods

### DIFF
--- a/src/akgentic/team/repositories/postgres/_queries.py
+++ b/src/akgentic/team/repositories/postgres/_queries.py
@@ -1,7 +1,42 @@
-"""Query helpers scaffold for the Nagra-backed Postgres event store.
+"""Query helpers for the Nagra-backed Postgres event store.
 
-This module is intentionally empty in story 17.1. Helper functions for
-``save_event``/``load_events``/``save_team``/etc. may land here in story
-17.2, or be absorbed directly into ``event_store.py`` if no shared shape
-emerges.
+This module currently exposes a single helper, :func:`decode_jsonb_column`,
+used by :class:`~akgentic.team.repositories.postgres.event_store.NagraEventStore`
+to normalise JSONB column values to Python dicts before Pydantic hydration.
+
+The helper is duplicated locally rather than imported from
+``akgentic.catalog.repositories.postgres._queries`` because ``akgentic-catalog``
+sits ABOVE ``akgentic-team`` in the dependency graph (see CLAUDE.md
+"Dependency graph"). A cross-layer import would be a module-boundary
+violation. The helper is four lines; duplicating it keeps team's dependency
+surface clean.
+
+Implements ADR-15 §3 (payload-authoritative JSONB hydration).
 """
+
+from __future__ import annotations
+
+import json
+from typing import cast
+
+__all__ = [
+    "decode_jsonb_column",
+]
+
+
+def decode_jsonb_column(raw: object) -> dict[str, object]:
+    """Normalise a JSONB column value to a Python dict.
+
+    psycopg 3 decodes JSONB columns to native Python objects by default, but
+    some driver configurations (or the plain ``JSON`` column type used by the
+    team schema) return a JSON string. Handle both so hydration is robust
+    regardless of the adapter wiring.
+
+    Mirrors the catalog helper at
+    ``akgentic.catalog.repositories.postgres._queries.decode_jsonb_column``.
+    Kept local to avoid a cross-submodule private-module import — see this
+    module's docstring for the rationale.
+    """
+    if isinstance(raw, str):
+        return cast("dict[str, object]", json.loads(raw))
+    return cast("dict[str, object]", raw)

--- a/src/akgentic/team/repositories/postgres/event_store.py
+++ b/src/akgentic/team/repositories/postgres/event_store.py
@@ -1,35 +1,39 @@
-"""``NagraEventStore`` stub — full implementation lands in story 17.2.
+"""Nagra-backed ``EventStore`` implementation.
 
-This module declares the class shape so the surrounding skeleton (schema
-loader, ``init_db``, packaging, init-container script, test fixtures) is
-verifiable end-to-end without committing to query helpers in 17.1. Every
-:class:`~akgentic.team.ports.EventStore` method raises
-``NotImplementedError`` with a pointer to story 17.2.
+Implements the nine :class:`~akgentic.team.ports.EventStore` Protocol methods
+against PostgreSQL using Nagra's :class:`~nagra.Transaction` wrapper. Each
+public method opens its own transaction (per-method ownership);
+:meth:`NagraEventStore.delete_team` is the one exception that spans a single
+transaction across three ``DELETE`` statements for atomic cascade semantics.
 
-The class satisfies the ``EventStore`` protocol via structural subtyping
-— it does NOT inherit from the Protocol explicitly (mirrors
-``YamlEventStore`` and ``MongoEventStore``).
+The class satisfies the ``EventStore`` Protocol via structural subtyping — it
+does NOT inherit from the Protocol explicitly (mirrors ``YamlEventStore`` and
+``MongoEventStore``).
+
+Implements ADR-15 Nagra-based PostgreSQL EventStore §§2, 3, 4, 8, 9, 10.
 """
 
 from __future__ import annotations
 
+import json
 import uuid
 
-from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process
+from nagra import Transaction  # type: ignore[import-untyped]
 
-_NOT_IMPLEMENTED_MSG = "Implemented in story 17.2"
+from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process
+from akgentic.team.repositories.postgres._queries import decode_jsonb_column
 
 
 class NagraEventStore:
-    """Nagra-backed ``EventStore`` stub.
+    """Nagra-backed ``EventStore`` implementation.
 
     Constructor calls :func:`_ensure_schema_loaded` so instances are always
     safe to build, but does NOT call :func:`init_db` — operators must
     invoke ``python -m akgentic.team.scripts.init_db`` once per deployment.
 
     Args:
-        conn_string: Nagra-compatible Postgres connection string used by
-            the (forthcoming) query helpers.
+        conn_string: Nagra-compatible Postgres connection string used to
+            open per-method transactions.
     """
 
     def __init__(self, conn_string: str) -> None:
@@ -41,29 +45,117 @@ class NagraEventStore:
         _ensure_schema_loaded()
         self._conn_string = conn_string
 
-    def save_event(self, event: PersistedEvent) -> None:
-        raise NotImplementedError(_NOT_IMPLEMENTED_MSG)
-
-    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
-        raise NotImplementedError(_NOT_IMPLEMENTED_MSG)
+    # --- team process (team_process_entries) -------------------------------
 
     def save_team(self, process: Process) -> None:
-        raise NotImplementedError(_NOT_IMPLEMENTED_MSG)
+        """Upsert a team process snapshot keyed by ``team_id``."""
+        data = json.dumps(process.model_dump())
+        with Transaction(self._conn_string) as trn:
+            trn.execute(
+                "INSERT INTO team_process_entries (id, data) VALUES (%s, %s) "
+                "ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data",
+                (str(process.team_id), data),
+            )
 
     def load_team(self, team_id: uuid.UUID) -> Process | None:
-        raise NotImplementedError(_NOT_IMPLEMENTED_MSG)
-
-    def delete_team(self, team_id: uuid.UUID) -> None:
-        raise NotImplementedError(_NOT_IMPLEMENTED_MSG)
-
-    def save_agent_state(self, snapshot: AgentStateSnapshot) -> None:
-        raise NotImplementedError(_NOT_IMPLEMENTED_MSG)
+        """Load a team process snapshot by id; return ``None`` if absent."""
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(
+                "SELECT data FROM team_process_entries WHERE id = %s",
+                (str(team_id),),
+            )
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        return Process.model_validate(decode_jsonb_column(row[0]))
 
     def list_teams(self) -> list[Process]:
-        raise NotImplementedError(_NOT_IMPLEMENTED_MSG)
+        """Return every persisted team process. Order is unspecified."""
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute("SELECT data FROM team_process_entries")
+            rows = cursor.fetchall()
+        return [Process.model_validate(decode_jsonb_column(r[0])) for r in rows]
+
+    def delete_team(self, team_id: uuid.UUID) -> None:
+        """Cascade-delete a team across all three tables in ONE transaction.
+
+        Order (dependency-safe): ``agent_state_entries`` → ``event_entries``
+        → ``team_process_entries``. Idempotent: calling twice for the same
+        id is a no-op on the second call (matches YAML / Mongo semantics).
+        """
+        tid = str(team_id)
+        with Transaction(self._conn_string) as trn:
+            trn.execute(
+                "DELETE FROM agent_state_entries WHERE team_id = %s", (tid,)
+            )
+            trn.execute("DELETE FROM event_entries WHERE team_id = %s", (tid,))
+            trn.execute(
+                "DELETE FROM team_process_entries WHERE id = %s", (tid,)
+            )
+
+    # --- events (event_entries) -------------------------------------------
+
+    def save_event(self, event: PersistedEvent) -> None:
+        """Append a single event. No upsert — events are immutable."""
+        data = json.dumps(event.model_dump())
+        with Transaction(self._conn_string) as trn:
+            trn.execute(
+                "INSERT INTO event_entries (team_id, sequence, data) "
+                "VALUES (%s, %s, %s)",
+                (str(event.team_id), event.sequence, data),
+            )
+
+    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
+        """Return all events for a team ordered by ``sequence`` ASC."""
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(
+                "SELECT data FROM event_entries WHERE team_id = %s "
+                "ORDER BY sequence ASC",
+                (str(team_id),),
+            )
+            rows = cursor.fetchall()
+        return [PersistedEvent.model_validate(decode_jsonb_column(r[0])) for r in rows]
 
     def get_max_sequence(self, team_id: uuid.UUID) -> int:
-        raise NotImplementedError(_NOT_IMPLEMENTED_MSG)
+        """Return the largest sequence for a team, or ``0`` if empty.
+
+        Uses ``COALESCE(MAX(sequence), 0)`` so the empty-team case is a
+        single round-trip and the method always returns an ``int`` (never
+        ``None``).
+        """
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(
+                "SELECT COALESCE(MAX(sequence), 0) FROM event_entries "
+                "WHERE team_id = %s",
+                (str(team_id),),
+            )
+            row = cursor.fetchone()
+        assert row is not None  # aggregate always returns one row
+        result: int = row[0]
+        return result
+
+    # --- agent states (agent_state_entries) --------------------------------
+
+    def save_agent_state(self, snapshot: AgentStateSnapshot) -> None:
+        """Upsert an agent state snapshot keyed by ``(team_id, agent_id)``."""
+        data = json.dumps(snapshot.model_dump())
+        with Transaction(self._conn_string) as trn:
+            trn.execute(
+                "INSERT INTO agent_state_entries (team_id, agent_id, data) "
+                "VALUES (%s, %s, %s) "
+                "ON CONFLICT (team_id, agent_id) DO UPDATE SET data = EXCLUDED.data",
+                (str(snapshot.team_id), snapshot.agent_id, data),
+            )
 
     def load_agent_states(self, team_id: uuid.UUID) -> list[AgentStateSnapshot]:
-        raise NotImplementedError(_NOT_IMPLEMENTED_MSG)
+        """Return every agent-state snapshot for a team. Order unspecified."""
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(
+                "SELECT data FROM agent_state_entries WHERE team_id = %s",
+                (str(team_id),),
+            )
+            rows = cursor.fetchall()
+        return [
+            AgentStateSnapshot.model_validate(decode_jsonb_column(r[0]))
+            for r in rows
+        ]

--- a/tests/repositories/postgres/test_event_store.py
+++ b/tests/repositories/postgres/test_event_store.py
@@ -1,0 +1,323 @@
+"""Tests for ``NagraEventStore`` — Postgres-backed ``EventStore``.
+
+Validates all nine ``EventStore`` Protocol methods including:
+
+* per-method ``Transaction`` ownership and upsert / delete semantics,
+* polymorphic ``Message`` / ``BaseState`` round-trip through JSONB,
+* cascading ``delete_team`` across all three tables,
+* schema-drift / payload-authority invariant — promoted columns are
+  routing keys only; ``data`` JSONB is the single source of truth.
+
+Acceptance Criteria: AC #19 through AC #30 from story 17.2.
+
+The Postgres directory is gated by ``conftest.py``'s
+``pytest.importorskip("nagra")`` / ``pytest.importorskip("testcontainers.postgres")``
+so this module never runs when those optional dependencies are missing.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+from akgentic.core.messages.message import UserMessage
+from nagra import Transaction  # type: ignore[import-untyped]
+
+from akgentic.team.models import TeamStatus
+from akgentic.team.repositories.postgres import NagraEventStore
+
+if TYPE_CHECKING:
+    from akgentic.team.ports import EventStore
+
+from tests.models.conftest import (
+    SampleAgentState,
+    make_agent_state_snapshot,
+    make_persisted_event,
+    make_process,
+)
+
+
+class TestNagraEventStore:
+    """All nine EventStore Protocol methods plus payload-authority invariant."""
+
+    # --- Protocol compliance (AC #19) -------------------------------------
+
+    def test_satisfies_event_store_protocol(
+        self, postgres_clean_tables: str
+    ) -> None:
+        """AC #19: NagraEventStore satisfies EventStore Protocol structurally."""
+        store: EventStore = NagraEventStore(postgres_clean_tables)
+        assert store is not None
+
+    # --- save_team / load_team round-trip (AC #20) ------------------------
+
+    def test_save_and_load_team_round_trip(
+        self, postgres_clean_tables: str
+    ) -> None:
+        """AC #20: save_team upserts; load_team hydrates via JSONB."""
+        store = NagraEventStore(postgres_clean_tables)
+        process = make_process()
+        store.save_team(process)
+        loaded = store.load_team(process.team_id)
+
+        assert loaded is not None
+        assert loaded.team_id == process.team_id
+        assert loaded.status == process.status
+        assert loaded.team_card.name == process.team_card.name
+        assert loaded.created_at == process.created_at
+
+    def test_save_team_upserts_on_second_call(
+        self, postgres_clean_tables: str
+    ) -> None:
+        """AC #20: save_team upserts on subsequent calls for the same team_id."""
+        store = NagraEventStore(postgres_clean_tables)
+        process = make_process(status=TeamStatus.RUNNING)
+        store.save_team(process)
+
+        updated = make_process(team_id=process.team_id, status=TeamStatus.STOPPED)
+        store.save_team(updated)
+
+        loaded = store.load_team(process.team_id)
+        assert loaded is not None
+        assert loaded.status == TeamStatus.STOPPED
+
+    def test_load_team_returns_none_for_nonexistent(
+        self, postgres_clean_tables: str
+    ) -> None:
+        """AC #20: load_team returns None when no row matches."""
+        store = NagraEventStore(postgres_clean_tables)
+        assert store.load_team(uuid.uuid4()) is None
+
+    # --- list_teams (AC #21) ----------------------------------------------
+
+    def test_list_teams_empty(self, postgres_clean_tables: str) -> None:
+        """AC #21: list_teams returns [] when no rows exist."""
+        store = NagraEventStore(postgres_clean_tables)
+        assert store.list_teams() == []
+
+    def test_list_teams_returns_all(self, postgres_clean_tables: str) -> None:
+        """AC #21: list_teams returns every persisted process (order-independent)."""
+        store = NagraEventStore(postgres_clean_tables)
+        p1 = make_process()
+        p2 = make_process()
+        store.save_team(p1)
+        store.save_team(p2)
+
+        result = store.list_teams()
+        assert len(result) == 2
+        assert {p.team_id for p in result} == {p1.team_id, p2.team_id}
+
+    # --- save_event / load_events ordering (AC #22, #23) ------------------
+
+    def test_load_events_returns_ordered_by_sequence(
+        self, postgres_clean_tables: str
+    ) -> None:
+        """AC #22: load_events returns rows sorted by sequence ASC.
+
+        Inserts 100 events for one team with sequences shuffled and
+        asserts the loaded order is the natural ascending sequence.
+        """
+        store = NagraEventStore(postgres_clean_tables)
+        team_id = uuid.uuid4()
+        sequences = random.sample(range(1, 101), 100)
+        for seq in sequences:
+            store.save_event(make_persisted_event(team_id=team_id, sequence=seq))
+
+        loaded = store.load_events(team_id)
+        assert [e.sequence for e in loaded] == list(range(1, 101))
+
+    def test_load_events_empty(self, postgres_clean_tables: str) -> None:
+        """AC #23: load_events returns [] for a team with no events."""
+        store = NagraEventStore(postgres_clean_tables)
+        assert store.load_events(uuid.uuid4()) == []
+
+    # --- get_max_sequence (AC #24) ----------------------------------------
+
+    def test_get_max_sequence(self, postgres_clean_tables: str) -> None:
+        """AC #24: get_max_sequence returns 0 on empty, then largest seen."""
+        store = NagraEventStore(postgres_clean_tables)
+        team_id = uuid.uuid4()
+
+        assert store.get_max_sequence(team_id) == 0
+
+        for seq in (1, 5, 3):
+            store.save_event(make_persisted_event(team_id=team_id, sequence=seq))
+        assert store.get_max_sequence(team_id) == 5
+
+        store.save_event(make_persisted_event(team_id=team_id, sequence=99))
+        assert store.get_max_sequence(team_id) == 99
+
+    # --- duplicate (team_id, sequence) propagates raw exception (AC #25) --
+
+    def test_duplicate_sequence_raises_native_exception(
+        self, postgres_clean_tables: str
+    ) -> None:
+        """AC #25: composite-PK violation propagates as a raw exception.
+
+        Asserts via ``pytest.raises(Exception)`` and inspects the message
+        substring rather than pinning a specific psycopg version.
+        """
+        store = NagraEventStore(postgres_clean_tables)
+        team_id = uuid.uuid4()
+        store.save_event(make_persisted_event(team_id=team_id, sequence=1))
+
+        with pytest.raises(Exception) as exc_info:
+            store.save_event(make_persisted_event(team_id=team_id, sequence=1))
+
+        msg = str(exc_info.value).lower()
+        assert "unique" in msg or "event_entries" in msg
+
+    # --- cascading delete_team (AC #26) -----------------------------------
+
+    def test_delete_team_cascades_and_is_idempotent(
+        self, postgres_clean_tables: str
+    ) -> None:
+        """AC #26: delete_team purges all three tables for one team only.
+
+        Other teams' rows remain. A second delete_team call is a no-op.
+        """
+        store = NagraEventStore(postgres_clean_tables)
+        team_a = make_process()
+        team_b = make_process()
+        store.save_team(team_a)
+        store.save_team(team_b)
+
+        for seq in range(1, 6):
+            store.save_event(
+                make_persisted_event(team_id=team_a.team_id, sequence=seq)
+            )
+        for agent_id in ("a1", "a2", "a3"):
+            store.save_agent_state(
+                make_agent_state_snapshot(team_id=team_a.team_id, agent_id=agent_id)
+            )
+
+        for seq in range(1, 3):
+            store.save_event(
+                make_persisted_event(team_id=team_b.team_id, sequence=seq)
+            )
+        store.save_agent_state(
+            make_agent_state_snapshot(team_id=team_b.team_id, agent_id="b1")
+        )
+
+        store.delete_team(team_a.team_id)
+
+        assert store.load_team(team_a.team_id) is None
+        assert store.load_events(team_a.team_id) == []
+        assert store.load_agent_states(team_a.team_id) == []
+
+        assert store.load_team(team_b.team_id) is not None
+        assert len(store.load_events(team_b.team_id)) == 2
+        assert len(store.load_agent_states(team_b.team_id)) == 1
+
+        # Idempotent — second call must not raise.
+        store.delete_team(team_a.team_id)
+
+    # --- schema-drift / payload-authority invariant (AC #27) --------------
+
+    def test_payload_is_authoritative_over_promoted_columns(
+        self, postgres_clean_tables: str
+    ) -> None:
+        """AC #27: hydrated model fields come from JSONB ``data`` only.
+
+        Plants a row whose promoted ``team_id`` / ``sequence`` columns
+        DISAGREE with the embedded payload, then asserts the hydrated
+        ``PersistedEvent`` carries the payload values — proving the
+        promoted columns are query keys only, never read back into the
+        model. Bypasses ``save_event`` on purpose to plant the drift.
+        """
+        store = NagraEventStore(postgres_clean_tables)
+        routing_team_id = uuid.uuid4()
+        payload_team_id = uuid.uuid4()
+
+        # Build a valid PersistedEvent payload, then mutate the dict to
+        # disagree with the promoted columns we'll write.
+        canonical = make_persisted_event(team_id=payload_team_id, sequence=42)
+        payload_dict = canonical.model_dump()
+        payload_dict["team_id"] = str(payload_team_id)
+        payload_dict["sequence"] = 42
+
+        with Transaction(postgres_clean_tables) as trn:
+            trn.execute(
+                "INSERT INTO event_entries (team_id, sequence, data) "
+                "VALUES (%s, %s, %s)",
+                (str(routing_team_id), 1, json.dumps(payload_dict)),
+            )
+
+        loaded = store.load_events(routing_team_id)
+        assert len(loaded) == 1
+        assert loaded[0].team_id == payload_team_id
+        assert loaded[0].sequence == 42
+
+    # --- polymorphic Message / BaseState round-trip (AC #28) --------------
+
+    def test_polymorphic_event_round_trip(
+        self, postgres_clean_tables: str
+    ) -> None:
+        """AC #28: PersistedEvent carrying UserMessage survives JSONB round-trip."""
+        store = NagraEventStore(postgres_clean_tables)
+        team_id = uuid.uuid4()
+        msg = UserMessage(content="hello")
+        store.save_event(
+            make_persisted_event(team_id=team_id, sequence=1, event=msg)
+        )
+
+        loaded = store.load_events(team_id)
+        assert len(loaded) == 1
+        assert isinstance(loaded[0].event, UserMessage)
+        assert loaded[0].event.content == "hello"
+
+    def test_polymorphic_agent_state_round_trip(
+        self, postgres_clean_tables: str
+    ) -> None:
+        """AC #28: AgentStateSnapshot carrying SampleAgentState survives round-trip."""
+        store = NagraEventStore(postgres_clean_tables)
+        team_id = uuid.uuid4()
+        state = SampleAgentState(task_count=5)
+        store.save_agent_state(
+            make_agent_state_snapshot(team_id=team_id, agent_id="a", state=state)
+        )
+
+        loaded = store.load_agent_states(team_id)
+        assert len(loaded) == 1
+        assert isinstance(loaded[0].state, SampleAgentState)
+        assert loaded[0].state.task_count == 5
+
+    # --- save_agent_state upsert (AC #29) ---------------------------------
+
+    def test_save_agent_state_upserts_for_same_pair(
+        self, postgres_clean_tables: str
+    ) -> None:
+        """AC #29: save_agent_state upserts on the (team_id, agent_id) PK."""
+        store = NagraEventStore(postgres_clean_tables)
+        team_id = uuid.uuid4()
+        store.save_agent_state(
+            make_agent_state_snapshot(
+                team_id=team_id,
+                agent_id="agent-a",
+                state=SampleAgentState(task_count=1),
+            )
+        )
+        store.save_agent_state(
+            make_agent_state_snapshot(
+                team_id=team_id,
+                agent_id="agent-a",
+                state=SampleAgentState(task_count=99),
+            )
+        )
+
+        loaded = store.load_agent_states(team_id)
+        assert len(loaded) == 1
+        assert isinstance(loaded[0].state, SampleAgentState)
+        assert loaded[0].state.task_count == 99
+
+    # --- load_agent_states empty (AC #30) ---------------------------------
+
+    def test_load_agent_states_empty(
+        self, postgres_clean_tables: str
+    ) -> None:
+        """AC #30: load_agent_states returns [] for a team with no snapshots."""
+        store = NagraEventStore(postgres_clean_tables)
+        assert store.load_agent_states(uuid.uuid4()) == []


### PR DESCRIPTION
## Summary

Implements `NagraEventStore` against PostgreSQL with all nine `EventStore` Protocol methods. Each method opens its own `nagra.Transaction` (per-method ownership); `delete_team` is the one exception, cascading three `DELETE`s across `agent_state_entries`, `event_entries`, and `team_process_entries` in a single transaction. `get_max_sequence` uses `COALESCE(MAX(sequence), 0)` so the empty-team case is one round-trip and the return type is always `int`. Hydration is payload-authoritative — `data` JSONB is the single source of truth; promoted columns are routing keys only.

## Changes

- `src/akgentic/team/repositories/postgres/event_store.py` — replace nine `NotImplementedError` stubs with the reference SQL implementation. All `%s` placeholders are bound (no f-strings, no `.format()`, no concatenation). Native exceptions (`psycopg.errors.UniqueViolation`, `pydantic.ValidationError`, connection failures) propagate unchanged.
- `src/akgentic/team/repositories/postgres/_queries.py` — add `decode_jsonb_column` helper as a local copy. Cross-submodule import from `akgentic-catalog` would violate the dependency graph (catalog sits ABOVE team).
- `tests/repositories/postgres/test_event_store.py` — new module with 16 tests covering all nine methods, polymorphic `Message` / `BaseState` round-trips, cascading `delete_team` with cross-team isolation, the schema-drift / payload-authority invariant, and structural `EventStore` Protocol compliance.

## Quality gates

- `ruff check packages/akgentic-team/src/` clean
- `mypy --strict packages/akgentic-team/src/` clean (20 source files)
- `pytest packages/akgentic-team/tests/` — 313 passed, 0 failed
- Coverage on `repositories/postgres/`: 97.92 %
- CI green on this branch

## Stacking

Branched from `feat/93-postgres-backend-skeleton` (story 17.1, PR #94, not yet merged). This PR targets that branch as base; retarget to `master` after PR #94 merges.

Closes #95
