### PR TITLE
feat(akgentic-team): 18-1 filter StateChangedMessage out of event log

### DIFF
--- a/src/akgentic/team/subscriber.py
+++ b/src/akgentic/team/subscriber.py
@@ -65,15 +65,7 @@ class PersistenceSubscriber(EventSubscriber):
         if self._restoring:
             return
 
-        self._sequence += 1
         now = datetime.now(UTC)
-        event = PersistedEvent(
-            team_id=self._team_id,
-            sequence=self._sequence,
-            event=msg,
-            timestamp=now,
-        )
-        self._event_store.save_event(event)
 
         if isinstance(msg, StateChangedMessage) and msg.sender is not None:
             snapshot = AgentStateSnapshot(
@@ -83,6 +75,15 @@ class PersistenceSubscriber(EventSubscriber):
                 updated_at=now,
             )
             self._event_store.save_agent_state(snapshot)
+        else:
+            self._sequence += 1
+            event = PersistedEvent(
+                team_id=self._team_id,
+                sequence=self._sequence,
+                event=msg,
+                timestamp=now,
+            )
+            self._event_store.save_event(event)
 
     def set_restoring(self, restoring: bool) -> None:
         """Set the restoring flag to skip or resume persistence.

--- a/tests/services/test_subscriber.py
+++ b/tests/services/test_subscriber.py
@@ -61,7 +61,7 @@ class TestPersistenceSubscriber:
     # -- 3.4: Agent state snapshot on StateChangedMessage ------------------
 
     def test_state_snapshot_on_state_changed_message(self) -> None:
-        """AC 2: StateChangedMessage triggers both save_event and save_agent_state."""
+        """AC 1-3: StateChangedMessage writes snapshot only — no PersistedEvent, no sequence bump."""
         sub, store, team_id = self._make_subscriber()
 
         sender = MagicMock(spec=ActorAddress)
@@ -71,11 +71,13 @@ class TestPersistenceSubscriber:
 
         sub.on_message(msg)
 
-        # Event saved
-        assert len(store.events) == 1
-        assert store.events[0].event == msg
+        # No event saved (AC 1: StateChangedMessage excluded from event log)
+        assert len(store.events) == 0
 
-        # Agent state snapshot saved
+        # Sequence not advanced (AC 3: gap-free numbering over behavioral events)
+        assert sub._sequence == 0  # noqa: SLF001
+
+        # Agent state snapshot saved (AC 2: snapshot still written)
         key = (team_id, "worker-agent")
         assert key in store.agent_states
         snapshot = store.agent_states[key]
@@ -85,6 +87,23 @@ class TestPersistenceSubscriber:
         assert snapshot.updated_at is not None
         assert isinstance(snapshot.state, SampleAgentState)
         assert snapshot.state.task_count == 5
+
+    def test_state_changed_does_not_break_sequence_continuity(self) -> None:
+        """AC 3: Interleaved StateChangedMessage keeps event-log sequence gap-free."""
+        sub, store, _team_id = self._make_subscriber()
+
+        sender = MagicMock(spec=ActorAddress)
+        sender.name = "agent-a"
+
+        sub.on_message(UserMessage(content="first"))  # seq 1
+        sub.on_message(StateChangedMessage(sender=sender, state=SampleAgentState(task_count=1)))
+        sub.on_message(UserMessage(content="second"))  # seq 2
+        sub.on_message(StateChangedMessage(sender=sender, state=SampleAgentState(task_count=2)))
+        sub.on_message(UserMessage(content="third"))  # seq 3
+
+        sequences = [e.sequence for e in store.events]
+        assert sequences == [1, 2, 3]
+        assert len(store.agent_states) == 1  # overwritten by last snapshot
 
     def test_state_changed_message_with_none_sender_skips_snapshot(self) -> None:
         """AC 2: StateChangedMessage with sender=None saves event but no snapshot."""


### PR DESCRIPTION
## Summary

- Filter `StateChangedMessage` out of the append-only `PersistedEvent` log in `PersistenceSubscriber.on_message()`, eliminating O(n^2) storage growth from repeated full-state blobs
- `AgentStateSnapshot` continues to be written on every `StateChangedMessage` with a non-null sender (overwrite strategy, 1 row per agent)
- Event-log sequence counter is not advanced for `StateChangedMessage`, keeping gap-free numbering over behavioral events
- Updated `test_state_snapshot_on_state_changed_message` to verify snapshot-only behaviour (no `PersistedEvent`)
- Added `test_state_changed_does_not_break_sequence_continuity` to verify interleaved `StateChangedMessage` events preserve gap-free sequences

Relates to #105

## Acceptance Criteria

- [x] AC1: `PersistenceSubscriber.on_message()` does NOT create a `PersistedEvent` row when the message is a `StateChangedMessage`
- [x] AC2: `PersistenceSubscriber.on_message()` still writes an `AgentStateSnapshot` on every `StateChangedMessage` with a non-null sender
- [x] AC3: `_sequence` is NOT incremented for `StateChangedMessage`, keeping the event-log sequence gap-free
- [x] AC4: All existing persistence tests pass; behaviour for non-state messages is unchanged
