### PR TITLE
fix(akgentic-team): WelcomeMessage sender + display_type corrections (Epic 20 / ADR-17)

### DIFF
--- a/src/akgentic/team/factory.py
+++ b/src/akgentic/team/factory.py
@@ -129,7 +129,7 @@ class TeamFactory:
                     SentMessage(
                         message=WelcomeMessage(
                             content=team_card.welcome_message,
-                            sender=entry_addr,
+                            sender=orchestrator_addr,
                             team_id=team_id,
                         ),
                         recipient=entry_addr,

--- a/src/akgentic/team/messages.py
+++ b/src/akgentic/team/messages.py
@@ -22,8 +22,9 @@ class WelcomeMessage(Message):
 
     Attributes:
         content: The greeting text declared on the TeamCard.
-        display_type: Display category for UI rendering; defaults to "ai".
+        display_type: Display category for UI rendering; defaults to "other"
+            -- the greeting is a synthetic system announcement, not an AI turn.
     """
 
     content: str
-    display_type: Literal["human", "ai", "other"] = "ai"
+    display_type: Literal["human", "ai", "other"] = "other"

--- a/tests/integration/test_welcome_announcement.py
+++ b/tests/integration/test_welcome_announcement.py
@@ -92,7 +92,7 @@ class TestWelcomeAnnouncement:
         """AC #1, #3: build() records a SentMessage wrapping a WelcomeMessage.
 
         The WelcomeMessage carries content == welcome_message,
-        sender == entry_addr, and team_id == the team's id.
+        sender == orchestrator_addr, and team_id == the team's id.
         """
         runtime = TeamFactory.build(_make_team_card(_GREETING), actor_system)
         orchestrator: Orchestrator = actor_system.proxy_ask(runtime.orchestrator_addr, Orchestrator)
@@ -113,7 +113,7 @@ class TestWelcomeAnnouncement:
         welcome = sent.message
         assert isinstance(welcome, WelcomeMessage)
         assert welcome.content == _GREETING
-        assert welcome.sender == runtime.entry_addr
+        assert welcome.sender == runtime.orchestrator_addr
         assert welcome.team_id == runtime.id
         assert sent.recipient == runtime.entry_addr
 

--- a/tests/integration/test_welcome_announcement.py
+++ b/tests/integration/test_welcome_announcement.py
@@ -144,7 +144,7 @@ class TestWelcomeAnnouncement:
         welcome = sent.message
         assert isinstance(welcome, WelcomeMessage)
         assert welcome.content == _GREETING
-        assert welcome.display_type == "ai"
+        assert welcome.display_type == "other"
 
     def test_no_announcement_when_welcome_message_none(
         self,

--- a/tests/models/test_welcome_message.py
+++ b/tests/models/test_welcome_message.py
@@ -18,10 +18,11 @@ class TestWelcomeMessage:
         """WelcomeMessage is a subclass of the core Message type."""
         assert issubclass(WelcomeMessage, Message)
 
-    def test_display_type_defaults_to_ai(self) -> None:
-        """display_type defaults to 'ai', overriding the base 'other' default."""
+    def test_display_type_defaults_to_other(self) -> None:
+        """display_type defaults to 'other' — the greeting is a synthetic system
+        announcement, not an AI turn (see ADR-17 amendment 2026-05-18)."""
         msg = WelcomeMessage(content="hi")
-        assert msg.display_type == "ai"
+        assert msg.display_type == "other"
 
     def test_content_is_required(self) -> None:
         """content is a required field — omitting it raises ValidationError."""
@@ -30,8 +31,8 @@ class TestWelcomeMessage:
 
     def test_display_type_can_be_overridden(self) -> None:
         """display_type accepts any value of the three-value Literal."""
-        msg = WelcomeMessage(content="hi", display_type="other")
-        assert msg.display_type == "other"
+        msg = WelcomeMessage(content="hi", display_type="ai")
+        assert msg.display_type == "ai"
 
     def test_round_trip_via_deserialize_object(self) -> None:
         """A WelcomeMessage round-trips through model_dump / deserialize_object.
@@ -45,7 +46,7 @@ class TestWelcomeMessage:
         assert type(restored) is WelcomeMessage
         assert restored == original
         assert restored.content == "Welcome to the team!"
-        assert restored.display_type == "ai"
+        assert restored.display_type == "other"
         assert restored.id == original.id
 
 


### PR DESCRIPTION
## Summary

Two follow-up corrections to Epic 20 / ADR-17 (Team Welcome Message), both amendments
to the `WelcomeMessage` type, each as a separate commit.

### Story 20-3 — `WelcomeMessage.sender` is the orchestrator (commit `3056aaf`)

The `WelcomeMessage` announced by `TeamFactory.build()` carried `sender=entry_addr`,
attributing the team's static startup greeting to the entry agent. `WelcomeMessage` is
a **synthetic, factory-originated event** — never produced by an agent calling
`send()` — so that attribution made the greeting indistinguishable from real
entry-agent output in the persisted event log.

Now `sender=orchestrator_addr`: the orchestrator is the actor that announces the
greeting and the honest, addressable origin. The `ActorSystem` itself has no
`ActorAddress`. `SentMessage.recipient` stays `entry_addr`.

### Story 20-4 — `WelcomeMessage.display_type` is `"other"` (commit `b5007b2`)

ADR-17 Decision 2 defined `WelcomeMessage` with `display_type="ai"`, tagging the
greeting as AI output. The greeting is static authored copy emitted verbatim by
`TeamFactory`, never produced by an LLM — so `"ai"` made clients render it as an agent
turn.

Now `display_type` defaults to `"other"` — the existing `Message.display_type` value
for "neither a human turn nor an AI turn". `"other"` was always in the `Literal`, so
this is a default-value change only: **no `akgentic-core` change**. This lets clients
discriminate the greeting structurally on `display_type` (see `akgentic-frontend`
ADR-011).

## Changes

- `src/akgentic/team/messages.py` — `WelcomeMessage.display_type` default `"ai"` →
  `"other"` (+ docstring).
- `src/akgentic/team/factory.py` — sub-step 5.b: `WelcomeMessage(sender=...)` `entry_addr`
  → `orchestrator_addr`.
- `tests/integration/test_welcome_announcement.py`,
  `tests/models/test_welcome_message.py` — assertions + docstrings updated for both
  changes.

Planning docs amended for coherence (`_bmad-output/`): ADR-17 carries two dated
amendments; the Epic 20 breakdown FR5 / Story 20.2 are updated.

## Verification

- The orchestrator is a normal actor with a `config`, so its `ActorAddress` serializes
  cleanly on the subscriber-broadcast path — this change is **not** affected by the
  `ActorSystemListener` serialization fragility noted in ADR-17's other amendment.
- Full `akgentic-team` suite: **350 passed, 5 skipped, 1 deselected, 0 failed**
  (skips/deselect pre-existing). Coverage 93.94% (gate 80%).
- mypy + ruff on `packages/akgentic-team/src/` — clean.

## Notes

- No `akgentic-core` change. Scope: `akgentic-team` only.
- GitHub CI for this branch is blocked by a **pre-existing `ci.yml` infrastructure bug**
  (the `working-directory: packages/akgentic-team` step — same root cause as the
  `akgentic-llm` CI bug), unrelated to these changes. To be fixed separately. The
  `quality`-job gates were verified locally instead — see the PR comments.

Relates to #120, #122
