### PR TITLE
CI wiring, env vars, and documentation for Nagra Postgres backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Example environment variables for akgentic-team storage backends.
+# Copy to .env and fill in values for your deployment. The team library
+# itself does NOT read these — env-var resolution happens at the wiring
+# layer (application startup / infra code). NagraEventStore takes a
+# plain connection string directly.
+
+# Nagra / PostgreSQL backend — used by the `[postgres]` extra.
+# Shared verbatim with akgentic-catalog (same DB, disjoint tables:
+#   catalog owns  template_entries / tool_entries / agent_entries / team_entries
+#   team owns     team_process_entries / event_entries / agent_state_entries
+# ).
+POSTGRES_SERVER=
+POSTGRES_PORT=5432
+POSTGRES_USER=
+POSTGRES_PASSWORD=
+POSTGRES_DB=
+# Full libpq URL; what NagraEventStore receives as `conn_string`.
+DB_CONN_STRING_PERSISTENCE=
+
+# MongoDB backend — used by the `[mongo]` extra.
+MONGO_URI=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,27 @@ env:
 jobs:
   quality:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: akgentic
+          POSTGRES_PASSWORD: akgentic
+          POSTGRES_DB: akgentic_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U akgentic"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    env:
+      POSTGRES_SERVER: localhost
+      POSTGRES_PORT: "5432"
+      POSTGRES_USER: akgentic
+      POSTGRES_PASSWORD: akgentic
+      POSTGRES_DB: akgentic_test
+      DB_CONN_STRING_PERSISTENCE: postgresql://akgentic:akgentic@localhost:5432/akgentic_test
     steps:
       - name: Checkout workspace
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ providing:
   is captured for crash recovery
 - **Crash recovery** via `TeamRestorer` — 3-phase restore protocol rebuilds
   teams from persisted events
-- **Two storage backends** (YAML files and MongoDB) behind a common
-  `EventStore` protocol
+- **Three storage backends** (YAML files, MongoDB, and PostgreSQL via Nagra)
+  behind a common `EventStore` protocol
 - **CLI** (`ak-team`) for managing team instances from the command line
 
 ```
@@ -53,9 +53,10 @@ TeamCard ──▶ TeamFactory.build() ──▶ TeamRuntime (live actors)
                               └────────────┘
                                     │
                               EventStore Protocol
-                              ┌─────┴──────┐
-                              │            │
-                         YamlEventStore  MongoEventStore
+                              ┌─────┬──────┬──────────────┐
+                              │     │      │              │
+                         YamlEventStore  MongoEventStore  NagraEventStore
+                                                          (PostgreSQL via Nagra)
 ```
 
 ## Installation
@@ -85,6 +86,9 @@ uv sync --extra cli
 
 # MongoDB backend
 uv sync --extra mongo
+
+# PostgreSQL backend (Nagra)
+uv sync --extra postgres
 
 # Everything
 uv sync --all-extras
@@ -153,7 +157,8 @@ flow:
 │  Models: TeamCard, TeamRuntime, Process      │
 │  Ports:  EventStore, ServiceRegistry         │
 ├──────────────────────────────────────────────┤
-│  Repositories: YamlEventStore, MongoEventStore│
+│  Repositories: YamlEventStore, MongoEventStore,│
+│                NagraEventStore (PostgreSQL)    │
 └──────────────────────────────────────────────┘
 ```
 
@@ -243,6 +248,147 @@ db = pymongo.MongoClient("mongodb://localhost:27017")["akgentic"]
 event_store = MongoEventStore(db)
 # Collections: teams, events, agent_states
 ```
+
+**PostgreSQL (Nagra)** — install the `[postgres]` extra:
+
+```bash
+uv sync --extra postgres
+# or: uv add "akgentic-team[postgres]"
+```
+
+The PostgreSQL backend is built on [Nagra](https://pypi.org/project/nagra/)
+and stores team state across three tables with promoted query keys plus a
+`data JSONB` payload (the payload is authoritative — promoted columns are
+indexes, not the source of truth):
+
+| Table | Natural key | Purpose |
+|---|---|---|
+| `team_process_entries` | `id` | One row per team — `Process` snapshot |
+| `event_entries` | `(team_id, sequence)` | Append-only event log |
+| `agent_state_entries` | `(team_id, agent_id)` | Agent state snapshots |
+
+Each public `NagraEventStore` method opens its own `Transaction`. The one
+exception is `delete_team`, which spans a single transaction across the
+three tables (ordered: `agent_state_entries` → `event_entries` →
+`team_process_entries`) so cascade deletion is atomic. `save_event`
+propagates the raw `psycopg`/Nagra `UniqueViolation` on duplicate
+`(team_id, sequence)` — matching the Mongo backend's raw
+`DuplicateKeyError` propagation.
+
+**Environment variables.** The backend follows the V1 Akgentic conventions
+so existing operator `.env` files work unchanged:
+
+| Variable | Purpose |
+|---|---|
+| `POSTGRES_SERVER` | Database host |
+| `POSTGRES_PORT` | Database port (typically `5432`) |
+| `POSTGRES_USER` | Database user |
+| `POSTGRES_PASSWORD` | Database password |
+| `POSTGRES_DB` | Database name |
+| `DB_CONN_STRING_PERSISTENCE` | Full libpq URL; what `NagraEventStore` receives as `conn_string` |
+
+`DB_CONN_STRING_PERSISTENCE` is **shared verbatim with `akgentic-catalog`** —
+both modules target the same database. Their tables are disjoint by design:
+the catalog owns `template_entries`, `tool_entries`, `agent_entries`, and
+`team_entries`; this package owns `team_process_entries` (renamed from
+`team_entries` to prevent collision), `event_entries`, and
+`agent_state_entries`. A single Postgres instance can serve both modules.
+
+`NagraEventStore.__init__` takes `conn_string` directly as a positional
+argument — env-var reading happens at the wiring layer (application
+startup / infra code), **not** inside the event store. This keeps the
+storage layer decoupled from process-level configuration.
+
+**Schema initialisation.** Call `init_db(conn_string)` once per deployment
+(at application startup or as a deploy hook). The call is idempotent —
+it creates any missing tables and is safe to re-run. `NagraEventStore`'s
+constructor does **not** call `init_db` implicitly.
+
+```python
+from akgentic.team.repositories.postgres import NagraEventStore, init_db
+
+conn_string = "postgresql://akgentic:akgentic@localhost:5432/akgentic"
+
+# One-time (idempotent) schema creation — run at deploy time.
+init_db(conn_string)
+
+# Construct the event store with the same conn_string.
+event_store = NagraEventStore(conn_string)
+```
+
+Schema evolution is handled as a redeploy concern — the backend does not
+adopt a migration framework. Drop-and-recreate semantics or manual
+`ALTER TABLE` statements are the expected evolution path.
+
+#### Database initialization (init container)
+
+For Kubernetes / Nomad deployments, run the schema-creation hook as a
+dedicated init container before the main team-runtime process starts:
+
+```bash
+python -m akgentic.team.scripts.init_db
+```
+
+The script reads `DB_CONN_STRING_PERSISTENCE` and exits with one of:
+
+| Exit code | Meaning |
+|---|---|
+| `0` | Success — tables created or already present |
+| `2` | `DB_CONN_STRING_PERSISTENCE` not set |
+| `1` | Any other failure (nagra not installed, connection refused, `init_db` raised) |
+
+Catalog and team can share a single init step — both modules expose the
+same entry-point shape (`python -m akgentic.<module>.scripts.init_db`) and
+read the same `DB_CONN_STRING_PERSISTENCE` env var.
+
+**Kubernetes initContainer** snippet:
+
+```yaml
+spec:
+  initContainers:
+    - name: akgentic-team-init-db
+      image: ghcr.io/b12consulting/akgentic-team:latest
+      command: ["python", "-m", "akgentic.team.scripts.init_db"]
+      env:
+        - name: DB_CONN_STRING_PERSISTENCE
+          valueFrom:
+            secretKeyRef:
+              name: akgentic-postgres
+              key: conn-string
+```
+
+**Nomad prestart task** snippet:
+
+```hcl
+task "init-db" {
+  driver = "docker"
+  lifecycle {
+    hook    = "prestart"
+    sidecar = false
+  }
+  config {
+    image   = "ghcr.io/b12consulting/akgentic-team:latest"
+    command = "python"
+    args    = ["-m", "akgentic.team.scripts.init_db"]
+  }
+  template {
+    destination = "secrets/db.env"
+    env         = true
+    data        = <<EOF
+DB_CONN_STRING_PERSISTENCE={{ with secret "kv/akgentic" }}{{ .Data.data.conn_string }}{{ end }}
+EOF
+  }
+}
+```
+
+#### Out of scope: enterprise wiring
+
+Wiring `NagraEventStore` into `akgentic-infra-enterprise`'s server +
+worker bootstrap (opt-in via `AKGENTIC_EVENT_STORE = "postgres"` or
+equivalent) is a **follow-up story tracked in `akgentic-infra-enterprise`**.
+This package only ships the backend implementation, the `[postgres]`
+extra, the deployment hook, and the documentation. The enterprise
+deployment project owns the application-level switch.
 
 ### Crash Recovery
 

--- a/tests/repositories/postgres/test_ci_env_wiring.py
+++ b/tests/repositories/postgres/test_ci_env_wiring.py
@@ -1,0 +1,86 @@
+"""CI env-wiring smoke tests for the Nagra-backed Postgres event store.
+
+These tests validate that the V1 PostgreSQL environment-variable wiring
+(notably ``DB_CONN_STRING_PERSISTENCE``) is plumbed correctly from the GHA
+service container declared in ``.github/workflows/ci.yml`` through to the
+:class:`~akgentic.team.repositories.postgres.NagraEventStore` constructor
+and the :func:`~akgentic.team.repositories.postgres.init_db` deployment hook.
+
+Two of the three tests skip cleanly when ``DB_CONN_STRING_PERSISTENCE``
+is unset (typical local ``pytest`` invocation): the env-wiring tests have
+nothing to talk to. The constructor regression guard runs unconditionally
+because it explicitly clears ``os.environ`` to verify ``__init__`` does
+not silently read from it.
+
+Module-level ``pytest.importorskip`` calls match the conventions of the
+sibling ``test_event_store.py`` module so the file skips cleanly when the
+``[postgres]`` extra is missing.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("nagra")
+pytest.importorskip("testcontainers.postgres")
+
+from akgentic.team.repositories.postgres import (  # noqa: E402
+    NagraEventStore,
+    init_db,
+)
+
+_ENV_VAR = "DB_CONN_STRING_PERSISTENCE"
+
+
+def test_db_conn_string_persistence_reachable() -> None:
+    """The CI env wiring yields a ``conn_string`` usable by NagraEventStore.
+
+    Skipped when the env var is unset (local runs). When CI sets the var
+    against the GHA service container, this proves:
+
+    1. The connection string parses and connects.
+    2. ``init_db`` succeeds against a fresh DB.
+    3. ``list_teams`` round-trips through SQL → hydrated ``Process`` list.
+    """
+    conn_string = os.environ.get(_ENV_VAR)
+    if not conn_string:
+        pytest.skip(f"{_ENV_VAR} not set — CI-only test")
+
+    init_db(conn_string)
+    store = NagraEventStore(conn_string)
+    assert isinstance(store.list_teams(), list)
+
+
+def test_init_db_is_idempotent_against_ci_env() -> None:
+    """``init_db`` is safe to invoke twice against the same database.
+
+    Mirrors the deployment shape — Kubernetes initContainers and Nomad
+    prestart tasks may rerun on every redeploy. This test uses the CI
+    env-wired Postgres because that is the operator-facing path the
+    deployment hook ultimately runs against.
+    """
+    conn_string = os.environ.get(_ENV_VAR)
+    if not conn_string:
+        pytest.skip(f"{_ENV_VAR} not set — CI-only test")
+
+    init_db(conn_string)
+    init_db(conn_string)
+
+
+def test_event_store_constructor_does_not_read_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression guard: ``NagraEventStore.__init__`` must take ``conn_string`` directly.
+
+    Env-var reading is a wiring-layer concern; the event store itself must
+    remain decoupled. Constructing with an empty environment and a bogus
+    conn string must succeed (no connection is opened in ``__init__``) and
+    the supplied string must be stored verbatim.
+    """
+    monkeypatch.setattr(os, "environ", {})
+
+    store = NagraEventStore("postgresql://nonexistent:0/nope")
+
+    assert store._conn_string == "postgresql://nonexistent:0/nope"


### PR DESCRIPTION
## Summary

Closes Epic 17 by wiring the Nagra/Postgres backend into CI and documentation. **Zero runtime code changes** — `src/` is untouched; this is exclusively CI config, docs, and one new test module.

- **CI** (`.github/workflows/ci.yml`): adds `services.postgres` (image `postgres:16-alpine`, `pg_isready` healthcheck) and a job-level `env:` block exposing the six V1 vars plus `DB_CONN_STRING_PERSISTENCE`. Mirrors the catalog 15-4 CI shape verbatim.
- **README.md**: new "PostgreSQL (Nagra)" subsection under Storage Backends, `[postgres]` extra in Optional Extras, "Three storage backends" overview update, "Database initialization (init container)" subsection with K8s and Nomad snippets, "Out of scope: enterprise wiring" callout.
- **Architecture doc** (`_bmad-output/akgentic-team/architecture/03-persistence.md`): new "PostgreSQL Layout (NagraEventStore)" subsection with three-tables shape, per-method `Transaction` ownership, cascading `delete_team`, raw `UniqueViolation` propagation, and the `team_process_entries` rename callout.
- **Tests** (`tests/repositories/postgres/test_ci_env_wiring.py`): three synchronous tests — env reachability via `DB_CONN_STRING_PERSISTENCE`, `init_db` idempotency, and a constructor regression guard. Module-level `importorskip` for `nagra` and `testcontainers.postgres`.
- **`.env.example`** (new): documents the six V1 Postgres vars + `MONGO_URI` placeholder. Mirrors catalog `.env.example` shape.

## Stacked PR

Base branch: `feat/95-nagra-event-store-impl` (Story 17.2). Retarget to `master` once PRs #94 and #96 land.

## Code review

Reviewed by Rex (Dev Code Reviewer): zero HIGH/CRITICAL findings, four LOW/MEDIUM items recorded in the story file. All 25 ACs implemented; CI green on the branch.

Closes #97
