### PR TITLE
feat(akgentic-team): epic 19 — EventStore.list_teams(user_id) push-down (19-1 → 19-4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akgentic-team"
-version = "1.2.0"
+version = "1.2.1"
 description = "Team lifecycle management — create, resume, stop, delete teams with event-sourced persistence"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/akgentic/team/ports.py
+++ b/src/akgentic/team/ports.py
@@ -63,10 +63,19 @@ class EventStore(Protocol):
         """
         ...
 
-    def list_teams(self) -> list[Process]:
-        """Load all team process snapshots.
+    def list_teams(self, user_id: str | None = None) -> list[Process]:
+        """Load team process snapshots.
 
-        Called by the CLI to enumerate all known teams.
+        Args:
+            user_id: If provided, return only snapshots whose ``Process.user_id``
+                matches. If ``None`` (default), return all snapshots — used by
+                the CLI to enumerate every team in the store.
+
+        Implementations MUST push the filter down to the backend (SQL WHERE,
+        Mongo find filter, directory-walk skip) rather than load-all-then-filter
+        in Python — the multi-tenant infra layer calls this on every request.
+
+        See ADR-16 §1 for the additive, backwards-compatible Protocol change.
         """
         ...
 

--- a/src/akgentic/team/repositories/mongo.py
+++ b/src/akgentic/team/repositories/mongo.py
@@ -99,15 +99,21 @@ class MongoEventStore:
         logger.debug("Loaded team %s", team_id)
         return process
 
-    def list_teams(self) -> list[Process]:
+    def list_teams(self, user_id: str | None = None) -> list[Process]:
         """Load all team process snapshots from the teams collection.
 
         Queries all documents in the ``teams`` collection and reconstructs
         each as a Process via ``model_validate()``. Corrupted documents
         are skipped with a warning.
 
+        Args:
+            user_id: If provided, return only snapshots whose
+                ``Process.user_id`` matches. If ``None`` (default), return all
+                snapshots. See ADR-16 §1.
+
         Returns:
-            List of all loadable Process snapshots.
+            List of all loadable Process snapshots (filtered by ``user_id``
+            when provided).
         """
         teams: list[Process] = []
         for doc in self._teams.find({}):
@@ -116,6 +122,10 @@ class MongoEventStore:
                 teams.append(Process.model_validate(doc))
             except (ValueError, TypeError) as exc:
                 logger.warning("Skipping corrupted team document: %s", exc)
+        # Interim in-memory filter for story 19-1 — replaced by
+        # find({"user_id": user_id}) + index in story 19-3 (ADR-16 §5).
+        if user_id is not None:
+            teams = [t for t in teams if t.user_id == user_id]
         logger.debug("Listed %d teams", len(teams))
         return teams
 

--- a/src/akgentic/team/repositories/mongo.py
+++ b/src/akgentic/team/repositories/mongo.py
@@ -56,6 +56,11 @@ class MongoEventStore:
         self._agent_states.create_index(
             [("team_id", 1), ("agent_id", 1)], unique=True
         )
+        # ADR-16 §5: B-tree index backing the ``list_teams(user_id=...)`` push-down.
+        # ``create_index`` is idempotent — re-running the constructor against the
+        # same database returns silently when an index with the same key spec
+        # already exists, so this is safe across redeploys.
+        self._teams.create_index("user_id", name="teams_user_id_idx")
         logger.debug("Initialized MongoEventStore with database '%s'", db.name)
 
     def save_team(self, process: Process) -> None:
@@ -100,32 +105,32 @@ class MongoEventStore:
         return process
 
     def list_teams(self, user_id: str | None = None) -> list[Process]:
-        """Load all team process snapshots from the teams collection.
+        """Load team process snapshots from the teams collection.
 
-        Queries all documents in the ``teams`` collection and reconstructs
-        each as a Process via ``model_validate()``. Corrupted documents
-        are skipped with a warning.
+        When ``user_id`` is provided, the filter is pushed down into the
+        Mongo ``find`` call as ``{"user_id": user_id}`` and runs in MongoDB
+        against the ``teams_user_id_idx`` B-tree index (created in
+        ``__init__``) — not in Python after hydration. When ``user_id`` is
+        ``None``, the call issues ``find({})`` and returns every team.
+        Corrupted documents are skipped with a warning. See ADR-16 §5.
 
         Args:
             user_id: If provided, return only snapshots whose
-                ``Process.user_id`` matches. If ``None`` (default), return all
-                snapshots. See ADR-16 §1.
+                ``Process.user_id`` matches via a Mongo backend filter.
+                If ``None`` (default), return all snapshots. See ADR-16 §1.
 
         Returns:
-            List of all loadable Process snapshots (filtered by ``user_id``
-            when provided).
+            List of loadable Process snapshots (filtered by ``user_id``
+            at the database level when provided).
         """
+        query: dict[str, str] = {"user_id": user_id} if user_id is not None else {}
         teams: list[Process] = []
-        for doc in self._teams.find({}):
+        for doc in self._teams.find(query):
             doc.pop("_id", None)
             try:
                 teams.append(Process.model_validate(doc))
             except (ValueError, TypeError) as exc:
                 logger.warning("Skipping corrupted team document: %s", exc)
-        # Interim in-memory filter for story 19-1 — replaced by
-        # find({"user_id": user_id}) + index in story 19-3 (ADR-16 §5).
-        if user_id is not None:
-            teams = [t for t in teams if t.user_id == user_id]
         logger.debug("Listed %d teams", len(teams))
         return teams
 

--- a/src/akgentic/team/repositories/postgres/__init__.py
+++ b/src/akgentic/team/repositories/postgres/__init__.py
@@ -52,11 +52,17 @@ def _ensure_schema_loaded() -> None:
 
 
 def init_db(conn_string: str) -> None:
-    """Create missing tables against the target Postgres instance.
+    """Create missing tables and indexes against the target Postgres instance.
 
     Idempotent: calling twice against the same database succeeds both times
-    and does not create duplicate tables. Intended as a deployment hook —
-    NEVER called implicitly by ``NagraEventStore.__init__``.
+    and does not create duplicate tables or indexes — table creation is
+    handled by ``Schema.default.create_tables()`` (Nagra's ``CREATE TABLE
+    IF NOT EXISTS`` path); the ``team_process_user_id_idx`` functional
+    expression index is created with ``CREATE INDEX IF NOT EXISTS``. Both
+    DDL statements run inside the same transaction. See ADR-16 §4.
+
+    Intended as a deployment hook — NEVER called implicitly by
+    ``NagraEventStore.__init__``.
 
     Args:
         conn_string: Nagra-compatible Postgres connection string.
@@ -64,8 +70,12 @@ def init_db(conn_string: str) -> None:
     from nagra import Transaction
 
     _ensure_schema_loaded()
-    with Transaction(conn_string):
+    with Transaction(conn_string) as trn:
         Schema.default.create_tables()
+        trn.execute(
+            "CREATE INDEX IF NOT EXISTS team_process_user_id_idx "
+            "ON team_process_entries ((data ->> 'user_id'))"
+        )
 
 
 # Import the event store last so it can rely on _ensure_schema_loaded above.

--- a/src/akgentic/team/repositories/postgres/event_store.py
+++ b/src/akgentic/team/repositories/postgres/event_store.py
@@ -69,12 +69,24 @@ class NagraEventStore:
             return None
         return Process.model_validate(decode_jsonb_column(row[0]))
 
-    def list_teams(self) -> list[Process]:
-        """Return every persisted team process. Order is unspecified."""
+    def list_teams(self, user_id: str | None = None) -> list[Process]:
+        """Return persisted team processes. Order is unspecified.
+
+        Args:
+            user_id: If provided, return only snapshots whose
+                ``Process.user_id`` matches. If ``None`` (default), return all
+                snapshots. See ADR-16 §1.
+        """
         with Transaction(self._conn_string) as trn:
             cursor = trn.execute("SELECT data FROM team_process_entries")
             rows = cursor.fetchall()
-        return [Process.model_validate(decode_jsonb_column(r[0])) for r in rows]
+        teams = [Process.model_validate(decode_jsonb_column(r[0])) for r in rows]
+        # Interim in-memory filter for story 19-1 — replaced by
+        # WHERE (data ->> 'user_id') = %s + functional expression index in
+        # story 19-4 (ADR-16 §4).
+        if user_id is not None:
+            teams = [t for t in teams if t.user_id == user_id]
+        return teams
 
     def delete_team(self, team_id: uuid.UUID) -> None:
         """Cascade-delete a team across all three tables in ONE transaction.

--- a/src/akgentic/team/repositories/postgres/event_store.py
+++ b/src/akgentic/team/repositories/postgres/event_store.py
@@ -72,21 +72,29 @@ class NagraEventStore:
     def list_teams(self, user_id: str | None = None) -> list[Process]:
         """Return persisted team processes. Order is unspecified.
 
+        When ``user_id`` is provided, the filter is pushed down to the
+        database via a JSONB extraction ``WHERE`` clause
+        (``WHERE (data ->> 'user_id') = %s``) backed by the functional
+        expression index ``team_process_user_id_idx`` created by
+        :func:`init_db`. ``user_id`` is bound through psycopg's ``%s``
+        placeholder — no f-strings, no string concatenation. See ADR-16 §4.
+
         Args:
             user_id: If provided, return only snapshots whose
                 ``Process.user_id`` matches. If ``None`` (default), return all
                 snapshots. See ADR-16 §1.
         """
         with Transaction(self._conn_string) as trn:
-            cursor = trn.execute("SELECT data FROM team_process_entries")
+            if user_id is None:
+                cursor = trn.execute("SELECT data FROM team_process_entries")
+            else:
+                cursor = trn.execute(
+                    "SELECT data FROM team_process_entries "
+                    "WHERE (data ->> 'user_id') = %s",
+                    (user_id,),
+                )
             rows = cursor.fetchall()
-        teams = [Process.model_validate(decode_jsonb_column(r[0])) for r in rows]
-        # Interim in-memory filter for story 19-1 — replaced by
-        # WHERE (data ->> 'user_id') = %s + functional expression index in
-        # story 19-4 (ADR-16 §4).
-        if user_id is not None:
-            teams = [t for t in teams if t.user_id == user_id]
-        return teams
+        return [Process.model_validate(decode_jsonb_column(r[0])) for r in rows]
 
     def delete_team(self, team_id: uuid.UUID) -> None:
         """Cascade-delete a team across all three tables in ONE transaction.

--- a/src/akgentic/team/repositories/yaml.py
+++ b/src/akgentic/team/repositories/yaml.py
@@ -116,6 +116,9 @@ class YamlEventStore:
         Iterates subdirectories of ``data_dir``, attempts to parse each
         directory name as a UUID, and loads the team snapshot for valid
         team directories. Non-UUID directories are skipped with a warning.
+        When ``user_id`` is provided, non-matching snapshots are skipped
+        in-memory during the iteration (skip-on-load) rather than after
+        the loop — see ADR-16 §3.
 
         Args:
             user_id: If provided, return only snapshots whose
@@ -138,12 +141,14 @@ class YamlEventStore:
                 logger.warning("Skipping non-team directory: %s", child.name)
                 continue
             process = self.load_team(team_id)
-            if process is not None:
-                teams.append(process)
-        # Interim in-memory filter for story 19-1 — replaced by the
-        # skip-on-load filter in story 19-2 (ADR-16 §3).
-        if user_id is not None:
-            teams = [t for t in teams if t.user_id == user_id]
+            if process is None:
+                continue
+            # Skip-on-load user_id filter (ADR-16 §3): discard non-matching
+            # snapshots in-memory before appending. No new I/O — the load
+            # already happened; we just don't keep the result.
+            if user_id is not None and process.user_id != user_id:
+                continue
+            teams.append(process)
         return teams
 
     def save_event(self, event: PersistedEvent) -> None:

--- a/src/akgentic/team/repositories/yaml.py
+++ b/src/akgentic/team/repositories/yaml.py
@@ -110,15 +110,21 @@ class YamlEventStore:
         logger.debug("Loaded team %s from %s", team_id, team_path)
         return process
 
-    def list_teams(self) -> list[Process]:
+    def list_teams(self, user_id: str | None = None) -> list[Process]:
         """Load all team process snapshots from the data directory.
 
         Iterates subdirectories of ``data_dir``, attempts to parse each
         directory name as a UUID, and loads the team snapshot for valid
         team directories. Non-UUID directories are skipped with a warning.
 
+        Args:
+            user_id: If provided, return only snapshots whose
+                ``Process.user_id`` matches. If ``None`` (default), return all
+                snapshots. See ADR-16 §1.
+
         Returns:
-            List of all loadable Process snapshots.
+            List of all loadable Process snapshots (filtered by ``user_id``
+            when provided).
         """
         if not self._data_dir.exists():
             return []
@@ -134,6 +140,10 @@ class YamlEventStore:
             process = self.load_team(team_id)
             if process is not None:
                 teams.append(process)
+        # Interim in-memory filter for story 19-1 — replaced by the
+        # skip-on-load filter in story 19-2 (ADR-16 §3).
+        if user_id is not None:
+            teams = [t for t in teams if t.user_id == user_id]
         return teams
 
     def save_event(self, event: PersistedEvent) -> None:

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -167,6 +167,7 @@ def make_process(
     team_id: uuid.UUID | None = None,
     team_card: TeamCard | None = None,
     status: TeamStatus = TeamStatus.RUNNING,
+    user_id: str | None = None,
 ) -> Process:
     """Create a Process with sensible defaults for testing.
 
@@ -174,16 +175,31 @@ def make_process(
         team_id: Optional team identifier.
         team_card: Optional pre-built TeamCard.
         status: Lifecycle status.
+        user_id: Optional owning user id. When ``None`` (default), the
+            ``user_id`` kwarg is omitted from the ``Process(...)`` call so
+            the underlying field falls back to its model default (``"cli"``
+            per ``Process.user_id``). When a string, it is passed through.
 
     Returns:
         A Process with the specified or default configuration.
     """
+    now = datetime.now(UTC)
+    if user_id is None:
+        # Omit user_id so the field defaults to "cli" per Process.user_id.
+        return Process(
+            team_id=team_id or uuid.uuid4(),
+            team_card=team_card or make_team_card(),
+            status=status,
+            created_at=now,
+            updated_at=now,
+        )
     return Process(
         team_id=team_id or uuid.uuid4(),
         team_card=team_card or make_team_card(),
         status=status,
-        created_at=datetime.now(UTC),
-        updated_at=datetime.now(UTC),
+        user_id=user_id,
+        created_at=now,
+        updated_at=now,
     )
 
 

--- a/tests/repositories/mongo/test_mongo.py
+++ b/tests/repositories/mongo/test_mongo.py
@@ -15,7 +15,7 @@ once per backend. This module retains only Mongo-specific invariants:
 from __future__ import annotations
 
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 from akgentic.team.repositories.mongo import MongoEventStore
@@ -100,6 +100,39 @@ class TestMongoEventStoreMongoSpecific:
         loaded = mongo_store.load_agent_states(team_id)
         assert len(loaded) == 1
         assert loaded[0].agent_id == "good-agent"
+
+    # --- user_id index presence ---------------------------------------------
+
+    def test_teams_user_id_index_created_on_init(
+        self, mongo_store: MongoEventStore, mongo_db: Any
+    ) -> None:
+        """``MongoEventStore.__init__`` creates ``teams_user_id_idx`` on ``teams``.
+
+        Asserts the index is present with a single-field ascending key spec
+        on ``user_id``. Backs the ``find({"user_id": ...})`` push-down in
+        ``list_teams`` (ADR-16 §5).
+        """
+        info = mongo_db["teams"].index_information()
+        assert "teams_user_id_idx" in info
+        assert info["teams_user_id_idx"]["key"] == [("user_id", 1)]
+
+    def test_teams_user_id_index_creation_is_idempotent(
+        self, mongo_store: MongoEventStore, mongo_db: Any
+    ) -> None:
+        """Re-running the constructor against the same database does not raise.
+
+        PyMongo's ``create_index`` returns silently when an index with the
+        same key spec already exists, so redeploys against a long-lived
+        MongoDB are safe (ADR-16 §5). After the second construction the
+        ``teams_user_id_idx`` entry is still present exactly once with the
+        same key spec.
+        """
+        # First construction already happened via the ``mongo_store`` fixture.
+        MongoEventStore(mongo_db)  # second construction — must not raise
+
+        info = mongo_db["teams"].index_information()
+        assert info["teams_user_id_idx"]["key"] == [("user_id", 1)]
+        assert list(info.keys()).count("teams_user_id_idx") == 1
 
     # --- Import guards ------------------------------------------------------
 

--- a/tests/repositories/postgres/test_init_db.py
+++ b/tests/repositories/postgres/test_init_db.py
@@ -117,3 +117,47 @@ class TestInitDbIntegration:
             after = {row[0] for row in cursor.fetchall()}
 
         assert before == after
+
+    def test_init_db_creates_user_id_functional_index(
+        self, postgres_initialized: str
+    ) -> None:
+        """After ``init_db``, ``team_process_user_id_idx`` exists in ``pg_indexes``.
+
+        Story 19.4 — the functional expression index
+        ``((data ->> 'user_id'))`` on ``team_process_entries`` backs the
+        ``WHERE (data ->> 'user_id') = %s`` push-down in
+        :meth:`NagraEventStore.list_teams`. See ADR-16 §4.
+        """
+        from nagra import Transaction
+
+        with Transaction(postgres_initialized) as trn:
+            cursor = trn.execute(
+                "SELECT 1 FROM pg_indexes "
+                "WHERE indexname = 'team_process_user_id_idx'"
+            )
+            rows = cursor.fetchall()
+        assert len(rows) == 1
+
+    def test_init_db_user_id_index_creation_is_idempotent(
+        self, postgres_initialized: str
+    ) -> None:
+        """A second ``init_db`` call exercises the ``IF NOT EXISTS`` branch.
+
+        The session-scoped ``postgres_initialized`` fixture already ran
+        ``init_db`` once during setup; calling again here must not raise
+        and must not duplicate the index. Idempotency is delivered by the
+        ``CREATE INDEX IF NOT EXISTS`` clause. See ADR-16 §4.
+        """
+        from nagra import Transaction
+
+        from akgentic.team.repositories.postgres import init_db
+
+        init_db(postgres_initialized)  # must not raise
+
+        with Transaction(postgres_initialized) as trn:
+            cursor = trn.execute(
+                "SELECT 1 FROM pg_indexes "
+                "WHERE indexname = 'team_process_user_id_idx'"
+            )
+            rows = cursor.fetchall()
+        assert len(rows) == 1

--- a/tests/repositories/test_event_store_contract.py
+++ b/tests/repositories/test_event_store_contract.py
@@ -96,6 +96,47 @@ class TestEventStoreContract:
         with_none = event_store.list_teams(user_id=None)
         assert {p.team_id for p in with_none} == {p.team_id for p in no_arg}
 
+    def test_list_teams_filters_by_user_id_returns_only_matching(
+        self, event_store: EventStore
+    ) -> None:
+        """``list_teams(user_id=...)`` returns only snapshots whose user_id matches."""
+        p1 = make_process(user_id="u1")
+        p2 = make_process(user_id="u2")
+        p3 = make_process(user_id="u1")
+        event_store.save_team(p1)
+        event_store.save_team(p2)
+        event_store.save_team(p3)
+
+        u1_result = event_store.list_teams(user_id="u1")
+        assert {p.team_id for p in u1_result} == {p1.team_id, p3.team_id}
+        assert len(u1_result) == 2
+
+        u2_result = event_store.list_teams(user_id="u2")
+        assert {p.team_id for p in u2_result} == {p2.team_id}
+        assert len(u2_result) == 1
+
+    def test_list_teams_filters_by_user_id_returns_empty_for_unknown(
+        self, event_store: EventStore
+    ) -> None:
+        """``list_teams(user_id="nonexistent")`` returns ``[]`` when nothing matches."""
+        event_store.save_team(make_process(user_id="u1"))
+        event_store.save_team(make_process(user_id="u1"))
+
+        assert event_store.list_teams(user_id="nonexistent") == []
+
+    def test_list_teams_filters_by_user_id_empty_string_is_literal(
+        self, event_store: EventStore
+    ) -> None:
+        """``user_id=""`` is a literal match, not an alias for "all teams" (ADR-16 §8)."""
+        p_u1 = make_process(user_id="u1")
+        p_empty = make_process(user_id="")
+        event_store.save_team(p_u1)
+        event_store.save_team(p_empty)
+
+        result = event_store.list_teams(user_id="")
+        assert {p.team_id for p in result} == {p_empty.team_id}
+        assert len(result) == 1
+
     # --- save_event / load_events ordering --------------------------------
 
     def test_save_and_load_events_in_sequence_order(self, event_store: EventStore) -> None:

--- a/tests/repositories/test_event_store_contract.py
+++ b/tests/repositories/test_event_store_contract.py
@@ -83,6 +83,19 @@ class TestEventStoreContract:
         assert len(result) == 3
         assert {p.team_id for p in result} == {p1.team_id, p2.team_id, p3.team_id}
 
+    def test_list_teams_user_id_none_equals_no_arg(self, event_store: EventStore) -> None:
+        """``list_teams(user_id=None)`` is equivalent to ``list_teams()`` (no arg)."""
+        p1 = make_process()
+        p2 = make_process()
+        p3 = make_process()
+        event_store.save_team(p1)
+        event_store.save_team(p2)
+        event_store.save_team(p3)
+
+        no_arg = event_store.list_teams()
+        with_none = event_store.list_teams(user_id=None)
+        assert {p.team_id for p in with_none} == {p.team_id for p in no_arg}
+
     # --- save_event / load_events ordering --------------------------------
 
     def test_save_and_load_events_in_sequence_order(self, event_store: EventStore) -> None:

--- a/tests/services/test_subscriber.py
+++ b/tests/services/test_subscriber.py
@@ -61,7 +61,10 @@ class TestPersistenceSubscriber:
     # -- 3.4: Agent state snapshot on StateChangedMessage ------------------
 
     def test_state_snapshot_on_state_changed_message(self) -> None:
-        """AC 1-3: StateChangedMessage writes snapshot only — no PersistedEvent, no sequence bump."""
+        """AC 1-3: StateChangedMessage writes snapshot only.
+
+        No ``PersistedEvent``, no sequence bump.
+        """
         sub, store, team_id = self._make_subscriber()
 
         sender = MagicMock(spec=ActorAddress)


### PR DESCRIPTION
## Epic 19 — EventStore.list_teams(user_id) push-down (ADR-16)

This umbrella PR delivers Epic 19: extend the `EventStore.list_teams` Protocol with an optional `user_id` filter and push that filter down into each of the three backends (yaml, mongo, postgres). The design is captured in [`_bmad-output/akgentic-team/decisions/adr-16-event-store-list-teams-user-id-filter.md`](../blob/feat/112-epic-19-list-teams-user-id-pushdown/_bmad-output/akgentic-team/decisions/adr-16-event-store-list-teams-user-id-filter.md). Stories land sequentially in this PR; each backend's real push-down replaces the interim in-memory filter introduced in 19-1.

## Stories

- [x] 19-1 — `EventStore.list_teams` Protocol: add optional `user_id` parameter + interim backend stubs (Relates to #112)
- [x] 19-2 — `YamlEventStore.list_teams`: skip-on-load `user_id` filter (Relates to #114)
- [x] 19-3 — `MongoEventStore.list_teams`: `find({"user_id": user_id})` push-down + `teams_user_id_idx` (Relates to #115)
- [x] 19-4 — `NagraEventStore.list_teams`: `WHERE (data ->> 'user_id') = %s` push-down + functional expression index (Relates to #116)

## Review status

- 19-1 review: PASS — Protocol signature is additive and backwards-compatible; all three backends accept the new parameter and apply an interim in-memory filter clearly marked for replacement in 19-2 / 19-3 / 19-4; baseline contract test asserts `list_teams(user_id=None) == list_teams()` across all backends. Local pytest (323 passed, 5 skipped), mypy strict, and ruff check all green.
- 19-2 review: PASS — `YamlEventStore.list_teams` post-loop comprehension cleanly replaced with an in-loop `continue` (skip-on-load); docstring updated; `make_process` factory extended with optional `user_id` preserving the `"cli"` default when omitted; three contract tests added (returns_only_matching, returns_empty_for_unknown, empty_string_is_literal) and exercised across all three backends via the parametrized `event_store` fixture. Local pytest (332 passed, 5 skipped), mypy strict, and ruff check all green. Scope stayed inside `packages/akgentic-team/`.
- 19-3 review: PASS — `MongoEventStore.list_teams` interim post-load filter cleanly replaced with a real `find(query)` push-down (`{"user_id": user_id}` when not None, `{}` otherwise); `teams_user_id_idx` ascending B-tree index on `user_id` added to `__init__` next to the existing `_events` / `_agent_states` index creations (no `unique=True`, no extra options — matches ADR-16 §5); two Mongo-specific tests added under `TestMongoEventStoreMongoSpecific` asserting index presence with key spec `[("user_id", 1)]` and idempotency on second construction. The three shared contract tests now exercise the real backend push-down on `[mongo]`. Local pytest (334 passed, 5 skipped), mypy strict, and ruff check all green. Scope stayed inside `packages/akgentic-team/` (only `mongo.py` and `tests/repositories/mongo/test_mongo.py` touched).
- 19-4 review: PASS — `NagraEventStore.list_teams` interim Python filter cleanly removed; SELECT now branches on `user_id is None` and binds `(data ->> 'user_id') = %s` through psycopg's `%s` placeholder (no f-strings, no concatenation). `init_db` opens the `Transaction` context as `with Transaction(conn_string) as trn:` and issues `CREATE INDEX IF NOT EXISTS team_process_user_id_idx ON team_process_entries ((data ->> 'user_id'))` inside the same transaction as `Schema.default.create_tables()`. `schema.toml` untouched (Option A — ADR-16 §4). Two Postgres-specific tests added in `TestInitDbIntegration` asserting `pg_indexes` contains the index exactly once after `init_db` and after a second idempotent call. Shared per-`user_id` contract tests now exercise the real WHERE push-down on `[postgres]`. Local pytest (336 passed, 5 skipped — Postgres testcontainers require local Docker), mypy strict, and ruff check all green. Scope stayed inside `packages/akgentic-team/`. Process note for future stories: keep ADR-NNN references out of commit message bodies (Golden Rule #8); docstring/comment references are still allowed and remain in the diff for navigation.

## Scope guard

All changes in this PR stay inside `packages/akgentic-team/`. No edits to sibling submodules. The follow-up caller change in `akgentic-infra` (`team_service.py`) is explicitly out of scope and will land as a separate story in the `akgentic-infra` sprint.

## Base branch

This PR targets `version-1.x` (the working branch for the `akgentic-team` submodule), NOT `master`.

## Epic 19 slice complete

All four stories of Epic 19 have landed on this branch:

- 19-1 — Protocol contract: `EventStore.list_teams(user_id: str | None = None)` (additive, backwards-compatible) plus interim in-memory filters across yaml/mongo/postgres backends and the shared per-`user_id` contract suite.
- 19-2 — Yaml backend: real skip-on-load push-down inside the snapshot-load loop, interim filter deleted.
- 19-3 — Mongo backend: real `find({"user_id": user_id})` push-down plus `teams_user_id_idx` ascending index on `user_id`, interim filter deleted.
- 19-4 — Postgres backend: real `WHERE (data ->> 'user_id') = %s` push-down plus `team_process_user_id_idx` functional expression index created idempotently by `init_db`, interim filter deleted. `schema.toml` unchanged (Option A — JSONB extraction).

After merge the team-package side of the epic is fully shipped. The cross-submodule caller cleanup in `akgentic-infra` (`team_service.py:60-63`) is tracked separately (out of scope for this epic per Golden Rule #4). Base branch remains `version-1.x`.
