### PR TITLE
feat(akgentic-team): epic 20 — Team Welcome Message (20-1-teamcard-welcome-message-field-and-welcomemessage-type → 20-2-announce-the-welcome-message-on-the-team-event-stream)

### DIFF
--- a/src/akgentic/team/__init__.py
+++ b/src/akgentic/team/__init__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from akgentic.team.factory import TeamFactory
 from akgentic.team.manager import TeamManager
+from akgentic.team.messages import WelcomeMessage
 from akgentic.team.models import (
     AgentStateSnapshot,
     PersistedEvent,
@@ -44,6 +45,7 @@ __all__: list[str] = [
     "TeamRestorer",
     "TeamRuntime",
     "TeamStatus",
+    "WelcomeMessage",
     "YamlEventStore",
 ]
 

--- a/src/akgentic/team/factory.py
+++ b/src/akgentic/team/factory.py
@@ -10,7 +10,9 @@ from akgentic.core.actor_address import ActorAddress
 from akgentic.core.actor_system_impl import ActorSystem
 from akgentic.core.agent import Akgent
 from akgentic.core.agent_config import BaseConfig
+from akgentic.core.messages.orchestrator import SentMessage
 from akgentic.core.orchestrator import EventSubscriber, Orchestrator
+from akgentic.team.messages import WelcomeMessage
 from akgentic.team.models import TeamCard, TeamCardMember, TeamRuntime
 
 logger = logging.getLogger(__name__)
@@ -115,6 +117,24 @@ class TeamFactory:
                 name = card.config.name
                 if name in addrs:
                     supervisor_addrs[name] = addrs[name]
+
+            # 5.b Announce the team's welcome message
+            # Hand the orchestrator a SentMessage wrapping a WelcomeMessage.
+            # The orchestrator's receiveMsg_SentMessage records it on the event
+            # log and broadcasts it to every subscriber (CLI printer,
+            # persistence, WebSocket -> frontend). Skipped when no greeting set.
+            if team_card.welcome_message:
+                actor_system.tell(
+                    orchestrator_addr,
+                    SentMessage(
+                        message=WelcomeMessage(
+                            content=team_card.welcome_message,
+                            sender=entry_addr,
+                            team_id=team_id,
+                        ),
+                        recipient=entry_addr,
+                    ),
+                )
 
             # 6. Build and return TeamRuntime
             return TeamRuntime(

--- a/src/akgentic/team/messages.py
+++ b/src/akgentic/team/messages.py
@@ -1,0 +1,29 @@
+"""Message types specific to team lifecycle management.
+
+Defines WelcomeMessage, the team's static startup greeting. It is a distinct
+Message subclass so the greeting is identifiable in the persisted event log
+and renderable specially by clients, without content heuristics.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from akgentic.core.messages.message import Message
+
+
+class WelcomeMessage(Message):
+    """The team's static startup greeting, announced on the event stream.
+
+    Carried as the payload of a SentMessage that TeamFactory hands to the
+    orchestrator at build time. A distinct type -- never produced by an LLM --
+    so the greeting is identifiable in the event log and renderable specially
+    by clients.
+
+    Attributes:
+        content: The greeting text declared on the TeamCard.
+        display_type: Display category for UI rendering; defaults to "ai".
+    """
+
+    content: str
+    display_type: Literal["human", "ai", "other"] = "ai"

--- a/src/akgentic/team/models.py
+++ b/src/akgentic/team/models.py
@@ -59,6 +59,8 @@ class TeamCard(SerializableBaseModel):
         entry_point: The member that serves as the team's external interface.
         members: Top-level members of the team (excluding the entry point).
         message_types: Message classes the team handles; first is the default.
+        welcome_message: Optional static greeting announced on the team's event
+            stream when the team is first created. ``None`` disables it.
     """
 
     name: str | None = Field(
@@ -81,6 +83,13 @@ class TeamCard(SerializableBaseModel):
     agent_profiles: list[AgentCard] = Field(
         default_factory=list,
         description="AgentCards available for runtime hiring, not instantiated at startup",
+    )
+    welcome_message: str | None = Field(
+        default=None,
+        description=(
+            "Optional static greeting announced on the team's event stream when "
+            "the team is first created. None disables it."
+        ),
     )
 
     @property

--- a/tests/integration/test_welcome_announcement.py
+++ b/tests/integration/test_welcome_announcement.py
@@ -1,0 +1,276 @@
+"""Integration tests for the welcome-message announcement (Story 20.2).
+
+Verifies that TeamFactory.build() announces a TeamCard.welcome_message on the
+team's event stream as a WelcomeMessage wrapped in a SentMessage, that the
+announcement is recorded and broadcast to subscribers, that it is skipped when
+no greeting is declared, and that it is replayed exactly once on resume.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.messages.message import Message, UserMessage
+from akgentic.core.messages.orchestrator import SentMessage
+from akgentic.core.orchestrator import Orchestrator
+
+from akgentic.team.factory import TeamFactory
+from akgentic.team.manager import TeamManager
+from akgentic.team.messages import WelcomeMessage
+from akgentic.team.models import TeamCard, TeamCardMember
+from tests.integration.conftest import (
+    RecordingAgent,
+    make_integration_agent_card,
+)
+from tests.services.conftest import InMemoryEventStore
+
+_GREETING = "Welcome to the team!"
+
+
+class _RecordingSubscriber:
+    """EventSubscriber that records every message broadcast via on_message.
+
+    Satisfies the EventSubscriber protocol via structural subtyping.
+    """
+
+    def __init__(self) -> None:
+        self.messages: list[Message] = []
+
+    def on_message(self, msg: Message) -> None:
+        """Append the broadcast message to the recorded list."""
+        self.messages.append(msg)
+
+    def on_start(self) -> None:
+        """No-op: not exercised by these tests."""
+
+    def on_stop(self) -> None:
+        """No-op: not exercised by these tests."""
+
+    def on_stop_request(self) -> None:
+        """No-op: not exercised by these tests."""
+
+
+def _make_team_card(welcome_message: str | None) -> TeamCard:
+    """Create a single-agent team card with the given welcome_message."""
+    entry = TeamCardMember(
+        card=make_integration_agent_card(
+            name="greeter",
+            role="Greeter",
+            agent_class=RecordingAgent,
+        ),
+    )
+    return TeamCard(
+        name="welcome-team",
+        description="A team for welcome-message announcement tests",
+        entry_point=entry,
+        members=[],
+        message_types=[UserMessage],
+        welcome_message=welcome_message,
+    )
+
+
+def _wait_for(predicate: Any, timeout: float = 3.0) -> bool:
+    """Poll predicate until True or timeout (announcement is fire-and-forget)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+class TestWelcomeAnnouncement:
+    """TeamFactory.build() welcome-message announcement (AC #1-#5)."""
+
+    def test_build_announces_welcome_message(
+        self,
+        actor_system: ActorSystem,
+    ) -> None:
+        """AC #1, #3: build() records a SentMessage wrapping a WelcomeMessage.
+
+        The WelcomeMessage carries content == welcome_message,
+        sender == entry_addr, and team_id == the team's id.
+        """
+        runtime = TeamFactory.build(_make_team_card(_GREETING), actor_system)
+        orchestrator: Orchestrator = actor_system.proxy_ask(runtime.orchestrator_addr, Orchestrator)
+
+        def announced() -> bool:
+            return any(
+                isinstance(m, SentMessage) and isinstance(m.message, WelcomeMessage)
+                for m in orchestrator.get_messages()
+            )
+
+        assert _wait_for(announced), "WelcomeMessage SentMessage not recorded on event log"
+
+        sent = next(
+            m
+            for m in orchestrator.get_messages()
+            if isinstance(m, SentMessage) and isinstance(m.message, WelcomeMessage)
+        )
+        welcome = sent.message
+        assert isinstance(welcome, WelcomeMessage)
+        assert welcome.content == _GREETING
+        assert welcome.sender == runtime.entry_addr
+        assert welcome.team_id == runtime.id
+        assert sent.recipient == runtime.entry_addr
+
+    def test_subscriber_receives_welcome_message(
+        self,
+        actor_system: ActorSystem,
+    ) -> None:
+        """AC #2: registered subscribers receive the WelcomeMessage via on_message."""
+        subscriber = _RecordingSubscriber()
+        runtime = TeamFactory.build(
+            _make_team_card(_GREETING), actor_system, subscribers=[subscriber]
+        )
+        assert runtime is not None
+
+        def broadcast() -> bool:
+            return any(
+                isinstance(m, SentMessage) and isinstance(m.message, WelcomeMessage)
+                for m in subscriber.messages
+            )
+
+        assert _wait_for(broadcast), "WelcomeMessage not broadcast to subscriber"
+
+        sent = next(
+            m
+            for m in subscriber.messages
+            if isinstance(m, SentMessage) and isinstance(m.message, WelcomeMessage)
+        )
+        welcome = sent.message
+        assert isinstance(welcome, WelcomeMessage)
+        assert welcome.content == _GREETING
+        assert welcome.display_type == "ai"
+
+    def test_no_announcement_when_welcome_message_none(
+        self,
+        actor_system: ActorSystem,
+    ) -> None:
+        """AC #4: build() announces nothing when welcome_message is None."""
+        runtime = TeamFactory.build(_make_team_card(None), actor_system)
+        orchestrator: Orchestrator = actor_system.proxy_ask(runtime.orchestrator_addr, Orchestrator)
+
+        # Give any (erroneous) async announcement a chance to land.
+        time.sleep(0.3)
+
+        welcome_sents = [
+            m
+            for m in orchestrator.get_messages()
+            if isinstance(m, SentMessage) and isinstance(m.message, WelcomeMessage)
+        ]
+        assert welcome_sents == [], "No WelcomeMessage expected when welcome_message is None"
+
+    def test_no_announcement_when_welcome_message_empty(
+        self,
+        actor_system: ActorSystem,
+    ) -> None:
+        """AC #4: build() announces nothing for an empty (falsy) welcome_message."""
+        runtime = TeamFactory.build(_make_team_card(""), actor_system)
+        orchestrator: Orchestrator = actor_system.proxy_ask(runtime.orchestrator_addr, Orchestrator)
+
+        time.sleep(0.3)
+
+        welcome_sents = [
+            m
+            for m in orchestrator.get_messages()
+            if isinstance(m, SentMessage) and isinstance(m.message, WelcomeMessage)
+        ]
+        assert welcome_sents == [], "No WelcomeMessage expected for empty welcome_message"
+
+    def test_announcement_failure_triggers_rollback(
+        self,
+        actor_system: ActorSystem,
+    ) -> None:
+        """AC #5: a delivery failure in sub-step 5.b triggers the standard rollback.
+
+        The announcement runs inside build()'s existing try block, so a failure
+        from actor_system.tell tears down already-spawned actors and re-raises.
+        """
+        team_card = _make_team_card(_GREETING)
+        original_tell = actor_system.tell
+        original_create = actor_system.createActor
+        spawned: list[Any] = []
+
+        def tracking_create(*args: Any, **kwargs: Any) -> Any:
+            addr = original_create(*args, **kwargs)
+            if addr is not None:
+                spawned.append(addr)
+            return addr
+
+        def failing_tell(addr: Any, message: Any) -> None:
+            if isinstance(message, SentMessage) and isinstance(message.message, WelcomeMessage):
+                raise RuntimeError("simulated announcement delivery failure")
+            return original_tell(addr, message)
+
+        actor_system.tell = failing_tell  # type: ignore[method-assign]
+        actor_system.createActor = tracking_create  # type: ignore[method-assign]
+        try:
+            with pytest.raises(RuntimeError, match="simulated announcement delivery failure"):
+                TeamFactory.build(team_card, actor_system)
+        finally:
+            actor_system.tell = original_tell  # type: ignore[method-assign]
+            actor_system.createActor = original_create  # type: ignore[method-assign]
+
+        # Rollback: every spawned actor was torn down.
+        assert spawned, "No actors were spawned -- rollback assertion is vacuous"
+        for addr in spawned:
+            assert not addr.is_alive(), "Actor still alive after rollback"
+
+
+class TestWelcomeResumeNonDuplication:
+    """Resume replays the greeting exactly once and never re-announces (AC #6)."""
+
+    def test_welcome_message_replayed_once_on_resume(
+        self,
+        actor_system: ActorSystem,
+    ) -> None:
+        """AC #6: stop + resume replays the greeting once -- never twice.
+
+        TeamRestorer replays the persisted SentMessage event; it does not call
+        TeamFactory.build() and adds no welcome-message announcement of its own,
+        so the greeting appears exactly once in the resumed event stream.
+        """
+        event_store = InMemoryEventStore()
+        manager = TeamManager(actor_system, event_store)
+        team_card = _make_team_card(_GREETING)
+
+        runtime = manager.create_team(team_card)
+        team_id = runtime.id
+
+        orchestrator: Orchestrator = actor_system.proxy_ask(runtime.orchestrator_addr, Orchestrator)
+
+        def announced_once() -> bool:
+            welcome = [
+                m
+                for m in orchestrator.get_messages()
+                if isinstance(m, SentMessage) and isinstance(m.message, WelcomeMessage)
+            ]
+            return len(welcome) == 1
+
+        assert _wait_for(announced_once), "WelcomeMessage not announced once on create"
+
+        # Allow the announcement to be persisted before stopping.
+        time.sleep(0.3)
+        manager.stop_team(team_id)
+
+        new_runtime = manager.resume_team(team_id)
+        resumed_orchestrator: Orchestrator = actor_system.proxy_ask(
+            new_runtime.orchestrator_addr, Orchestrator
+        )
+
+        welcome_after_resume = [
+            m
+            for m in resumed_orchestrator.get_messages()
+            if isinstance(m.message if isinstance(m, SentMessage) else m, WelcomeMessage)
+        ]
+        assert len(welcome_after_resume) == 1, (
+            f"Expected the welcome greeting exactly once after resume, "
+            f"got {len(welcome_after_resume)} -- re-announcement detected"
+        )
+        welcome = welcome_after_resume[0].message
+        assert isinstance(welcome, WelcomeMessage)
+        assert welcome.content == _GREETING

--- a/tests/models/test_team_card.py
+++ b/tests/models/test_team_card.py
@@ -127,6 +127,24 @@ class TestTeamCard:
         team = make_team_card()
         assert team.message_types == []
 
+    def test_welcome_message_defaults_to_none(self) -> None:
+        """welcome_message defaults to None when omitted (backward compatible)."""
+        team = make_team_card()
+        assert team.welcome_message is None
+
+    def test_welcome_message_accepts_a_string(self) -> None:
+        """welcome_message accepts an explicit greeting string."""
+        entry = TeamCardMember(card=make_agent_card(name="entry", role="Entry"))
+        team = TeamCard(entry_point=entry, welcome_message="Welcome aboard!")
+        assert team.welcome_message == "Welcome aboard!"
+
+    def test_welcome_message_round_trip(self) -> None:
+        """welcome_message survives a model_dump / model_validate round-trip."""
+        entry = TeamCardMember(card=make_agent_card(name="entry", role="Entry"))
+        team = TeamCard(entry_point=entry, welcome_message="Hello team")
+        restored = TeamCard.model_validate(team.model_dump())
+        assert restored.welcome_message == "Hello team"
+
     def test_agent_cards_raises_on_duplicate_config_name(self) -> None:
         """agent_cards raises ValueError when two members share config.name."""
         entry = TeamCardMember(card=make_agent_card(name="entry", role="Entry"))

--- a/tests/models/test_welcome_message.py
+++ b/tests/models/test_welcome_message.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import akgentic.team
 import pytest
 from akgentic.core.messages.message import Message
 from akgentic.core.utils.deserializer import deserialize_object
 from pydantic import ValidationError
 
+import akgentic.team
 from akgentic.team.messages import WelcomeMessage
 
 

--- a/tests/models/test_welcome_message.py
+++ b/tests/models/test_welcome_message.py
@@ -1,0 +1,63 @@
+"""Tests for the WelcomeMessage type and its public-API export."""
+
+from __future__ import annotations
+
+import akgentic.team
+import pytest
+from akgentic.core.messages.message import Message
+from akgentic.core.utils.deserializer import deserialize_object
+from pydantic import ValidationError
+
+from akgentic.team.messages import WelcomeMessage
+
+
+class TestWelcomeMessage:
+    """Tests for the WelcomeMessage message class."""
+
+    def test_is_message_subclass(self) -> None:
+        """WelcomeMessage is a subclass of the core Message type."""
+        assert issubclass(WelcomeMessage, Message)
+
+    def test_display_type_defaults_to_ai(self) -> None:
+        """display_type defaults to 'ai', overriding the base 'other' default."""
+        msg = WelcomeMessage(content="hi")
+        assert msg.display_type == "ai"
+
+    def test_content_is_required(self) -> None:
+        """content is a required field — omitting it raises ValidationError."""
+        with pytest.raises(ValidationError):
+            WelcomeMessage()  # type: ignore[call-arg]
+
+    def test_display_type_can_be_overridden(self) -> None:
+        """display_type accepts any value of the three-value Literal."""
+        msg = WelcomeMessage(content="hi", display_type="other")
+        assert msg.display_type == "other"
+
+    def test_round_trip_via_deserialize_object(self) -> None:
+        """A WelcomeMessage round-trips through model_dump / deserialize_object.
+
+        Polymorphic reconstruction via the __model__ tag must restore the
+        concrete WelcomeMessage type and all fields identically.
+        """
+        original = WelcomeMessage(content="Welcome to the team!")
+        data = original.model_dump()
+        restored = deserialize_object(data)
+        assert type(restored) is WelcomeMessage
+        assert restored == original
+        assert restored.content == "Welcome to the team!"
+        assert restored.display_type == "ai"
+        assert restored.id == original.id
+
+
+class TestWelcomeMessageExport:
+    """Tests for the public-API export of WelcomeMessage."""
+
+    def test_importable_from_package(self) -> None:
+        """WelcomeMessage is importable from the akgentic.team package."""
+        from akgentic.team import WelcomeMessage as ExportedWelcomeMessage
+
+        assert ExportedWelcomeMessage is WelcomeMessage
+
+    def test_present_in_all(self) -> None:
+        """WelcomeMessage is listed in akgentic.team.__all__."""
+        assert "WelcomeMessage" in akgentic.team.__all__


### PR DESCRIPTION
## Epic 20 — Team Welcome Message

Restores the V1 `welcome_message` capability the V2 way: a team author declares a startup greeting on the `TeamCard`, and `TeamFactory.build()` announces it on the team's event stream as a `WelcomeMessage` wrapped in a `SentMessage`. The feature is contained entirely within `akgentic-team`.

This is the umbrella PR for the epic; stories land on this shared branch and are checked off below as they complete.

### Stories

- [x] `20-1-teamcard-welcome-message-field-and-welcomemessage-type` (Relates to #117)
- [x] `20-2-announce-the-welcome-message-on-the-team-event-stream` (Relates to #119)

## Review status

### 20-1 — TeamCard `welcome_message` field and `WelcomeMessage` type — APPROVED

- Implementation matches the ADR-17 reference code exactly: `WelcomeMessage(Message)` with `content: str` and `display_type: Literal["human", "ai", "other"] = "ai"`; `TeamCard.welcome_message: str | None = None`.
- All 6 acceptance criteria covered by tests, including the polymorphic `model_dump()` / `deserialize_object()` round-trip and the public-API export.
- Module boundary upheld: `WelcomeMessage` imports `Message` from `akgentic-core`; no `akgentic-core` change.
- One review fixup applied (`f44ae72`): reordered imports in `test_welcome_message.py` to resolve a ruff `I001` violation introduced by the dev commit.
- Gates green locally: `pytest packages/akgentic-team/tests/` 344 passed / 5 skipped; `mypy packages/akgentic-team/src/` clean (20 files); `ruff check` clean on src and the touched test files.

### 20-2 — Announce the welcome message on the team event stream — PASS

- Implementation (`24be4e6`) matches the ADR-17 Decision 3 reference code verbatim: build sub-step 5.b in `TeamFactory.build()` inserted between step 5 (`supervisor_addrs`) and step 6 (`return TeamRuntime`), inside the existing `try` block. When `team_card.welcome_message` is truthy, the factory hands the orchestrator a `SentMessage(message=WelcomeMessage(content=..., sender=entry_addr, team_id=team_id), recipient=entry_addr)`.
- All 6 acceptance criteria covered by 6 integration tests in `tests/integration/test_welcome_announcement.py`: announcement + attribution (AC #1/#3), subscriber broadcast (AC #2), `None` and empty-string skip (AC #4), rollback on simulated delivery failure (AC #5), and resume-replays-once non-duplication (AC #6).
- Module boundary upheld: `SentMessage` imported from `akgentic.core.messages.orchestrator`, `WelcomeMessage` from `akgentic.team.messages` (within-package) — no `akgentic-core` change, no new handler.
- No fix-worthy (HIGH/MEDIUM) issues found — no review fixup commit was required. The negative-assertion settling `time.sleep` calls are consistent with the existing `test_persistence.py` pattern; positive assertions use a `_wait_for` poll helper.
- Gates green locally: `pytest packages/akgentic-team/tests/` 350 passed / 5 skipped / 1 deselected; `mypy packages/akgentic-team/src/` clean (20 files); `ruff check` clean on src and the new test file.

## Epic 20 slice complete

Both stories of Epic 20 are reviewed and `done`. The epic is fully contained inside `packages/akgentic-team/` — `src/akgentic/team/{__init__.py,messages.py,models.py,factory.py}` and `tests/{models,integration}/`. No cross-submodule edits.

**Dependency — must merge first:** Epic 20 depends on the `akgentic-core` fix on branch `feat/69-actorsystemlistener-serializable-identity` (**PR #70** — ActorSystemListener serializable-identity fix). The subscriber-broadcast path exercised by story 20-2's tests requires that fix. **PR #70 MUST be merged before this PR #118** — merging #118 first would leave the workspace `akgentic-core` pointer on a revision where the welcome-message broadcast path is not yet correct.

## Scope guard

All changes in this PR stay inside `packages/akgentic-team/`. No cross-submodule edits. Pre-existing `ruff format` drift in untouched files was intentionally left alone per one-commit-one-responsibility.
