### PR TITLE
feat(akgentic-team): epic 22 — Wait on the Non-Blocking Orchestrator Stop (22-1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.1.0",
+    "pytest-timeout>=2.4.0",
     "mypy>=1.8.0",
     "ruff>=0.1.0",
     "mongomock>=4.0.0",
@@ -67,7 +68,11 @@ markers = ["integration: Full lifecycle tests requiring real LLM and API keys"]
 # --ignore: integration tests import akgentic.agent (not a dependency of
 # akgentic-team); skip collecting them so the import does not error before the
 # 'not integration' marker filter is applied.
-addopts = "-m 'not integration' --ignore=tests/integration"
+# --timeout is a deadlock backstop, not a latency budget: the team stop/teardown
+# paths now wait on the orchestrator's stop event; a regression that blocks the
+# actor thread would hang forever, so a finite per-test bound fails it fast.
+# --timeout-method=thread dumps every thread's stack when it fires.
+addopts = "-m 'not integration' --ignore=tests/integration --timeout=300 --timeout-method=thread"
 
 [tool.ruff]
 target-version = "py312"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akgentic-team"
-version = "1.3.0"
+version = "1.3.1"
 description = "Team lifecycle management — create, resume, stop, delete teams with event-sourced persistence"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/akgentic/team/factory.py
+++ b/src/akgentic/team/factory.py
@@ -11,11 +11,17 @@ from akgentic.core.actor_system_impl import ActorSystem
 from akgentic.core.agent import Akgent
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.messages.orchestrator import SentMessage
-from akgentic.core.orchestrator import EventSubscriber, Orchestrator
+from akgentic.core.orchestrator import STOP_TIMEOUT, EventSubscriber, Orchestrator
 from akgentic.team.messages import WelcomeMessage
 from akgentic.team.models import TeamCard, TeamCardMember, TeamRuntime
 
 logger = logging.getLogger(__name__)
+
+# Grace period passed into the non-blocking ``Orchestrator.stop(grace_timeout)``
+# on the rollback path (ADR-19 §2). Defaulted to core's ``STOP_TIMEOUT``; the
+# returned event is ``.wait()``-ed with no caller-side timeout because core's
+# backstop guarantees it is set within ~this many seconds.
+GRACE_TIMEOUT_SECONDS = STOP_TIMEOUT
 
 
 class TeamFactory:
@@ -148,13 +154,41 @@ class TeamFactory:
             )
 
         except Exception:
-            # Rollback: stop all already-spawned actors via proxy API
-            for addr in reversed(spawned_addrs):
-                try:
-                    actor_system.proxy_ask(addr, Akgent).stop()
-                except Exception:
-                    logger.warning("Failed to stop actor during rollback: %s", addr)
+            TeamFactory._rollback_spawned(actor_system, spawned_addrs)
             raise
+
+    @staticmethod
+    def _rollback_spawned(
+        actor_system: ActorSystem,
+        spawned_addrs: list[ActorAddress],
+    ) -> None:
+        """Tear down already-spawned actors after a partial-build failure.
+
+        Stops ``reversed(spawned_addrs)`` so the orchestrator (spawned first) is
+        stopped last — by then its team roster is empty, so its stop finalizes
+        near-instantly. The orchestrator entry uses the non-blocking
+        ``Orchestrator.stop(grace).wait()`` (akgentic-core ADR-012) so rollback
+        does not return while a live orchestrator (subscribers attached, event
+        stream open) lingers; agent entries keep the unchanged blocking
+        ``Akgent.stop()`` (ADR-19 §2). Best-effort: per-actor failures are
+        logged and do not abort the rollback.
+
+        Args:
+            actor_system: The actor system whose proxies drive the stops.
+            spawned_addrs: Actors spawned so far, in spawn order
+                (``spawned_addrs[0]`` is the orchestrator).
+        """
+        orchestrator_addr = spawned_addrs[0] if spawned_addrs else None
+        for addr in reversed(spawned_addrs):
+            try:
+                if addr == orchestrator_addr:
+                    actor_system.proxy_ask(addr, Orchestrator).stop(
+                        GRACE_TIMEOUT_SECONDS
+                    ).wait()
+                else:
+                    actor_system.proxy_ask(addr, Akgent).stop()
+            except Exception:
+                logger.warning("Failed to stop actor during rollback: %s", addr)
 
     @staticmethod
     def _register_subscribers(

--- a/src/akgentic/team/manager.py
+++ b/src/akgentic/team/manager.py
@@ -7,7 +7,7 @@ import uuid
 from datetime import UTC, datetime
 
 from akgentic.core.actor_system_impl import ActorSystem
-from akgentic.core.orchestrator import EventSubscriber, Orchestrator
+from akgentic.core.orchestrator import STOP_TIMEOUT, EventSubscriber, Orchestrator
 from akgentic.team.factory import TeamFactory
 from akgentic.team.models import Process, TeamCard, TeamRuntime, TeamStatus
 from akgentic.team.ports import EventStore, NullServiceRegistry, ServiceRegistry
@@ -15,6 +15,13 @@ from akgentic.team.restorer import TeamRestorer
 from akgentic.team.subscriber import PersistenceSubscriber, TimerStopSubscriber
 
 logger = logging.getLogger(__name__)
+
+# Grace period passed into the non-blocking ``Orchestrator.stop(grace_timeout)``
+# at every orchestrator-stop site. It is the single stop timeout (ADR-19 §4):
+# core's backstop guarantees the returned event is set within ~this many seconds,
+# so callers ``.wait()`` with NO separate caller-side timeout. Defaulted to core's
+# ``STOP_TIMEOUT`` so the team grace period tracks the framework default.
+GRACE_TIMEOUT_SECONDS = STOP_TIMEOUT
 
 
 class TeamManager:
@@ -257,7 +264,20 @@ class TeamManager:
         return runtime
 
     def _teardown_team(self, team_id: uuid.UUID, runtime: TeamRuntime) -> None:
-        """Trigger graceful orchestrator stop via proxy.
+        """Trigger graceful orchestrator stop via proxy and wait for completion.
+
+        ``Orchestrator.stop(grace_timeout)`` is non-blocking (akgentic-core
+        ADR-012): the ``proxy_ask`` resolves immediately and returns a
+        ``threading.Event`` that core sets once teardown is complete (mailbox
+        drained, subscribers' ``on_stop`` fired, actor deregistered). We
+        ``.wait()`` on that event — on this caller/daemon thread, NOT the
+        orchestrator's actor thread — so ``stop_team`` only persists ``STOPPED``
+        and deregisters AFTER the actors are actually down.
+
+        The wait takes no timeout: core's backstop guarantees the event is set
+        within ~``GRACE_TIMEOUT_SECONDS``, so it cannot hang and always returns
+        ``True``. There is therefore no ``if not stopped:`` branch — the
+        "had to force it" WARNING lives in core's ``_force_stop``.
 
         The orchestrator's own ``on_stop`` fans out ``on_stop(team_id)`` to
         every attached subscriber *before* tearing actors down and clearing
@@ -276,7 +296,7 @@ class TeamManager:
             orchestrator_proxy: Orchestrator = self._actor_system.proxy_ask(
                 runtime.orchestrator_addr, Orchestrator
             )
-            orchestrator_proxy.stop()
+            orchestrator_proxy.stop(GRACE_TIMEOUT_SECONDS).wait()
         except Exception:
             logger.warning(
                 "Failed to teardown orchestrator for team %s",

--- a/src/akgentic/team/restorer.py
+++ b/src/akgentic/team/restorer.py
@@ -20,7 +20,7 @@ from akgentic.core.messages.orchestrator import (
     StartMessage,
     StopMessage,
 )
-from akgentic.core.orchestrator import EventSubscriber, Orchestrator
+from akgentic.core.orchestrator import STOP_TIMEOUT, EventSubscriber, Orchestrator
 from akgentic.core.utils.deserializer import import_class
 from akgentic.team.models import (
     AgentStateSnapshot,
@@ -36,6 +36,12 @@ logger = logging.getLogger(__name__)
 # Role string used by ToolActor agents (PlanningTool, KnowledgeGraphTool, Sandbox).
 # Duplicated here because akgentic-team MUST NOT import from akgentic-tool.
 _TOOL_ACTOR_ROLE = "ToolActor"
+
+# Grace period passed into the non-blocking ``Orchestrator.stop(grace_timeout)``
+# on the rollback path (ADR-19 §3). Defaulted to core's ``STOP_TIMEOUT``; the
+# returned event is ``.wait()``-ed with no caller-side timeout because core's
+# backstop guarantees it is set within ~this many seconds.
+GRACE_TIMEOUT_SECONDS = STOP_TIMEOUT
 
 
 @dataclass
@@ -134,10 +140,22 @@ class TeamRestorer:
             return runtime
 
         except Exception:
-            # Rollback: stop all spawned actors in reverse order via proxy API
+            # Rollback: stop all spawned actors in reverse order via proxy API.
+            # The orchestrator (created first, so ``spawned_addrs[0]``) is stopped
+            # last and uses the non-blocking ``Orchestrator.stop(grace).wait()``
+            # (akgentic-core ADR-012) so rollback does not return while a live
+            # orchestrator (subscribers attached, event stream open) lingers;
+            # agent entries keep the unchanged blocking ``Akgent.stop()``
+            # (ADR-19 §3).
+            orchestrator_addr = spawned_addrs[0] if spawned_addrs else None
             for addr in reversed(spawned_addrs):
                 try:
-                    self._actor_system.proxy_ask(addr, Akgent).stop()
+                    if addr == orchestrator_addr:
+                        self._actor_system.proxy_ask(addr, Orchestrator).stop(
+                            GRACE_TIMEOUT_SECONDS
+                        ).wait()
+                    else:
+                        self._actor_system.proxy_ask(addr, Akgent).stop()
                 except Exception:
                     logger.warning("Failed to stop actor during rollback: %s", addr)
             raise

--- a/tests/services/test_factory.py
+++ b/tests/services/test_factory.py
@@ -299,17 +299,35 @@ class TestTeamFactoryBuild:
             TeamFactory.build(tc, actor_system)
 
     def test_rollback_handles_stop_failure(self, actor_system: ActorSystem) -> None:
-        """Rollback continues even if stopping an actor raises."""
+        """Rollback completes promptly even when stopping an actor raises.
+
+        A broken ``Akgent.stop`` means the failed worker never emits a
+        StopMessage, so the orchestrator's roster never empties and its stop
+        finalizes only via the backstop timer. Drive the rollback grace down to
+        a fraction of a second (patching the module-level ``GRACE_TIMEOUT_SECONDS``
+        the rollback reads) so this best-effort cleanup path does not block for
+        the full production grace on a wedged team. The rollback must still log
+        the stop failure and re-raise the original build error.
+        """
         failing = _make_member("failing", "Failing", agent_class=FailingAgent)
         tc = _make_team_card(members=[failing])
 
-        with patch.object(Akgent, "stop", side_effect=RuntimeError("stop failed")):
+        with (
+            patch("akgentic.team.factory.GRACE_TIMEOUT_SECONDS", 0.1),
+            patch.object(Akgent, "stop", side_effect=RuntimeError("stop failed")),
+        ):
+            start = time.monotonic()
             with pytest.raises(RuntimeError) as excinfo:
                 TeamFactory.build(tc, actor_system)
+            elapsed = time.monotonic() - start
+
             # The original spawn failure from FailingAgent propagates as-is
             # (no wrapping). Test asserts on type + non-empty str, not a
             # fragile match on the fixture's own message text.
             assert str(excinfo.value)
+            # Rollback returned promptly via the small grace backstop rather than
+            # blocking for the full production grace on the wedged orchestrator.
+            assert elapsed < 5.0, f"rollback blocked too long: {elapsed:.1f}s"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_factory.py
+++ b/tests/services/test_factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 import uuid
 from typing import Any
@@ -14,8 +15,9 @@ from akgentic.core.agent_card import AgentCard
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.agent_state import BaseState
 from akgentic.core.messages.message import Message
+from akgentic.core.orchestrator import Orchestrator
 
-from akgentic.team.factory import TeamFactory
+from akgentic.team.factory import GRACE_TIMEOUT_SECONDS, TeamFactory
 from akgentic.team.models import TeamCard, TeamCardMember, TeamRuntime
 
 # ---------------------------------------------------------------------------
@@ -432,3 +434,82 @@ class TestFactoryProxySpawning:
         assert "lead" not in runtime.supervisor_proxies
         # Entry point is still reachable via entry_proxy
         assert runtime.entry_proxy is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests: rollback waits on the orchestrator stop event (ADR-19 §2)
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryRollbackWaitsOnOrchestrator:
+    """AC2: build rollback waits on the orchestrator's non-blocking stop event.
+
+    On a partial-build failure the rollback stops ``reversed(spawned_addrs)``.
+    Agent entries keep the blocking ``Akgent.stop()``; the orchestrator entry
+    (spawned first, stopped last) must use the non-blocking
+    ``Orchestrator.stop(grace).wait()`` so rollback does not return while a
+    live orchestrator lingers.
+    """
+
+    def test_factory_rollback_waits_on_orchestrator(
+        self, actor_system: ActorSystem
+    ) -> None:
+        """AC2: rollback stops agents blocking, then waits on the orchestrator
+        entry's stop event; the orchestrator is dead once build re-raises.
+
+        We wrap the real ``Orchestrator.stop`` so it returns a wrapped event
+        whose ``wait`` records the call order, and the real ``Akgent.stop`` so
+        agent stops record their order. The orchestrator's ``wait()`` must run
+        AFTER both agent stops (reversed order) and the orchestrator must be
+        torn down by the time ``build`` re-raises.
+        """
+        good_worker = _make_member("good", "Good")
+        failing = _make_member("failing", "Failing", agent_class=FailingAgent)
+        tc = _make_team_card(members=[good_worker, failing])
+
+        events: list[str] = []
+        wait_calls: list[float] = []
+        grace_args: list[float] = []
+
+        real_orch_stop = Orchestrator.stop
+        real_agent_stop = Akgent.stop
+
+        def wrapped_orch_stop(
+            self: Orchestrator, grace_timeout: float = GRACE_TIMEOUT_SECONDS
+        ) -> threading.Event:
+            grace_args.append(grace_timeout)
+            evt = real_orch_stop(self, grace_timeout)
+
+            class _RecordingEvent:
+                def __init__(self, inner: threading.Event) -> None:
+                    self._inner = inner
+
+                def wait(self, timeout: float | None = None) -> bool:
+                    events.append("orchestrator-wait")
+                    wait_calls.append(time.monotonic())
+                    return self._inner.wait(timeout)
+
+            return _RecordingEvent(evt)  # type: ignore[return-value]
+
+        def wrapped_agent_stop(self: Akgent[Any, Any]) -> None:
+            # Only record non-orchestrator agent stops.
+            if not isinstance(self, Orchestrator):
+                events.append("agent-stop")
+            return real_agent_stop(self)
+
+        with (
+            patch.object(Orchestrator, "stop", wrapped_orch_stop),
+            patch.object(Akgent, "stop", wrapped_agent_stop),
+        ):
+            with pytest.raises(RuntimeError):
+                TeamFactory.build(tc, actor_system)
+
+        # Orchestrator stop received the single grace timeout, and its wait()
+        # ran. Agent stops are blocking and occur BEFORE the orchestrator wait
+        # (reversed spawn order → orchestrator last).
+        assert grace_args == [GRACE_TIMEOUT_SECONDS]
+        assert events.count("agent-stop") >= 1, f"no agent stops recorded: {events}"
+        assert "orchestrator-wait" in events
+        assert events.index("orchestrator-wait") == len(events) - 1, (
+            f"orchestrator wait must be last (after agent stops): {events}"
+        )

--- a/tests/services/test_manager.py
+++ b/tests/services/test_manager.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import threading
 import time
 import uuid
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from akgentic.core.actor_system_impl import ActorSystem
@@ -14,9 +15,9 @@ from akgentic.core.agent_card import AgentCard
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.agent_state import BaseState
 from akgentic.core.messages.message import Message
-from akgentic.core.orchestrator import EventSubscriber
+from akgentic.core.orchestrator import EventSubscriber, Orchestrator
 
-from akgentic.team.manager import TeamManager
+from akgentic.team.manager import GRACE_TIMEOUT_SECONDS, TeamManager
 from akgentic.team.models import (
     Process,
     TeamCard,
@@ -1206,3 +1207,166 @@ def _create_and_stop_team_with_namespace(
 
     manager.stop_team(team_id)
     return team_id
+
+
+# ---------------------------------------------------------------------------
+# Tests: _teardown_team waits on the orchestrator stop event (ADR-19 §1)
+# ---------------------------------------------------------------------------
+
+
+class TestTeardownWaitsOnStopEvent:
+    """AC1: ``_teardown_team`` waits on the orchestrator's stop event.
+
+    The non-blocking ``Orchestrator.stop(grace_timeout)`` returns a
+    ``threading.Event`` immediately; ``_teardown_team`` must ``.wait()`` on it
+    so that ``stop_team`` persists ``STOPPED`` / deregisters only AFTER the
+    actors are actually down.
+    """
+
+    def test_teardown_team_waits_for_stop_event(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC1: ``stop()`` returns a real Event; STOPPED/deregister happen only
+        after that event is set.
+
+        The mocked orchestrator stops by returning an unset event that a
+        background thread sets after a delay. We record the moment ``STOPPED``
+        is persisted and the moment ``deregister_team`` runs, and assert both
+        occur strictly after the event was set — proving the wait gates the
+        write path (behaviour only, no ADR-string assertions).
+        """
+        mock_registry = MagicMock(spec=NullServiceRegistry)
+        instance_id = uuid.uuid4()
+        mgr = TeamManager(
+            actor_system=actor_system,
+            event_store=event_store,
+            service_registry=mock_registry,
+            instance_id=instance_id,
+        )
+        tc = _make_team_card()
+        runtime = mgr.create_team(tc)
+        team_id = runtime.id
+        mock_registry.deregister_team.reset_mock()
+
+        stop_event = threading.Event()
+        set_time: dict[str, float] = {}
+
+        def _set_after_delay() -> None:
+            time.sleep(0.3)
+            set_time["event"] = time.monotonic()
+            stop_event.set()
+
+        # Mock proxy_ask so the orchestrator proxy's stop() returns our event.
+        orchestrator_proxy = MagicMock()
+        orchestrator_proxy.stop.return_value = stop_event
+
+        def fake_proxy_ask(addr: Any, cls: type[Any]) -> Any:
+            if cls is Orchestrator:
+                return orchestrator_proxy
+            return MagicMock()
+
+        deregister_time: dict[str, float] = {}
+
+        def timed_deregister(*args: Any, **kwargs: Any) -> None:
+            # Stamp the moment deregister runs. The MagicMock still records the
+            # call args for assert_called_*; the side_effect only adds timing.
+            deregister_time["t"] = time.monotonic()
+
+        mock_registry.deregister_team.side_effect = timed_deregister
+
+        setter = threading.Thread(target=_set_after_delay)
+        with patch.object(actor_system, "proxy_ask", side_effect=fake_proxy_ask):
+            setter.start()
+            mgr.stop_team(team_id)
+        setter.join()
+
+        # stop() was called with the single grace timeout, and .wait() gated
+        # the subsequent write path.
+        orchestrator_proxy.stop.assert_called_once_with(GRACE_TIMEOUT_SECONDS)
+        assert stop_event.is_set()
+
+        # Process is STOPPED and deregister ran — but only after the event set.
+        process = event_store.load_team(team_id)
+        assert process is not None
+        assert process.status == TeamStatus.STOPPED
+        assert "event" in set_time, "stop event was never set by the background thread"
+        assert "t" in deregister_time, "deregister_team was not called"
+        assert deregister_time["t"] >= set_time["event"], (
+            "deregister_team ran before the orchestrator stop event was set — "
+            "_teardown_team did not wait()"
+        )
+
+    def test_teardown_team_best_effort_on_dead_proxy(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC1: a failing ``stop()``/``proxy_ask`` still logs and never raises;
+        ``stop_team`` still persists ``STOPPED``."""
+        mgr = TeamManager(actor_system=actor_system, event_store=event_store)
+        tc = _make_team_card()
+        runtime = mgr.create_team(tc)
+        team_id = runtime.id
+
+        def boom_proxy_ask(addr: Any, cls: type[Any]) -> Any:
+            raise RuntimeError("dead proxy")
+
+        with patch.object(actor_system, "proxy_ask", side_effect=boom_proxy_ask):
+            # Must not raise — _teardown_team is best-effort.
+            mgr.stop_team(team_id)
+
+        process = event_store.load_team(team_id)
+        assert process is not None
+        assert process.status == TeamStatus.STOPPED
+
+    def test_grace_timeout_passed_into_stop(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC3: ``stop()`` is called with the single ``GRACE_TIMEOUT_SECONDS``;
+        no separate caller-side wait-timeout constant exists."""
+        import akgentic.team.manager as manager_module
+
+        mgr = TeamManager(actor_system=actor_system, event_store=event_store)
+        tc = _make_team_card()
+        runtime = mgr.create_team(tc)
+        team_id = runtime.id
+
+        already_set = threading.Event()
+        already_set.set()
+        orchestrator_proxy = MagicMock()
+        orchestrator_proxy.stop.return_value = already_set
+
+        def fake_proxy_ask(addr: Any, cls: type[Any]) -> Any:
+            if cls is Orchestrator:
+                return orchestrator_proxy
+            return MagicMock()
+
+        with patch.object(actor_system, "proxy_ask", side_effect=fake_proxy_ask):
+            mgr.stop_team(team_id)
+
+        orchestrator_proxy.stop.assert_called_once_with(GRACE_TIMEOUT_SECONDS)
+
+        # The grace timeout passed into stop() is the single stop timeout
+        # (ADR-19 §4). There is deliberately NO separate caller-side wait
+        # timeout: no WAIT-named constant, and the only team-owned grace
+        # constant is GRACE_TIMEOUT_SECONDS. (``STOP_TIMEOUT`` is the
+        # re-exported core constant that GRACE_TIMEOUT_SECONDS defaults to,
+        # not a caller-side wait knob.)
+        wait_consts = [
+            n for n in dir(manager_module) if n.isupper() and "WAIT" in n
+        ]
+        assert wait_consts == [], (
+            f"Unexpected caller-side wait constant(s) in manager module: {wait_consts}"
+        )
+        grace_consts = [
+            n
+            for n in dir(manager_module)
+            if n.isupper() and "GRACE" in n
+        ]
+        assert grace_consts == ["GRACE_TIMEOUT_SECONDS"], (
+            f"Unexpected grace constants in manager module: {grace_consts}"
+        )

--- a/tests/services/test_restorer.py
+++ b/tests/services/test_restorer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 import uuid
 from datetime import UTC, datetime
@@ -32,7 +33,7 @@ from akgentic.team.models import (
     TeamRuntime,
     TeamStatus,
 )
-from akgentic.team.restorer import TeamRestorer
+from akgentic.team.restorer import GRACE_TIMEOUT_SECONDS, TeamRestorer
 from tests.services.conftest import InMemoryEventStore
 
 # ---------------------------------------------------------------------------
@@ -707,6 +708,81 @@ class TestTeamRestorerRollback:
         actors_after = len(pykka.ActorRegistry.get_all())
         assert actors_after == actors_before, (
             f"Rollback failed: {actors_after - actors_before} actor(s) leaked"
+        )
+
+    def test_restorer_rollback_waits_on_orchestrator(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC2 (restore path): rollback stops agents blocking, then waits on the
+        orchestrator entry's stop event; the orchestrator wait runs last.
+
+        We build a team with two agents and make agent-class resolution succeed
+        for the first agent and fail for the second, so exactly one agent is
+        spawned before the failure. Rollback then stops that agent (blocking
+        ``Akgent.stop``) and waits on the orchestrator (non-blocking
+        ``Orchestrator.stop(grace).wait()``), in that order.
+        """
+        worker = _make_member("worker", "Worker")
+        tc = _make_team_card(members=[worker])
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        events: list[str] = []
+        grace_args: list[float] = []
+
+        real_orch_stop = Orchestrator.stop
+        real_agent_stop = Akgent.stop
+
+        from akgentic.team import restorer as restorer_module
+
+        real_import_class = restorer_module.import_class
+        call_count = {"n": 0}
+
+        def flaky_import_class(path: str) -> Any:
+            call_count["n"] += 1
+            if call_count["n"] >= 2:
+                raise ImportError("cannot resolve second agent class")
+            return real_import_class(path)
+
+        def wrapped_orch_stop(
+            self: Orchestrator, grace_timeout: float = GRACE_TIMEOUT_SECONDS
+        ) -> threading.Event:
+            grace_args.append(grace_timeout)
+            evt = real_orch_stop(self, grace_timeout)
+
+            class _RecordingEvent:
+                def __init__(self, inner: threading.Event) -> None:
+                    self._inner = inner
+
+                def wait(self, timeout: float | None = None) -> bool:
+                    events.append("orchestrator-wait")
+                    return self._inner.wait(timeout)
+
+            return _RecordingEvent(evt)  # type: ignore[return-value]
+
+        def wrapped_agent_stop(self: Akgent[Any, Any]) -> None:
+            if not isinstance(self, Orchestrator):
+                events.append("agent-stop")
+            return real_agent_stop(self)
+
+        restorer = TeamRestorer(actor_system, event_store)
+
+        with (
+            patch.object(restorer_module, "import_class", flaky_import_class),
+            patch.object(Orchestrator, "stop", wrapped_orch_stop),
+            patch.object(Akgent, "stop", wrapped_agent_stop),
+        ):
+            with pytest.raises(ImportError, match="second agent class"):
+                restorer.restore(process)
+
+        # Orchestrator stop received the single grace timeout; its wait() ran
+        # last, after the (blocking) agent stop in reversed spawn order.
+        assert grace_args == [GRACE_TIMEOUT_SECONDS]
+        assert events.count("agent-stop") >= 1, f"no agent stops recorded: {events}"
+        assert "orchestrator-wait" in events
+        assert events.index("orchestrator-wait") == len(events) - 1, (
+            f"orchestrator wait must be last (after agent stops): {events}"
         )
 
     def test_subscribers_registered_with_orchestrator(

--- a/tests/services/test_timer_stop_subscriber.py
+++ b/tests/services/test_timer_stop_subscriber.py
@@ -140,6 +140,41 @@ def test_lifecycle_methods_reject_wrong_team_id() -> None:
     assert manager.calls == []
 
 
+def test_timer_stop_still_offthread() -> None:
+    """AC4: ``TimerStopSubscriber`` drains ``stop_team`` on a *separate* daemon
+    thread, never on the calling (orchestrator actor) thread.
+
+    This is the load-bearing invariant for ADR-19's ``.wait()``: because
+    ``_teardown_team`` now blocks on the orchestrator's stop event, running it
+    on the orchestrator's own actor thread would self-deadlock (the thread that
+    must ``set()`` the event would be the one blocked waiting for it). The
+    daemon-thread offload guarantees the wait lands off the actor thread.
+    ``subscriber.py`` is unchanged; this test pins the behaviour it relies on.
+    """
+    seen: dict[str, int | bool] = {}
+    done = threading.Event()
+
+    class _ThreadRecordingManager:
+        def stop_team(self, team_id: uuid.UUID) -> None:
+            seen["thread_id"] = threading.get_ident()
+            seen["is_daemon"] = threading.current_thread().daemon
+            done.set()
+
+    manager = _ThreadRecordingManager()
+    team_id = uuid.uuid4()
+    sub = TimerStopSubscriber(manager, team_id)  # type: ignore[arg-type]
+
+    caller_thread_id = threading.get_ident()
+    sub.on_stop_request(team_id)
+
+    assert done.wait(timeout=2.0), "stop_team never ran on a background thread"
+    assert seen["thread_id"] != caller_thread_id, (
+        "stop_team ran on the calling thread — the .wait() would self-deadlock "
+        "if this were the orchestrator actor thread"
+    )
+    assert seen["is_daemon"] is True, "stop_team must run on a daemon thread"
+
+
 def test_on_stop_request_uses_background_thread() -> None:
     """Ensure on_stop_request returns before stop_team fires (no sync recursion)."""
     started = threading.Event()


### PR DESCRIPTION
## Epic 22 — Wait on the Non-Blocking Orchestrator Stop

Caller-side migration for the non-blocking `Orchestrator.stop(grace_timeout)` introduced upstream in `akgentic-core` (ADR-012). Reconstructs the "team fully stopped before we continue" guarantee by `.wait()`-ing on the `threading.Event` returned by `stop()` — moving the block off the orchestrator's actor thread (where it deadlocked) onto the caller/daemon thread.

### Stories

- [x] 22-1-wait-on-orchestrator-stop-event — wait on the non-blocking orchestrator stop (Relates to #128)

### Changes

- `manager.py` — `_teardown_team` now calls `orchestrator_proxy.stop(GRACE_TIMEOUT_SECONDS).wait()` (no caller-side wait timeout, no `if not stopped:` branch); stays best-effort. `STOPPED` is persisted / deregistered only after the wait returns.
- `factory.py` — build rollback extracted into `_rollback_spawned`; the orchestrator entry (`spawned_addrs[0]`, stopped last) waits on its stop event, agent entries keep the blocking `Akgent.stop()`.
- `restorer.py` — restore rollback applies the same orchestrator-waits / agents-blocking split.
- Single module-level `GRACE_TIMEOUT_SECONDS = STOP_TIMEOUT` per affected module; no separate wait-timeout constant.
- `subscriber.py` — UNCHANGED; the existing daemon-thread offload already runs `_teardown_team` off the orchestrator actor thread, so the new `.wait()` never self-deadlocks.

## Review status

Reviewed by Rex. 22-1 verdict: APPROVED. Implementation is exactly ADR-19-conformant — orchestrator-stop sites wait on the event, agent-stop sites remain blocking and unchanged, single grace timeout, best-effort semantics intact, no ADR-string test assertions (Golden Rule #8). No fix-worthy issues found; no fixup commit required.

Local gate (the gate for this slice): `pytest packages/akgentic-team/tests/` → 339 passed, 4 skipped; `mypy packages/akgentic-team/src/` clean (20 files); `ruff check packages/akgentic-team/src/` clean. The 31 postgres/mongo errors are testcontainers/Docker-daemon setup failures (no Docker locally) and are unrelated to this change.

## Epic 22 slice complete

Single-story epic. 22-1 is the only and last story; with it landed, Epic 22 is functionally complete on the caller side. The team package no longer persists `STOPPED` / deregisters while actors are still alive, and the intermittent full-suite stop deadlock is gone (inherited from core ADR-012).

## Cross-submodule dependency

This depends on `akgentic-core` epic-18 / ADR-012 (non-blocking `Orchestrator.stop(grace_timeout)` returning a `threading.Event`), which is tracked in `akgentic-core` PR #78. That change is present in the workspace via the editable `akgentic-core` install (branch `feat/77`) but is NOT yet merged/released.

Team GitHub CI resolves the released `akgentic-core` and will therefore be RED until `akgentic-core` PR #78 merges and a new `akgentic-core` release is resolved into team's dependency. This is EXPECTED, not a defect — `.wait()` is called on the `threading.Event` that the new core `stop()` returns; the released core still returns `None`. The local suite (against the editable core) is green.

DO NOT MERGE this PR before `akgentic-core` PR #78 is merged and a new core release is resolved into `akgentic-team`.

## Scope guard

All changes are inside `packages/akgentic-team/` (3 source files, 4 test files). No other submodule touched (Golden Rule #4).
