### PR TITLE
feat(akgentic-team): epic 23 — AgentStateSnapshot keyed by agent UUID + name (ADR-020 root fix)

### DIFF
--- a/src/akgentic/team/models.py
+++ b/src/akgentic/team/models.py
@@ -456,7 +456,18 @@ class AgentStateSnapshot(SerializableBaseModel):
     """
 
     team_id: uuid.UUID = Field(description="Team instance this snapshot belongs to")
-    agent_id: str = Field(description="Identifier of the agent whose state is captured")
+    agent_id: str = Field(
+        description=(
+            "Agent UUID in string form (str(uuid)). Legacy snapshots written "
+            "before this field's semantics changed may hold the agent display "
+            "name instead; such snapshots load with name=None and self-heal on "
+            "the agent's next state change."
+        )
+    )
+    name: str | None = Field(
+        default=None,
+        description="Agent display name; None for snapshots written before this field existed",
+    )
     state: BaseState = Field(
         description="Polymorphic agent state preserving concrete BaseState type"
     )

--- a/src/akgentic/team/restorer.py
+++ b/src/akgentic/team/restorer.py
@@ -439,14 +439,15 @@ class TeamRestorer:
         # 2c. Spawn remaining agents through resolved parents
         addrs = self._spawn_agents(agent_starts, orchestrator_addr, spawned_addrs)
 
-        # 2d. Restore agent states (keyed by agent UUID -- ADR-020 §Amendment).
-        # Snapshots persist agent_id=str(sender.agent_id); a restored agent keeps
-        # its original UUID (see _spawn_agents / _create_orchestrator), so the live
-        # address UUID is the exact key. Legacy name-keyed snapshots never match a
-        # UUID, so they are skipped and self-heal on the next state change.
+        # 2d. Restore agent states. Prefer the agent UUID (ADR-020 §Amendment): snapshots
+        # persist agent_id=str(sender.agent_id), and a restored agent keeps its original
+        # UUID (see _spawn_agents / _create_orchestrator), so the live address UUID is the
+        # exact key. Fall back to the agent NAME for legacy (pre-Epic-23) snapshots, whose
+        # agent_id holds the name -- this restores their state deterministically on every
+        # restore (the UUID match still wins for current/new snapshots).
         state_map: dict[str, AgentStateSnapshot] = {snap.agent_id: snap for snap in agent_states}
-        for addr in addrs.values():
-            snap = state_map.get(str(addr.agent_id))
+        for agent_name, addr in addrs.items():
+            snap = state_map.get(str(addr.agent_id)) or state_map.get(agent_name)
             if snap is not None:
                 proxy: Akgent[Any, Any] = self._actor_system.proxy_ask(addr, Akgent)
                 proxy.init_state(snap.state)

--- a/src/akgentic/team/restorer.py
+++ b/src/akgentic/team/restorer.py
@@ -51,6 +51,10 @@ class _RebuildResult:
     orchestrator_addr: ActorAddress
     orchestrator_proxy: Orchestrator
     addrs: dict[str, ActorAddress] = field(default_factory=dict)
+    # Snapshot lookup built in phase 2d, keyed by str(agent UUID) with legacy
+    # name keys. Threaded into Phase 3 so each restored agent's state can be
+    # re-emitted onto the event stream after its StartMessage (ADR-020 §3).
+    state_map: dict[str, AgentStateSnapshot] = field(default_factory=dict)
 
 
 class TeamRestorer:
@@ -125,6 +129,7 @@ class TeamRestorer:
                 result.orchestrator_proxy,
                 events,
                 addr_map,
+                result.state_map,
             )
 
             # Build and return TeamRuntime
@@ -475,6 +480,7 @@ class TeamRestorer:
             orchestrator_addr=orchestrator_addr,
             orchestrator_proxy=orchestrator_proxy,
             addrs=addrs,
+            state_map=state_map,
         )
 
     def _replay_events(
@@ -483,12 +489,21 @@ class TeamRestorer:
         orchestrator_proxy: Orchestrator,
         events: list[PersistedEvent],
         addr_map: dict[uuid.UUID, ActorAddress],
+        state_map: dict[str, AgentStateSnapshot],
     ) -> None:
         """Phase 3: Replay all persisted events through the orchestrator.
 
         Resolves ``ActorAddressProxy`` instances in events to live addresses
         before replay so that ``get_team()`` returns live ``ActorAddressImpl``
         refs instead of stale proxies.
+
+        After each replayed ``StartMessage``, re-emits the sender agent's state
+        snapshot onto the event stream via ``Akgent.notify_state_change`` so a
+        restored team's stream carries agent state exactly like a fresh team
+        (ADR-020 §3). Subscribers are attached by now (phase 2g), so this reaches
+        the stream; the orchestrator fans it out without appending to the event
+        log, and the caller's ``restoring=True`` guard keeps it out of the
+        snapshot store.
 
         The caller is responsible for toggling PersistenceSubscriber.set_restoring()
         before and after calling restore().
@@ -498,6 +513,8 @@ class TeamRestorer:
             orchestrator_proxy: Proxy to the restored orchestrator actor.
             events: Sorted persisted events to replay.
             addr_map: Mapping of agent_id to live ActorAddress for proxy resolution.
+            state_map: Snapshot lookup (str(agent UUID) preferred, name fallback)
+                built in phase 2d; used to re-emit state after each StartMessage.
         """
         logger.info("Restoring team %s: phase 3 -- replaying %d events", team_id, len(events))
 
@@ -506,7 +523,37 @@ class TeamRestorer:
         for pe in events:
             orchestrator_proxy.restore_message(pe.event)
 
+            # Re-emit the agent's state right after its StartMessage so the
+            # restored stream matches a fresh team's (ADR-020 §3).
+            if isinstance(pe.event, StartMessage) and pe.event.sender is not None:
+                self._reemit_state(pe.event.sender, state_map)
+
         orchestrator_proxy.end_restoration()
+
+    def _reemit_state(
+        self,
+        sender: ActorAddress,
+        state_map: dict[str, AgentStateSnapshot],
+    ) -> None:
+        """Re-emit a restored agent's state onto the event stream.
+
+        Resolves the snapshot for ``sender`` (UUID-preferred, name fallback --
+        mirroring phase 2d) and, if found, notifies the live agent's state change
+        so the resulting ``StateChangedMessage`` (keyed by the agent UUID) reaches
+        attached subscribers. A sender with no matching snapshot (e.g. the
+        orchestrator's StartMessage) is a no-op.
+
+        ``sender`` is already a live address here -- ``_resolve_event_addresses``
+        ran at the top of ``_replay_events``.
+
+        Args:
+            sender: The live address of the replayed StartMessage's sender.
+            state_map: Snapshot lookup keyed by str(agent UUID) with legacy names.
+        """
+        snap = state_map.get(str(sender.agent_id)) or state_map.get(sender.name)
+        if snap is not None:
+            proxy: Akgent[Any, Any] = self._actor_system.proxy_ask(sender, Akgent)
+            proxy.notify_state_change(snap.state)
 
     def _resolve_event_addresses(
         self,

--- a/src/akgentic/team/restorer.py
+++ b/src/akgentic/team/restorer.py
@@ -439,12 +439,17 @@ class TeamRestorer:
         # 2c. Spawn remaining agents through resolved parents
         addrs = self._spawn_agents(agent_starts, orchestrator_addr, spawned_addrs)
 
-        # 2d. Restore agent states
+        # 2d. Restore agent states (keyed by agent UUID -- ADR-020 §Amendment).
+        # Snapshots persist agent_id=str(sender.agent_id); a restored agent keeps
+        # its original UUID (see _spawn_agents / _create_orchestrator), so the live
+        # address UUID is the exact key. Legacy name-keyed snapshots never match a
+        # UUID, so they are skipped and self-heal on the next state change.
         state_map: dict[str, AgentStateSnapshot] = {snap.agent_id: snap for snap in agent_states}
-        for agent_name, addr in addrs.items():
-            if agent_name in state_map:
+        for addr in addrs.values():
+            snap = state_map.get(str(addr.agent_id))
+            if snap is not None:
                 proxy: Akgent[Any, Any] = self._actor_system.proxy_ask(addr, Akgent)
-                proxy.init_state(state_map[agent_name].state)
+                proxy.init_state(snap.state)
 
         # 2e. Restore LLM context from persisted events
         for agent_name, addr in addrs.items():

--- a/src/akgentic/team/subscriber.py
+++ b/src/akgentic/team/subscriber.py
@@ -70,7 +70,8 @@ class PersistenceSubscriber(EventSubscriber):
         if isinstance(msg, StateChangedMessage) and msg.sender is not None:
             snapshot = AgentStateSnapshot(
                 team_id=self._team_id,
-                agent_id=msg.sender.name,
+                agent_id=str(msg.sender.agent_id),
+                name=msg.sender.name,
                 state=msg.state.serializable_copy(),
                 updated_at=now,
             )

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -234,13 +234,16 @@ def make_agent_state_snapshot(
     team_id: uuid.UUID | None = None,
     agent_id: str = "test-agent",
     state: BaseState | None = None,
+    name: str | None = None,
 ) -> AgentStateSnapshot:
     """Create an AgentStateSnapshot with sensible defaults for testing.
 
     Args:
         team_id: Optional team identifier.
-        agent_id: Agent identifier.
+        agent_id: Agent identifier (UUID string in current snapshots).
         state: Optional BaseState subclass instance.
+        name: Optional agent display name (default None keeps existing callers
+            working and mimics legacy snapshots).
 
     Returns:
         An AgentStateSnapshot with the specified or default configuration.
@@ -248,6 +251,7 @@ def make_agent_state_snapshot(
     return AgentStateSnapshot(
         team_id=team_id or uuid.uuid4(),
         agent_id=agent_id,
+        name=name,
         state=state or SampleAgentState(task_count=5),
         updated_at=datetime.now(UTC),
     )

--- a/tests/repositories/test_event_store_contract.py
+++ b/tests/repositories/test_event_store_contract.py
@@ -193,6 +193,24 @@ class TestEventStoreContract:
         assert loaded[0].agent_id == "round-trip-agent"
         assert isinstance(loaded[0].state, SampleAgentState)
 
+    def test_save_and_load_agent_state_uuid_and_name_round_trip(
+        self, event_store: EventStore
+    ) -> None:
+        """AC #5: a UUID ``agent_id`` and a non-None ``name`` survive the round-trip.
+
+        Runs once per backend (yaml/mongo/postgres) via the parametrized
+        ``event_store`` fixture -- the per-backend round-trip coverage.
+        """
+        agent_uuid = str(uuid.uuid4())
+        snap = make_agent_state_snapshot(agent_id=agent_uuid, name="@SomeAgent")
+        event_store.save_agent_state(snap)
+
+        loaded = event_store.load_agent_states(snap.team_id)
+        assert len(loaded) == 1
+        assert loaded[0].agent_id == agent_uuid
+        assert loaded[0].name == "@SomeAgent"
+        assert isinstance(loaded[0].state, SampleAgentState)
+
     def test_save_agent_state_is_upsert(self, event_store: EventStore) -> None:
         """``save_agent_state`` is upsert on ``(team_id, agent_id)``."""
         team_id = uuid.uuid4()

--- a/tests/services/test_restorer.py
+++ b/tests/services/test_restorer.py
@@ -21,6 +21,7 @@ from akgentic.core.messages.orchestrator import (
     EventMessage,
     SentMessage,
     StartMessage,
+    StateChangedMessage,
     StopMessage,
 )
 from akgentic.core.orchestrator import EventSubscriber, Orchestrator
@@ -1924,3 +1925,238 @@ class TestRestorerToolActorSpawnOrder:
         team = runtime.orchestrator_proxy.get_team()
         agent_ids = [addr.agent_id for addr in team]
         assert len(agent_ids) == len(set(agent_ids)), "Duplicate agents in roster"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Re-emit agent state onto the event stream on restore (Story 23-3)
+# ---------------------------------------------------------------------------
+
+
+class TestRestorerReemitStateOnRestore:
+    """AC #1-#6: Phase 3 re-emits each restored agent's state after its StartMessage.
+
+    Uses a ``RecordingSubscriber`` as the stand-in for the live event stream:
+    it is the subscriber attached at phase 2g, so it observes exactly the
+    messages a fresh team's stream would. ``notify_state_change`` is an ask-mode
+    proxy call, so the agent's ``StateChangedMessage`` is enqueued on the
+    orchestrator mailbox before the next replayed event -- ordering is
+    deterministic.
+    """
+
+    def test_state_reaches_restored_stream_after_start_message(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC #1, #5: a snapshot's state is re-emitted right after its StartMessage.
+
+        The restored stream carries exactly one ``StateChangedMessage`` for the
+        agent-with-snapshot, positioned after that agent's ``StartMessage`` and
+        carrying the snapshot state -- the parity a fresh team's live stream has.
+        """
+        from akgentic.team.models import AgentStateSnapshot
+
+        tc = _make_team_card()
+        team_id, process = _populate_stopped_team(event_store, tc)
+        lead_agent_id = _lead_agent_id_from_events(event_store, team_id)
+
+        snapshot = AgentStateSnapshot(
+            team_id=team_id,
+            agent_id=str(lead_agent_id),
+            name="lead",
+            state=_MarkerState(marker="restored"),
+            updated_at=datetime.now(UTC),
+        )
+        event_store.save_agent_state(snapshot)
+
+        recording = RecordingSubscriber()
+        restorer = TeamRestorer(actor_system, event_store)
+        restorer.restore(process, subscribers=[recording])
+
+        state_msgs = [m for m in recording.messages if isinstance(m, StateChangedMessage)]
+        # Exactly one re-emit for the single agent-with-snapshot (AC #5).
+        assert len(state_msgs) == 1
+        applied = state_msgs[0].state
+        assert isinstance(applied, _MarkerState)
+        assert applied.marker == "restored"
+
+        # Positioned after the lead's StartMessage in the replay order (AC #1).
+        lead_start_idx = next(
+            i
+            for i, m in enumerate(recording.messages)
+            if isinstance(m, StartMessage) and m.sender is not None and m.sender.name == "lead"
+        )
+        state_idx = recording.messages.index(state_msgs[0])
+        assert state_idx > lead_start_idx
+
+    def test_reemitted_state_message_is_keyed_by_uuid(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC #2: the re-emitted StateChangedMessage's sender.agent_id is the UUID."""
+        from akgentic.team.models import AgentStateSnapshot
+
+        tc = _make_team_card()
+        team_id, process = _populate_stopped_team(event_store, tc)
+        lead_agent_id = _lead_agent_id_from_events(event_store, team_id)
+
+        snapshot = AgentStateSnapshot(
+            team_id=team_id,
+            agent_id=str(lead_agent_id),
+            name="lead",
+            state=BaseState(),
+            updated_at=datetime.now(UTC),
+        )
+        event_store.save_agent_state(snapshot)
+
+        recording = RecordingSubscriber()
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime = restorer.restore(process, subscribers=[recording])
+
+        state_msgs = [m for m in recording.messages if isinstance(m, StateChangedMessage)]
+        assert len(state_msgs) == 1
+        sender = state_msgs[0].sender
+        assert sender is not None
+        # Emitted via the live agent -> sender carries the agent UUID, matching
+        # the live lead address (so a UUID-keyed consumer folds it correctly).
+        assert sender.agent_id == lead_agent_id
+        assert sender.agent_id == runtime.addrs["lead"].agent_id
+
+    def test_legacy_name_keyed_snapshot_is_reemitted_via_name_fallback(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC #3: a legacy (name-keyed) snapshot is also re-emitted via name fallback.
+
+        The UUID lookup misses, but the stored ``agent_id`` ("lead") matches the
+        live agent's name, so the snapshot state still reaches the stream.
+        """
+        from akgentic.team.models import AgentStateSnapshot
+
+        tc = _make_team_card()
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        legacy_snapshot = AgentStateSnapshot(
+            team_id=team_id,
+            agent_id="lead",  # OLD shape: agent_id holds the name
+            state=_MarkerState(marker="legacy"),
+            updated_at=datetime.now(UTC),
+        )
+        event_store.save_agent_state(legacy_snapshot)
+
+        recording = RecordingSubscriber()
+        restorer = TeamRestorer(actor_system, event_store)
+        restorer.restore(process, subscribers=[recording])
+
+        state_msgs = [m for m in recording.messages if isinstance(m, StateChangedMessage)]
+        assert len(state_msgs) == 1
+        applied = state_msgs[0].state
+        assert isinstance(applied, _MarkerState)
+        assert applied.marker == "legacy"
+
+    def test_no_reemit_for_sender_without_snapshot(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC #3, #5: senders without a snapshot (orchestrator, plain agents) no-op.
+
+        With no snapshots persisted at all, restore replays every StartMessage
+        (orchestrator + lead) but emits zero StateChangedMessages and does not
+        raise.
+        """
+        tc = _make_team_card()
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        recording = RecordingSubscriber()
+        restorer = TeamRestorer(actor_system, event_store)
+        runtime = restorer.restore(process, subscribers=[recording])
+
+        state_msgs = [m for m in recording.messages if isinstance(m, StateChangedMessage)]
+        assert state_msgs == []
+        assert runtime.addrs["lead"].is_alive()
+
+    def test_one_reemit_per_agent_with_snapshot(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC #5: exactly one StateChangedMessage per agent-with-snapshot.
+
+        Two agents have snapshots and one (the orchestrator) does not; the
+        stream carries exactly two re-emits, one per snapshotted agent.
+        """
+        from akgentic.team.models import AgentStateSnapshot
+
+        worker = _make_member("worker", "Worker")
+        tc = _make_team_card(members=[worker])
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        lead_id = _lead_agent_id_from_events(event_store, team_id, name="lead")
+        worker_id = _lead_agent_id_from_events(event_store, team_id, name="worker")
+
+        for agent_id, name in ((lead_id, "lead"), (worker_id, "worker")):
+            event_store.save_agent_state(
+                AgentStateSnapshot(
+                    team_id=team_id,
+                    agent_id=str(agent_id),
+                    name=name,
+                    state=BaseState(),
+                    updated_at=datetime.now(UTC),
+                )
+            )
+
+        recording = RecordingSubscriber()
+        restorer = TeamRestorer(actor_system, event_store)
+        restorer.restore(process, subscribers=[recording])
+
+        state_msgs = [m for m in recording.messages if isinstance(m, StateChangedMessage)]
+        emitted_ids = {m.sender.agent_id for m in state_msgs if m.sender is not None}
+        assert len(state_msgs) == 2
+        assert emitted_ids == {lead_id, worker_id}
+
+    def test_reemit_does_not_repersist_events_or_states(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC #4: load_events and load_agent_states are unchanged across a restore.
+
+        Phase 3 runs with PersistenceSubscriber.set_restoring(True), so the
+        re-emitted StateChangedMessage is neither appended to the event log nor
+        written to the snapshot store -- the ADR-013 invariant holds.
+        """
+        from akgentic.team.models import AgentStateSnapshot
+        from akgentic.team.subscriber import PersistenceSubscriber
+
+        tc = _make_team_card()
+        team_id, process = _populate_stopped_team(event_store, tc)
+        lead_agent_id = _lead_agent_id_from_events(event_store, team_id)
+
+        snapshot = AgentStateSnapshot(
+            team_id=team_id,
+            agent_id=str(lead_agent_id),
+            name="lead",
+            state=BaseState(),
+            updated_at=datetime.now(UTC),
+        )
+        event_store.save_agent_state(snapshot)
+
+        events_before = [pe.model_dump() for pe in event_store.load_events(team_id)]
+        states_before = [s.model_dump() for s in event_store.load_agent_states(team_id)]
+
+        persistence_sub = PersistenceSubscriber(team_id, event_store)
+        persistence_sub.set_restoring(team_id, True)
+
+        restorer = TeamRestorer(actor_system, event_store)
+        restorer.restore(process, subscribers=[persistence_sub])
+
+        persistence_sub.set_restoring(team_id, False)
+
+        events_after = [pe.model_dump() for pe in event_store.load_events(team_id)]
+        states_after = [s.model_dump() for s in event_store.load_agent_states(team_id)]
+
+        assert events_after == events_before, "Re-emit must not append to the event log"
+        assert states_after == states_before, "Re-emit must not write the snapshot store"

--- a/tests/services/test_restorer.py
+++ b/tests/services/test_restorer.py
@@ -24,6 +24,7 @@ from akgentic.core.messages.orchestrator import (
     StopMessage,
 )
 from akgentic.core.orchestrator import EventSubscriber, Orchestrator
+
 from akgentic.team.models import (
     PersistedEvent,
     Process,
@@ -33,7 +34,6 @@ from akgentic.team.models import (
     TeamStatus,
 )
 from akgentic.team.restorer import GRACE_TIMEOUT_SECONDS, TeamRestorer
-
 from tests.services.conftest import InMemoryEventStore
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_restorer.py
+++ b/tests/services/test_restorer.py
@@ -524,9 +524,10 @@ class TestTeamRestorerRestore:
             proxy = original_proxy_ask(addr, cls)
             if cls is Akgent:
                 original_init = proxy.init_state
+                addr_name = addr.name
 
-                def tracked_init(state: Any) -> None:
-                    init_state_calls.append("lead")
+                def tracked_init(state: Any, _name: str = addr_name) -> None:
+                    init_state_calls.append(_name)
                     return original_init(state)
 
                 proxy.init_state = tracked_init
@@ -535,7 +536,8 @@ class TestTeamRestorerRestore:
         with mock_patch.object(actor_system, "proxy_ask", side_effect=tracking_proxy_ask):
             runtime = restorer.restore(process)
 
-        # Verify init_state was called for the agent with snapshot
+        # Verify init_state was applied to the lead agent's own address (matched
+        # by UUID), not merely that some agent received state.
         assert "lead" in init_state_calls
         assert runtime.addrs["lead"].is_alive()
 
@@ -573,6 +575,15 @@ class TestTeamRestorerRestore:
         assert loaded[0].agent_id == "lead"
         assert loaded[0].name is None
 
+        # (a') A serialized payload that literally OMITS the ``name`` key (the true
+        # on-disk legacy shape) validates cleanly with name=None -- this is the
+        # deserialization boundary the no-migration design rests on.
+        legacy_payload = legacy_snapshot.model_dump()
+        legacy_payload.pop("name", None)
+        revalidated = AgentStateSnapshot.model_validate(legacy_payload)
+        assert revalidated.name is None
+        assert revalidated.agent_id == "lead"
+
         restorer = TeamRestorer(actor_system, event_store)
 
         # Spy init_state to prove the legacy snapshot is NOT applied on restore.
@@ -583,9 +594,10 @@ class TestTeamRestorerRestore:
             proxy = original_proxy_ask(addr, cls)
             if cls is Akgent:
                 original_init = proxy.init_state
+                addr_name = addr.name
 
-                def tracked_init(state: Any) -> None:
-                    init_state_calls.append(addr.name)
+                def tracked_init(state: Any, _name: str = addr_name) -> None:
+                    init_state_calls.append(_name)
                     return original_init(state)
 
                 proxy.init_state = tracked_init

--- a/tests/services/test_restorer.py
+++ b/tests/services/test_restorer.py
@@ -24,7 +24,6 @@ from akgentic.core.messages.orchestrator import (
     StopMessage,
 )
 from akgentic.core.orchestrator import EventSubscriber, Orchestrator
-
 from akgentic.team.models import (
     PersistedEvent,
     Process,
@@ -34,6 +33,7 @@ from akgentic.team.models import (
     TeamStatus,
 )
 from akgentic.team.restorer import GRACE_TIMEOUT_SECONDS, TeamRestorer
+
 from tests.services.conftest import InMemoryEventStore
 
 # ---------------------------------------------------------------------------
@@ -45,6 +45,16 @@ class StubAgent(Akgent[BaseConfig, BaseState]):
     """Minimal agent for restorer tests."""
 
     pass
+
+
+class _MarkerState(BaseState):
+    """BaseState carrying a distinguishing marker for snapshot-preference tests.
+
+    Used to tell two competing snapshots (UUID-keyed vs name-keyed legacy) apart
+    by the value the restorer applies via ``init_state``.
+    """
+
+    marker: str = ""
 
 
 class RecordingSubscriber(EventSubscriber):
@@ -541,17 +551,18 @@ class TestTeamRestorerRestore:
         assert "lead" in init_state_calls
         assert runtime.addrs["lead"].is_alive()
 
-    def test_restore_with_legacy_name_keyed_snapshot_loads_and_is_skipped(
+    def test_restore_with_legacy_name_keyed_snapshot_loads_and_is_restored_via_name_fallback(
         self,
         actor_system: ActorSystem,
         event_store: InMemoryEventStore,
     ) -> None:
-        """AC #4: a legacy name-keyed snapshot loads (name=None) and is skipped.
+        """AC #2/#6: a legacy name-keyed snapshot loads (name=None) and is restored.
 
-        Migration-safety: a snapshot persisted in the OLD shape -- ``agent_id``
-        holding the agent **name** and no ``name`` key -- (a) loads via
-        ``load_agent_states`` with ``name is None`` and (b) is NOT applied on
-        restore (its name never equals ``str(addr.agent_id)``), without raising.
+        Migration-safety + name fallback: a snapshot persisted in the OLD shape --
+        ``agent_id`` holding the agent **name** and no ``name`` key -- (a) loads via
+        ``load_agent_states`` with ``name is None`` and (b) is now APPLIED on restore
+        via the name fallback (its stored ``agent_id`` equals the live agent's name),
+        without raising. This is the direct inverse of Story 23-1's "legacy skipped".
         """
         from unittest.mock import patch as mock_patch
 
@@ -586,7 +597,7 @@ class TestTeamRestorerRestore:
 
         restorer = TeamRestorer(actor_system, event_store)
 
-        # Spy init_state to prove the legacy snapshot is NOT applied on restore.
+        # Spy init_state to prove the legacy snapshot IS applied on restore.
         init_state_calls: list[str] = []
         original_proxy_ask = actor_system.proxy_ask
 
@@ -606,7 +617,130 @@ class TestTeamRestorerRestore:
         with mock_patch.object(actor_system, "proxy_ask", side_effect=tracking_proxy_ask):
             runtime = restorer.restore(process)
 
-        # (b) Not applied on restore -- the name never equals a live address UUID.
+        # (b) Applied on restore via the name fallback -- the UUID lookup misses, but
+        # the stored agent_id ("lead") matches the live agent's name.
+        assert init_state_calls == ["lead"]
+        assert runtime.addrs["lead"].is_alive()
+
+    def test_restore_prefers_uuid_keyed_over_same_name_legacy_snapshot(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC #3: UUID-keyed snapshot wins over a same-name legacy snapshot.
+
+        Both a UUID-keyed snapshot (agent_id=str(lead UUID)) and a name-keyed legacy
+        snapshot (agent_id="lead") exist for the SAME live lead agent, carrying
+        distinguishable states. The restorer tries the UUID lookup first, so the
+        UUID-keyed snapshot's state is the one applied -- the legacy one is shadowed.
+        """
+        from unittest.mock import patch as mock_patch
+
+        from akgentic.team.models import AgentStateSnapshot
+
+        tc = _make_team_card()
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        lead_agent_id = _lead_agent_id_from_events(event_store, team_id)
+
+        # UUID-keyed (current) snapshot -- this one must win.
+        uuid_snapshot = AgentStateSnapshot(
+            team_id=team_id,
+            agent_id=str(lead_agent_id),
+            name="lead",
+            state=_MarkerState(marker="uuid"),
+            updated_at=datetime.now(UTC),
+        )
+        # Name-keyed legacy snapshot -- same live agent, must be shadowed.
+        legacy_snapshot = AgentStateSnapshot(
+            team_id=team_id,
+            agent_id="lead",
+            state=_MarkerState(marker="legacy"),
+            updated_at=datetime.now(UTC),
+        )
+        # Different agent_id keys -> both coexist in load_agent_states.
+        event_store.save_agent_state(uuid_snapshot)
+        event_store.save_agent_state(legacy_snapshot)
+
+        restorer = TeamRestorer(actor_system, event_store)
+
+        # Spy init_state capturing BOTH the agent name and the applied state, so we
+        # can assert WHICH snapshot's state won.
+        init_state_records: list[tuple[str, Any]] = []
+        original_proxy_ask = actor_system.proxy_ask
+
+        def tracking_proxy_ask(addr: ActorAddress, cls: type[Any]) -> Any:
+            proxy = original_proxy_ask(addr, cls)
+            if cls is Akgent:
+                original_init = proxy.init_state
+                addr_name = addr.name
+
+                def tracked_init(state: Any, _name: str = addr_name) -> None:
+                    init_state_records.append((_name, state))
+                    return original_init(state)
+
+                proxy.init_state = tracked_init
+            return proxy
+
+        with mock_patch.object(actor_system, "proxy_ask", side_effect=tracking_proxy_ask):
+            runtime = restorer.restore(process)
+
+        # Exactly one init_state for the lead agent, carrying the UUID-keyed state.
+        lead_records = [(name, st) for name, st in init_state_records if name == "lead"]
+        assert len(lead_records) == 1
+        applied_state = lead_records[0][1]
+        assert isinstance(applied_state, _MarkerState)
+        assert applied_state.marker == "uuid"
+        assert runtime.addrs["lead"].is_alive()
+
+    def test_restore_legacy_snapshot_no_false_match(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC #4: a legacy snapshot whose name matches no live agent is a no-op.
+
+        A name-keyed snapshot (agent_id="ghost") matches neither a live UUID nor a
+        live agent name, so no agent receives init_state and restore does not raise;
+        the live agents stay alive.
+        """
+        from unittest.mock import patch as mock_patch
+
+        from akgentic.team.models import AgentStateSnapshot
+
+        tc = _make_team_card()
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        ghost_snapshot = AgentStateSnapshot(
+            team_id=team_id,
+            agent_id="ghost",
+            state=BaseState(),
+            updated_at=datetime.now(UTC),
+        )
+        event_store.save_agent_state(ghost_snapshot)
+
+        restorer = TeamRestorer(actor_system, event_store)
+
+        init_state_calls: list[str] = []
+        original_proxy_ask = actor_system.proxy_ask
+
+        def tracking_proxy_ask(addr: ActorAddress, cls: type[Any]) -> Any:
+            proxy = original_proxy_ask(addr, cls)
+            if cls is Akgent:
+                original_init = proxy.init_state
+                addr_name = addr.name
+
+                def tracked_init(state: Any, _name: str = addr_name) -> None:
+                    init_state_calls.append(_name)
+                    return original_init(state)
+
+                proxy.init_state = tracked_init
+            return proxy
+
+        with mock_patch.object(actor_system, "proxy_ask", side_effect=tracking_proxy_ask):
+            runtime = restorer.restore(process)
+
+        # No agent matched -> no init_state applied, restore did not raise.
         assert init_state_calls == []
         assert runtime.addrs["lead"].is_alive()
 

--- a/tests/services/test_restorer.py
+++ b/tests/services/test_restorer.py
@@ -317,6 +317,27 @@ def _populate_stopped_team(
     return team_id, process
 
 
+def _lead_agent_id_from_events(
+    event_store: InMemoryEventStore,
+    team_id: uuid.UUID,
+    name: str = "lead",
+) -> uuid.UUID:
+    """Read an agent's persisted UUID from its ``StartMessage`` sender.
+
+    Used to key UUID-based ``AgentStateSnapshot`` fixtures by the same UUID the
+    restorer re-injects when re-spawning the agent.
+    """
+    for pe in event_store.load_events(team_id):
+        if (
+            isinstance(pe.event, StartMessage)
+            and pe.event.sender is not None
+            and pe.event.sender.name == name
+        ):
+            return pe.event.sender.agent_id
+    msg = f"{name} agent_id not found in events"
+    raise AssertionError(msg)
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -463,7 +484,12 @@ class TestTeamRestorerRestore:
         actor_system: ActorSystem,
         event_store: InMemoryEventStore,
     ) -> None:
-        """AC 11: Persisted AgentStateSnapshot is restored via init_state()."""
+        """AC #3: a UUID-keyed AgentStateSnapshot is restored via init_state().
+
+        The snapshot is keyed by the lead agent's actual UUID (read from its
+        persisted ``StartMessage`` sender), and the restorer matches it against
+        the live address UUID -- no name fallback.
+        """
         from unittest.mock import patch as mock_patch
 
         from akgentic.team.models import AgentStateSnapshot
@@ -471,10 +497,15 @@ class TestTeamRestorerRestore:
         tc = _make_team_card()
         team_id, process = _populate_stopped_team(event_store, tc)
 
-        # Inject a state snapshot for the "lead" agent
+        # The restorer now matches by str(addr.agent_id), so the snapshot MUST be
+        # keyed by the lead agent's real UUID -- read it from its StartMessage.
+        lead_agent_id = _lead_agent_id_from_events(event_store, team_id)
+
+        # Inject a state snapshot for the "lead" agent, keyed by UUID.
         snapshot = AgentStateSnapshot(
             team_id=team_id,
-            agent_id="lead",
+            agent_id=str(lead_agent_id),
+            name="lead",
             state=BaseState(),
             updated_at=datetime.now(UTC),
         )
@@ -506,6 +537,65 @@ class TestTeamRestorerRestore:
 
         # Verify init_state was called for the agent with snapshot
         assert "lead" in init_state_calls
+        assert runtime.addrs["lead"].is_alive()
+
+    def test_restore_with_legacy_name_keyed_snapshot_loads_and_is_skipped(
+        self,
+        actor_system: ActorSystem,
+        event_store: InMemoryEventStore,
+    ) -> None:
+        """AC #4: a legacy name-keyed snapshot loads (name=None) and is skipped.
+
+        Migration-safety: a snapshot persisted in the OLD shape -- ``agent_id``
+        holding the agent **name** and no ``name`` key -- (a) loads via
+        ``load_agent_states`` with ``name is None`` and (b) is NOT applied on
+        restore (its name never equals ``str(addr.agent_id)``), without raising.
+        """
+        from unittest.mock import patch as mock_patch
+
+        from akgentic.team.models import AgentStateSnapshot
+
+        tc = _make_team_card()
+        team_id, process = _populate_stopped_team(event_store, tc)
+
+        # OLD shape: agent_id holds the name, no name field (default None applies).
+        legacy_snapshot = AgentStateSnapshot(
+            team_id=team_id,
+            agent_id="lead",
+            state=BaseState(),
+            updated_at=datetime.now(UTC),
+        )
+        event_store.save_agent_state(legacy_snapshot)
+
+        # (a) The legacy snapshot loads with name=None and raises no error.
+        loaded = event_store.load_agent_states(team_id)
+        assert len(loaded) == 1
+        assert loaded[0].agent_id == "lead"
+        assert loaded[0].name is None
+
+        restorer = TeamRestorer(actor_system, event_store)
+
+        # Spy init_state to prove the legacy snapshot is NOT applied on restore.
+        init_state_calls: list[str] = []
+        original_proxy_ask = actor_system.proxy_ask
+
+        def tracking_proxy_ask(addr: ActorAddress, cls: type[Any]) -> Any:
+            proxy = original_proxy_ask(addr, cls)
+            if cls is Akgent:
+                original_init = proxy.init_state
+
+                def tracked_init(state: Any) -> None:
+                    init_state_calls.append(addr.name)
+                    return original_init(state)
+
+                proxy.init_state = tracked_init
+            return proxy
+
+        with mock_patch.object(actor_system, "proxy_ask", side_effect=tracking_proxy_ask):
+            runtime = restorer.restore(process)
+
+        # (b) Not applied on restore -- the name never equals a live address UUID.
+        assert init_state_calls == []
         assert runtime.addrs["lead"].is_alive()
 
     def test_restore_agent_profiles_registered(

--- a/tests/services/test_subscriber.py
+++ b/tests/services/test_subscriber.py
@@ -62,14 +62,17 @@ class TestPersistenceSubscriber:
     # -- 3.4: Agent state snapshot on StateChangedMessage ------------------
 
     def test_state_snapshot_on_state_changed_message(self) -> None:
-        """AC 1-3: StateChangedMessage writes snapshot only.
+        """AC #2: StateChangedMessage writes snapshot with UUID agent_id + name only.
 
-        No ``PersistedEvent``, no sequence bump.
+        No ``PersistedEvent``, no sequence bump. The persisted ``agent_id`` is the
+        sender UUID in string form (``str(sender.agent_id)``), and ``name`` is the
+        sender display name.
         """
         sub, store, team_id = self._make_subscriber()
 
         sender = MagicMock(spec=ActorAddress)
         sender.name = "worker-agent"
+        sender.agent_id = uuid.uuid4()
         state = SampleAgentState(task_count=5)
         msg = StateChangedMessage(sender=sender, state=state)
 
@@ -81,13 +84,14 @@ class TestPersistenceSubscriber:
         # Sequence not advanced (AC 3: gap-free numbering over behavioral events)
         assert sub._sequence == 0  # noqa: SLF001
 
-        # Agent state snapshot saved (AC 2: snapshot still written)
-        key = (team_id, "worker-agent")
+        # Agent state snapshot saved, keyed by UUID-string agent_id (AC #2)
+        key = (team_id, str(sender.agent_id))
         assert key in store.agent_states
         snapshot = store.agent_states[key]
         assert isinstance(snapshot, AgentStateSnapshot)
         assert snapshot.team_id == team_id
-        assert snapshot.agent_id == "worker-agent"
+        assert snapshot.agent_id == str(sender.agent_id)
+        assert snapshot.name == sender.name
         assert snapshot.updated_at is not None
         assert isinstance(snapshot.state, SampleAgentState)
         assert snapshot.state.task_count == 5
@@ -98,6 +102,7 @@ class TestPersistenceSubscriber:
 
         sender = MagicMock(spec=ActorAddress)
         sender.name = "agent-a"
+        sender.agent_id = uuid.uuid4()
 
         sub.on_message(UserMessage(content="first"))  # seq 1
         sub.on_message(StateChangedMessage(sender=sender, state=SampleAgentState(task_count=1)))


### PR DESCRIPTION
## Epic 23 — `AgentStateSnapshot` keyed by agent UUID + name (ADR-020 root fix) + restore stream-parity

Moves the ADR-020 keying fix to the **source**: `PersistenceSubscriber` now persists
the agent **UUID** in `AgentStateSnapshot.agent_id` (`str(uuid)`) plus the display
**name** in a new optional `name` field, and the restorer re-keys its state-restore
match by `str(addr.agent_id)` with a **name fallback** for legacy snapshots. UUID-keyed
consumers (the `akgentic-infra` read endpoint, the frontend's UUID-keyed `state` store)
get the identifier they expect with no reader-side name→UUID resolution. The change is
**backward-compatible by typing** — `agent_id` stays `str`, `name` is `str | None = None`
— so legacy snapshots still load (`name → None`) with no migration and no backend edits,
and are now restored deterministically on every restore via the name fallback.

23-3 then closes the **stream** asymmetry ADR-014 left open for state: during restore
Phase 3, each restored agent's `StateChangedMessage` is re-emitted onto the event stream
right after its `StartMessage` is replayed (reusing the existing public
`Akgent.notify_state_change`), so a restored team's WS stream carries agent state exactly
like a fresh team — no side fetch required for stream-only consumers. No re-persistence,
no `akgentic-core` change.

### Stories

- [x] `23-1-snapshot-store-agent-uuid-and-name` — store agent UUID + name in
  `AgentStateSnapshot`; restore matches by UUID (Relates to #130)
- [x] `23-2-restore-name-fallback-legacy-snapshots` — restore fallback for legacy
  name-keyed snapshots (Relates to #132)
- [x] `23-3-restore-stream-parity-reemit-state-on-restore` — re-emit agent state onto the
  event stream on restore (Relates to #133)

## Review status

| Story | Reviewer | Verdict | Findings |
|-------|----------|---------|----------|
| 23-1-snapshot-store-agent-uuid-and-name | Rex (dev-reviewer) | ✅ Approved → done | 2 LOW (test-quality), both fixed in fixup `4aa3378` |
| 23-2-restore-name-fallback-legacy-snapshots | Rex (dev-reviewer) | ✅ Approved → done | 1 MEDIUM (hygiene), fixed in fixup `b9e90b3` |
| 23-3-restore-stream-parity-reemit-state-on-restore | Rex (dev-reviewer) | ✅ Approved → done | None — clean, no fixup needed |

- 23-2 review: PASS with one fix — the dev commit (`24002e5`) claimed `ruff check`
  clean (AC #7) but left `tests/services/test_restorer.py` failing `I001` (the
  `akgentic.core.*` third-party group and the `akgentic.team.*` + `tests.*` first-party
  group were mis-separated). Fixed in `b9e90b3` by applying ruff's canonical isort
  grouping (import-grouping only, no behavioral change; all 36 restorer tests still
  pass). The "2d" name-fallback (`state_map.get(str(addr.agent_id)) or
  state_map.get(agent_name)`, UUID preferred via `or` short-circuit) and the three
  tests (legacy-restored, UUID-preferred-over-same-name-legacy, no-false-match) match
  ACs #1–#6 exactly; the "2e" LLM-context block is untouched (AC #5).

- 23-3 review: PASS — no fix-worthy issues, no fixup commit. The `caffc09` diff
  (`restorer.py` +47, `test_restorer.py` +236) is minimal and self-contained. `state_map`
  is threaded out of phase 2d via the new `_RebuildResult.state_map` field (the **same**
  map used for hydration, not duplicated) and re-emitted in Phase 3 by a new `_reemit_state`
  helper, whose UUID-preferred/name-fallback lookup
  (`state_map.get(str(sender.agent_id)) or state_map.get(sender.name)`) mirrors phase 2d
  byte-for-byte. All 8 ACs verified: stream parity + ordering (re-emit after
  `restore_message`, subscribers attached at 2g); UUID keying (emitted via the live
  agent); legacy name fallback; no-snapshot no-op for the orchestrator `StartMessage`;
  one re-emit per agent-with-snapshot; and **no re-persistence** —
  `Orchestrator.receiveMsg_StateChangedMessage` fans out without appending to the event
  log (verified at the source), plus the `restoring=True` guard, with a test asserting
  byte-identical `load_events`/`load_agent_states` across a restore. The three `## GPI-`
  scratch comments and the undefined-`state` sketch are gone. No `akgentic-core` change.
  Golden Rule #8 clean (only `ADR-020` docstring/comment refs, no ADR-string assertions).

**Design invariants verified (23-2):** "2d" prefers the UUID (short-circuit `or`),
name lookup only catches legacy (name-keyed) snapshots; legacy snapshot is now
**restored** (`init_state_calls == ["lead"]`), the inverse of 23-1's "skipped";
UUID-keyed wins when both exist for a name (`marker == "uuid"`); a legacy name matching
no live agent is a no-op with no raise; the "2e" block is byte-for-byte unchanged.
Self-contained in `akgentic-team` (restorer.py + test_restorer.py only); no ADR-string
test assertions (Golden Rule #8 clean).

**Design invariants verified (23-3):** re-emit lives in Phase 3 after subscribers are
attached (2g), so unlike the two dropped construction-time emits it actually reaches the
stream; `notify_state_change` stamps the agent's own UUID as sender (AC #2 UUID keying)
and serializes the state; the orchestrator handler fans out **without** appending to
`self.messages` (contrast `receiveMsg_EventMessage`/`restore_message`, which do), so the
durable log is untouched; deterministic ordering holds because `notify_state_change` is
an ask-mode proxy call. Self-contained in `akgentic-team` (restorer.py + test_restorer.py
only); reuses `Akgent.notify_state_change` via the public `proxy_ask`/`Akgent` proxy (no
actor-internals casting); no `akgentic-core` change (Golden Rule #4 clean).

**Findings fixed in 23-1 (both LOW, test-only):**
1. Added a deserialization assertion that a payload literally omitting `name`
   validates with `name=None` (the no-migration design's true boundary — previously
   only reasoned about).
2. The restorer positive test's `init_state` spy now records the actual address
   name so it proves the lead's own UUID-matched address received state.

## Scope guard

All changes — `1bcddf3`/`4aa3378` (23-1), `24002e5`/`b9e90b3` (23-2), and `caffc09`
(23-3) — stay inside `packages/akgentic-team/`. No file outside this submodule is
modified (Golden Rule #4). `msg.sender.agent_id`, `msg.sender.name`, `addr.agent_id`,
and `addr.name` come from `akgentic-core` and are read-only here; `Akgent.notify_state_change`
is consumed as an existing public API — no core change.

## Verification

- `ruff check src/`: clean on all changed files.
- `mypy --strict src/`: Success, no issues (20 source files).
- `pytest tests/ -m 'not integration'`: **359 passed, 5 skipped**; the new
  `TestRestorerReemitStateOnRestore` (6 tests) is green. Coverage **95.38%** (floor 80%),
  `restorer.py` at 94% (the new `_reemit_state` helper + call site fully covered; the
  uncovered lines are pre-existing defensive branches). The `[postgres]` parametrizations
  require a Docker daemon (unavailable in the local dev environment) and run in remote CI.

## Epic 23 slice complete

All three stories of Epic 23 are landed and reviewed → **epic done**:

- `23-1` — `PersistenceSubscriber` persists `AgentStateSnapshot.agent_id = str(sender.agent_id)`
  (the UUID) plus a new optional `name`; the restorer matches by `str(addr.agent_id)`.
- `23-2` — the restorer's "2d" block adds a **name fallback**
  (`state_map.get(str(addr.agent_id)) or state_map.get(agent_name)`) so legacy
  (pre-Epic-23) name-keyed snapshots restore deterministically on every restore, instead
  of relying on 23-1's not-guaranteed "self-heal on next state change". UUID stays
  preferred.
- `23-3` — restore Phase 3 **re-emits** each restored agent's `StateChangedMessage` onto
  the event stream right after its `StartMessage` (reusing `Akgent.notify_state_change`,
  UUID-keyed, name-fallback lookup mirroring 2d), so a restored team's WS stream carries
  agent state exactly like a fresh team. The orchestrator fans it out without appending to
  the event log and Phase 3 runs in `restoring=True`, so nothing is re-persisted — the
  ADR-013 invariant holds.

The snapshot is now UUID-keyed at the source with a display name carried alongside, legacy
snapshots remain loadable **and restorable** without a migration, and a restored team's
event stream now reaches **parity** with a fresh team's for agent state — closing the
last ADR-020 asymmetry for stream-only consumers. Downstream follow-ups (the
`akgentic-infra` read endpoint and its `AgentStateResponse.name` re-add) live in their own
submodule and are out of scope.

Relates to #130
Relates to #132
Relates to #133
