### PR TITLE
chore: bump version to 1.0.0-alpha.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akgentic-team"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 description = "Team lifecycle management — create, resume, stop, delete teams with event-sourced persistence"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/akgentic/team/__init__.py
+++ b/src/akgentic/team/__init__.py
@@ -26,7 +26,7 @@ from akgentic.team.repositories import YamlEventStore
 from akgentic.team.restorer import TeamRestorer
 from akgentic.team.subscriber import PersistenceSubscriber
 
-__version__ = "1.0.0-alpha.1"
+__version__ = "1.0.0-alpha.2"
 
 __all__: list[str] = [
     "__version__",


### PR DESCRIPTION
Bumps pyproject.toml version 1.0.0-alpha.1 → 1.0.0-alpha.2 in lockstep with the other 7 akgentic submodules.

Closes #109