### PR TITLE
feat(akgentic-team): memory-leak diagnostics (ObjectCensus, TeamMemoryProbe, MemorySampler)

### DIFF
--- a/src/akgentic/team/__init__.py
+++ b/src/akgentic/team/__init__.py
@@ -6,6 +6,12 @@ re-exported here via explicit __all__.
 
 from __future__ import annotations
 
+from akgentic.team.diagnostics import (
+    LeakReport,
+    ReferrerInfo,
+    RetainedType,
+    TeamMemoryProbe,
+)
 from akgentic.team.factory import TeamFactory
 from akgentic.team.manager import TeamManager
 from akgentic.team.messages import WelcomeMessage
@@ -25,6 +31,14 @@ from akgentic.team.ports import (
 )
 from akgentic.team.repositories import YamlEventStore
 from akgentic.team.restorer import TeamRestorer
+from akgentic.team.sampler import (
+    MemorySample,
+    MemorySampler,
+    MemoryTrend,
+    ObjectCensus,
+    TypeGrowth,
+    census_by_type,
+)
 from akgentic.team.subscriber import PersistenceSubscriber
 
 __version__ = "1.0.0-alpha.2"
@@ -33,11 +47,20 @@ __all__: list[str] = [
     "__version__",
     "AgentStateSnapshot",
     "EventStore",
+    "LeakReport",
+    "MemorySample",
+    "MemorySampler",
+    "MemoryTrend",
     "NullServiceRegistry",
+    "ObjectCensus",
     "PersistenceSubscriber",
     "PersistedEvent",
     "Process",
+    "ReferrerInfo",
+    "RetainedType",
     "ServiceRegistry",
+    "TeamMemoryProbe",
+    "TypeGrowth",
     "TeamCard",
     "TeamCardMember",
     "TeamFactory",
@@ -47,6 +70,7 @@ __all__: list[str] = [
     "TeamStatus",
     "WelcomeMessage",
     "YamlEventStore",
+    "census_by_type",
 ]
 
 _mongo_available = False

--- a/src/akgentic/team/diagnostics.py
+++ b/src/akgentic/team/diagnostics.py
@@ -1,0 +1,261 @@
+"""Memory-leak diagnostics for the team lifecycle.
+
+``TeamMemoryProbe`` answers one question across a create → stop → delete cycle:
+which framework objects are still resident after teardown, and who holds them?
+
+It works by weak-referencing every live "team object" at peak, then — after the
+caller has stopped the team and dropped its own handles — counting which
+weakrefs are still alive before and after ``gc.collect()`` and naming the
+referrers that pin any survivor. Imports stay core-only (the akgentic-team
+boundary); higher-layer suspects (ContextManager, ReactAgent, BaseAgent) are
+tracked by class name, not import.
+"""
+
+from __future__ import annotations
+
+import gc
+import weakref
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_state import BaseState
+from akgentic.team.models import TeamRuntime
+from akgentic.team.subscriber import PersistenceSubscriber, TimerStopSubscriber
+
+# Importable core/team bases whose instances are per-team framework objects.
+# ``EventSubscriber`` itself is a non-runtime-checkable Protocol, so we track the
+# concrete per-team subscribers by class instead. threading.Thread is excluded:
+# it would match every Pykka actor thread and the system listener, drowning real
+# leaks in runtime noise. Pass it in ``tracked_bases`` explicitly when chasing
+# the TimerStopSubscriber daemon thread on the inactivity-timer stop path.
+DEFAULT_TRACKED_BASES: tuple[type, ...] = (
+    Akgent,  # orchestrator + every agent + UserProxy/HumanProxy
+    BaseState,  # agent state (holds the agent<->state observer cycle)
+    TeamRuntime,  # holds actor_system + addresses + rebuilt proxies
+    PersistenceSubscriber,  # per-team event-store bridge
+    TimerStopSubscriber,  # holds TeamManager -> _runtimes -> every team
+)
+
+# Higher-layer suspects we may not import (boundary) — matched by class name.
+# NOTE: this curated set is only for the in-process TeamMemoryProbe. The Docker
+# A/B uses ObjectCensus, which censuses EVERY class (no list), so it is the
+# comprehensive tool — this list just mirrors what that census has surfaced so
+# the probe-based test can assert on the same leak classes.
+DEFAULT_TRACKED_NAMES: frozenset[str] = frozenset(
+    {
+        # llm / agent object graph
+        "ContextManager",  # llm: holds agent in its observer list
+        "ReactAgent",  # llm: holds ContextManager
+        "MockReactAgent",  # llm loadtest: same shape as ReactAgent
+        "BaseAgent",  # agent: holds ReactAgent
+        # core actor infrastructure (pykka) — leak #1 signature
+        "Timer",  # core: orchestrator inactivity timer (callback cycle)
+        "ActorRef",  # pykka actor reference
+        "ActorProxy",  # pykka proxy (carries AttrInfo)
+        "ProxyWrapper",  # pykka proxy wrapper
+        "ActorAddressImpl",  # core actor address
+        "AttrInfo",  # pykka per-proxy method introspection (amplifier)
+        # per-team async + state — leak #2 signature
+        "_UnixSelectorEventLoop",  # one asyncio loop per team, retained
+        "StructuredOutput",  # agent routing output, dragged along
+        "TaskState",  # planning state
+        "Request",  # routing request
+        # OpenTelemetry instruments pinned by the global MeterProvider — leak #2
+        "_ProxyHistogram",
+        "_ProxyMeter",
+        # dynamically-built pydantic model classes never freed — leak #2
+        "ModelMetaclass",
+        "SchemaValidator",
+        "SchemaSerializer",
+    }
+)
+
+
+class ReferrerInfo(BaseModel):
+    """One object that still references a leaked instance."""
+
+    referrer_type: str = Field(description="Class name of the referring object")
+    detail: str = Field(description="Trimmed repr of the referrer for identification")
+
+
+class RetainedType(BaseModel):
+    """A tracked type with surviving instances after teardown."""
+
+    type_name: str = Field(description="Class name of the surviving objects")
+    count: int = Field(description="Number of live instances after gc.collect()")
+    referrers: list[ReferrerInfo] = Field(
+        default_factory=list,
+        description="Sample of objects pinning the survivors (the leak holders)",
+    )
+
+
+class LeakReport(BaseModel):
+    """Outcome of one probe cycle: what survived teardown and who held it."""
+
+    label: str = Field(description="Caller-supplied label for this cycle")
+    total_tracked: int = Field(description="Tracked instances captured at peak")
+    alive_before_gc: int = Field(description="Survivors after teardown, before gc.collect()")
+    alive_after_gc: int = Field(description="Survivors after gc.collect()")
+    gc_collected: int = Field(description="Objects reclaimed by gc.collect()")
+    uncollectable: int = Field(description="len(gc.garbage) — objects gc could not free")
+    retained: list[RetainedType] = Field(
+        default_factory=list, description="Per-type breakdown of survivors with holders"
+    )
+
+    @property
+    def leaked(self) -> bool:
+        """True if any tracked instance survived teardown + gc.collect()."""
+        return self.alive_after_gc > 0
+
+    @property
+    def cycle_held(self) -> bool:
+        """True if survivors were freed only by the cyclic collector, not refcount."""
+        return self.alive_before_gc > self.alive_after_gc
+
+    def format(self) -> str:
+        """Render a human-readable summary for logs / test failure messages."""
+        head = (
+            f"[{self.label}] tracked={self.total_tracked} "
+            f"alive(pre-gc)={self.alive_before_gc} gc_freed={self.gc_collected} "
+            f"alive(post-gc)={self.alive_after_gc} uncollectable={self.uncollectable}"
+        )
+        lines = [head]
+        for rt in self.retained:
+            lines.append(f"  LEAK {rt.type_name} x{rt.count}")
+            for ref in rt.referrers:
+                lines.append(f"      held by {ref.referrer_type}: {ref.detail}")
+        if not self.retained:
+            lines.append("  no survivors — team fully released")
+        return "\n".join(lines)
+
+
+class TeamMemoryProbe:
+    """Weak-reference probe that pinpoints retained team objects after teardown.
+
+    Usage::
+
+        probe = TeamMemoryProbe()
+        probe.mark_baseline()             # ignore objects from other teams/tests
+        runtime = manager.create_team(card)
+        probe.mark_peak()                 # snapshot objects this cycle created
+        del runtime                       # drop the caller's strong handle
+        manager.stop_team(team_id)
+        manager.delete_team(team_id)
+        report = probe.report(label="cycle-1")
+        assert not report.leaked, report.format()
+    """
+
+    def __init__(
+        self,
+        tracked_bases: tuple[type, ...] = DEFAULT_TRACKED_BASES,
+        tracked_names: frozenset[str] = DEFAULT_TRACKED_NAMES,
+    ) -> None:
+        self._bases = tracked_bases
+        self._names = tracked_names
+        self._baseline_ids: frozenset[int] = frozenset()
+        self._watched: list[weakref.ref[Any]] = []
+
+    def _is_tracked(self, obj: object) -> bool:
+        """True if ``obj`` is a per-team framework object we should follow."""
+        try:
+            if isinstance(obj, self._bases):
+                return True
+        except TypeError:
+            pass  # a non-runtime-checkable Protocol slipped into tracked_bases
+        return type(obj).__name__ in self._names
+
+    def count_live(self) -> dict[str, int]:
+        """Return {type_name: count} of tracked instances currently alive."""
+        counts: dict[str, int] = {}
+        for obj in gc.get_objects():
+            if self._is_tracked(obj):
+                name = type(obj).__name__
+                counts[name] = counts.get(name, 0) + 1
+        return counts
+
+    def mark_baseline(self) -> int:
+        """Record the ids of tracked objects that already exist.
+
+        Call before creating the team. ``mark_peak`` then ignores everything
+        captured here, so the probe follows only objects the cycle creates —
+        making it robust to objects other tests / teams leave resident. Returns
+        the baseline count.
+        """
+        ids = {id(obj) for obj in gc.get_objects() if self._is_tracked(obj)}
+        self._baseline_ids = frozenset(ids)
+        return len(ids)
+
+    def mark_peak(self) -> int:
+        """Weak-reference each tracked instance created since ``mark_baseline``.
+
+        Runs the scan in this frame and keeps only weakrefs, so the probe never
+        pins the objects it measures. Objects present at baseline are excluded by
+        id (id reuse after a baseline object dies is the only blind spot, and it
+        can only hide a leak, never invent one). Returns the number captured.
+        """
+        watched: list[weakref.ref[Any]] = []
+        for obj in gc.get_objects():
+            if id(obj) in self._baseline_ids or not self._is_tracked(obj):
+                continue
+            try:
+                watched.append(weakref.ref(obj))
+            except TypeError:
+                pass  # not weak-referenceable
+        self._watched = watched
+        return len(watched)
+
+    def report(self, label: str = "") -> LeakReport:
+        """Stop the world, collect cycles, and report what survived and who holds it."""
+        total = len(self._watched)
+        alive_before = sum(1 for ref in self._watched if ref() is not None)
+
+        collected = gc.collect()
+        survivors = [obj for ref in self._watched if (obj := ref()) is not None]
+        alive_after = len(survivors)
+
+        retained = self._build_retained(survivors)
+        report = LeakReport(
+            label=label,
+            total_tracked=total,
+            alive_before_gc=alive_before,
+            alive_after_gc=alive_after,
+            gc_collected=collected,
+            uncollectable=len(gc.garbage),
+            retained=retained,
+        )
+        del survivors
+        return report
+
+    def _build_retained(self, survivors: list[Any]) -> list[RetainedType]:
+        """Group survivors by type and attach a sample of their holders."""
+        by_type: dict[str, list[Any]] = {}
+        for obj in survivors:
+            by_type.setdefault(type(obj).__name__, []).append(obj)
+
+        retained: list[RetainedType] = []
+        for name, objs in sorted(by_type.items()):
+            referrers = self._describe_holders(objs[0])
+            retained.append(RetainedType(type_name=name, count=len(objs), referrers=referrers))
+        return retained
+
+    def _describe_holders(self, obj: object, limit: int = 5) -> list[ReferrerInfo]:
+        """Summarize the objects that still reference ``obj`` (the leak holders)."""
+        skip = {id(self), id(self._watched), id(obj)}
+        infos: list[ReferrerInfo] = []
+        for r in gc.get_referrers(obj):
+            if id(r) in skip or isinstance(r, weakref.ref) or _is_frame(r):
+                continue
+            rep = repr(r)
+            if len(rep) > 100:
+                rep = rep[:97] + "..."
+            infos.append(ReferrerInfo(referrer_type=type(r).__name__, detail=rep))
+            if len(infos) >= limit:
+                break
+        return infos
+
+
+def _is_frame(obj: object) -> bool:
+    """True for frame objects (the probe's own call stack), which we never report."""
+    return type(obj).__name__ == "frame"

--- a/src/akgentic/team/sampler.py
+++ b/src/akgentic/team/sampler.py
@@ -1,0 +1,293 @@
+"""Heap-vs-RSS memory sampler for load-test loops.
+
+``MemorySampler`` records, once per iteration, three independent signals so a
+plateau can be classified instead of guessed at:
+
+* **heap** — ``tracemalloc`` current traced bytes (live Python objects). Grows
+  linearly with iterations ⇒ a real object leak.
+* **rss** — process resident set size (OS footprint). Grows while heap stays
+  flat ⇒ allocator/arena retention (CPython keeps freed arenas), *not* a leak.
+* **object census** — ``gc.get_objects`` counts per type, so the report can name
+  which object types are actually accumulating.
+
+Each sample runs ``gc.collect()`` first, so cycles are reclaimed and only truly
+retained memory is measured. Stdlib only; RSS uses ``psutil`` if importable,
+else ``/proc`` on Linux, else reports unavailable.
+"""
+
+from __future__ import annotations
+
+import gc
+import os
+import tracemalloc
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+
+def census_by_type() -> dict[str, int]:
+    """Live-instance count per type name across the whole heap (no gc.collect)."""
+    counts: dict[str, int] = {}
+    for obj in gc.get_objects():
+        name = type(obj).__name__
+        counts[name] = counts.get(name, 0) + 1
+    return counts
+
+
+# A run is a likely real leak if EITHER the traced heap grew past this many bytes
+# OR the live object count grew past this many instances (post-warmup). Heap
+# catches few-large-object leaks; object count catches many-small-object leaks
+# (e.g. per-actor wrappers). tracemalloc measures live Python allocations *after*
+# gc.collect(), so growth there means real retention — arena retention shows up
+# only in RSS, never in tracemalloc.
+_HEAP_LEAK_BYTES = 2 * 1024 * 1024
+_OBJECT_LEAK_COUNT = 1500
+
+
+class MemorySample(BaseModel):
+    """One iteration's memory reading, taken after ``gc.collect()``."""
+
+    label: str = Field(description="Caller label for this iteration")
+    iteration: int = Field(description="Zero-based iteration index")
+    heap_bytes: int = Field(description="tracemalloc current traced bytes (live Python heap)")
+    rss_bytes: int = Field(description="Process RSS in bytes, or 0 if unavailable")
+    gc_objects: int = Field(description="len(gc.get_objects()) after collection")
+
+
+class TypeGrowth(BaseModel):
+    """Per-type live-instance change between two censuses."""
+
+    type_name: str = Field(description="Class name")
+    baseline: int = Field(description="Live count in the baseline census")
+    final: int = Field(description="Live count in the candidate census")
+    delta: int = Field(description="final - baseline (positive == accumulating)")
+
+
+class ObjectCensus(BaseModel):
+    """A snapshot of live-instance counts per class, for A/B leak comparison.
+
+    Capture one at the same lifecycle point in two separate processes — e.g.
+    just before server shutdown in a *no-teams* run (baseline) and a
+    *created-then-stopped-teams* run (candidate) — then ``diff`` them. Classes
+    with a positive delta are exactly the objects the team activity left
+    resident: the leak suspects. Run the two captures in SEPARATE processes so
+    the baseline run's residue cannot pollute the candidate.
+    """
+
+    label: str = Field(default="", description="Caller label, e.g. 'no-teams' / 'with-teams'")
+    counts: dict[str, int] = Field(
+        default_factory=dict, description="type name -> live instance count (post gc.collect)"
+    )
+
+    @classmethod
+    def capture(cls, label: str = "") -> ObjectCensus:
+        """Collect cycles, then snapshot live counts per class. Call before shutdown."""
+        gc.collect()
+        return cls(label=label, counts=census_by_type())
+
+    def save(self, path: str | os.PathLike[str]) -> None:
+        """Write the census as JSON (one file per process run)."""
+        Path(path).write_text(self.model_dump_json(indent=2), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: str | os.PathLike[str]) -> ObjectCensus:
+        """Read a census written by :meth:`save`."""
+        return cls.model_validate_json(Path(path).read_text(encoding="utf-8"))
+
+    @staticmethod
+    def diff(
+        baseline: ObjectCensus, candidate: ObjectCensus, top: int | None = None
+    ) -> list[TypeGrowth]:
+        """Per-class growth ``candidate - baseline``, positive deltas, descending.
+
+        The ranked result is the leak: classes the candidate run retained that the
+        baseline run did not. ``top`` truncates to the worst N.
+        """
+        names = set(baseline.counts) | set(candidate.counts)
+        rows = [
+            TypeGrowth(
+                type_name=name,
+                baseline=baseline.counts.get(name, 0),
+                final=candidate.counts.get(name, 0),
+                delta=candidate.counts.get(name, 0) - baseline.counts.get(name, 0),
+            )
+            for name in names
+        ]
+        rows = [r for r in rows if r.delta > 0]
+        rows.sort(key=lambda r: r.delta, reverse=True)
+        return rows[:top] if top is not None else rows
+
+    @staticmethod
+    def format_diff(rows: list[TypeGrowth]) -> str:
+        """Render a diff as a ranked table for logs / CLI output."""
+        if not rows:
+            return "no class grew between the two censuses — no object leak detected"
+        lines = ["leaked classes (candidate - baseline), worst first:"]
+        for r in rows:
+            lines.append(f"  +{r.delta:>6}  {r.type_name}  ({r.baseline} -> {r.final})")
+        return "\n".join(lines)
+
+
+class MemoryTrend(BaseModel):
+    """Classified outcome of a sampled load run."""
+
+    samples: list[MemorySample] = Field(default_factory=list)
+    rss_available: bool = Field(description="Whether RSS could be read on this platform")
+    heap_growth_bytes: int = Field(description="Last heap minus first heap")
+    rss_growth_bytes: int = Field(description="Last RSS minus first RSS")
+    object_growth: int = Field(description="Last gc object count minus first")
+    top_type_growth: list[TypeGrowth] = Field(
+        default_factory=list, description="Types accumulating the most instances"
+    )
+    top_alloc_sites: list[str] = Field(
+        default_factory=list, description="tracemalloc allocation sites that grew most"
+    )
+
+    @property
+    def is_object_leak(self) -> bool:
+        """Heap OR live-object count grew materially ⇒ objects are being retained."""
+        return self.heap_growth_bytes > _HEAP_LEAK_BYTES or self.object_growth > _OBJECT_LEAK_COUNT
+
+    @property
+    def verdict(self) -> str:
+        """One-line classification of the run."""
+        if self.is_object_leak:
+            return (
+                f"LIKELY REAL LEAK — Python heap grew {_mib(self.heap_growth_bytes)}, "
+                f"live objects grew +{self.object_growth} (post-warmup). See top_type_growth."
+            )
+        if self.rss_available and self.rss_growth_bytes > _HEAP_LEAK_BYTES:
+            return (
+                f"ARENA RETENTION (not an object leak) — RSS grew "
+                f"{_mib(self.rss_growth_bytes)} but heap only {_mib(self.heap_growth_bytes)}; "
+                "freed memory held by the allocator, not by live objects."
+            )
+        return f"STABLE — heap grew {_mib(self.heap_growth_bytes)}, no accumulation."
+
+    def format(self) -> str:
+        """Render trend, verdict, and the accumulating types for logs."""
+        lines = [self.verdict, "  " + "-" * 70]
+        for s in self.samples:
+            rss = _mib(s.rss_bytes) if self.rss_available else "n/a"
+            lines.append(
+                f"  iter {s.iteration:>3} {s.label:<14} "
+                f"heap={_mib(s.heap_bytes):>10}  rss={rss:>10}  objs={s.gc_objects}"
+            )
+        if self.top_type_growth:
+            lines.append("  top accumulating types (final - baseline):")
+            for tg in self.top_type_growth:
+                lines.append(f"    +{tg.delta:>6}  {tg.type_name}  ({tg.baseline} -> {tg.final})")
+        if self.top_alloc_sites:
+            lines.append("  top growing allocation sites:")
+            lines.extend(f"    {site}" for site in self.top_alloc_sites)
+        return "\n".join(lines)
+
+
+def _mib(num_bytes: int) -> str:
+    """Format a byte count as MiB."""
+    return f"{num_bytes / 1024 / 1024:.1f}MiB"
+
+
+def _read_rss_bytes() -> int:
+    """Current process RSS in bytes, or 0 if no source is available."""
+    try:
+        import psutil  # type: ignore[import-untyped]  # noqa: PLC0415
+
+        return int(psutil.Process().memory_info().rss)
+    except Exception:
+        pass
+    try:
+        with open("/proc/self/statm", encoding="ascii") as fh:
+            resident_pages = int(fh.read().split()[1])
+        return resident_pages * os.sysconf("SC_PAGE_SIZE")
+    except (OSError, ValueError, IndexError):
+        return 0
+
+
+class MemorySampler:
+    """Per-iteration heap/RSS/object sampler for a load loop.
+
+    Usage::
+
+        sampler = MemorySampler()
+        sampler.start()
+        for i in range(n):
+            run_one_iteration()
+            sampler.sample(label="cycle", iteration=i)
+        print(sampler.report().format())
+        sampler.stop()
+    """
+
+    def __init__(self, traceback_frames: int = 10) -> None:
+        self._frames = traceback_frames
+        self._samples: list[MemorySample] = []
+        self._baseline_census: dict[str, int] = {}
+        self._baseline_snapshot: tracemalloc.Snapshot | None = None
+        self._rss_available = _read_rss_bytes() > 0
+
+    def start(self) -> None:
+        """Begin tracing and record the baseline census/snapshot."""
+        tracemalloc.start(self._frames)
+        gc.collect()
+        self._baseline_census = self._census()
+        self._baseline_snapshot = tracemalloc.take_snapshot()
+        self._samples = []
+
+    def _census(self) -> dict[str, int]:
+        """Live-instance count per type name across the whole heap."""
+        return census_by_type()
+
+    def sample(self, label: str = "", iteration: int | None = None) -> MemorySample:
+        """Collect cycles, then record heap/RSS/object counts for this iteration."""
+        gc.collect()
+        heap_current, _peak = tracemalloc.get_traced_memory()
+        sample = MemorySample(
+            label=label,
+            iteration=iteration if iteration is not None else len(self._samples),
+            heap_bytes=heap_current,
+            rss_bytes=_read_rss_bytes(),
+            gc_objects=len(gc.get_objects()),
+        )
+        self._samples.append(sample)
+        return sample
+
+    def report(self, top: int = 15) -> MemoryTrend:
+        """Build the classified trend from the recorded samples."""
+        first, last = self._samples[0], self._samples[-1]
+        return MemoryTrend(
+            samples=self._samples,
+            rss_available=self._rss_available,
+            heap_growth_bytes=last.heap_bytes - first.heap_bytes,
+            rss_growth_bytes=last.rss_bytes - first.rss_bytes,
+            object_growth=last.gc_objects - first.gc_objects,
+            top_type_growth=self._type_growth(top),
+            top_alloc_sites=self._alloc_sites(top),
+        )
+
+    def _type_growth(self, top: int) -> list[TypeGrowth]:
+        """Types with the largest positive instance growth since baseline."""
+        final = self._census()
+        growth = [
+            TypeGrowth(
+                type_name=name,
+                baseline=self._baseline_census.get(name, 0),
+                final=count,
+                delta=count - self._baseline_census.get(name, 0),
+            )
+            for name, count in final.items()
+        ]
+        growth = [g for g in growth if g.delta > 0]
+        growth.sort(key=lambda g: g.delta, reverse=True)
+        return growth[:top]
+
+    def _alloc_sites(self, top: int) -> list[str]:
+        """tracemalloc allocation sites that grew most since baseline."""
+        if self._baseline_snapshot is None:
+            return []
+        current = tracemalloc.take_snapshot()
+        stats = current.compare_to(self._baseline_snapshot, "lineno")
+        return [str(stat) for stat in stats[:top]]
+
+    def stop(self) -> None:
+        """Stop tracing."""
+        tracemalloc.stop()

--- a/tests/integration/test_memory_release.py
+++ b/tests/integration/test_memory_release.py
@@ -1,0 +1,153 @@
+"""Memory-release regression tests for the team lifecycle.
+
+Drives the real ``TeamManager`` over repeated create → stop → delete cycles and
+asserts that the live population of framework objects (orchestrator, agents,
+state, subscribers, runtimes) returns to baseline — i.e. teardown actually
+releases the team's RAM. ``TeamMemoryProbe`` names the holder when it does not.
+
+The probe is constructed with ``tracked_names=frozenset()`` so it tracks only the
+importable team-owned bases (``Akgent``/``BaseState``/``TeamRuntime``/subscribers),
+not the broader name-matched set. In-process, asyncio's default-loop policy keeps
+one benign thread-local reference to the last ``set_event_loop``'d loop — a bounded,
+team-external residual that would otherwise produce a false positive here.
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import Any
+
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.agent import Akgent
+from akgentic.core.messages.message import UserMessage
+
+from akgentic.team.diagnostics import TeamMemoryProbe
+from akgentic.team.manager import TeamManager
+from akgentic.team.models import TeamCard, TeamCardMember
+from tests.integration.conftest import (
+    RecordingAgent,
+    make_integration_agent_card,
+    wait_for_agent_state,
+)
+from tests.services.conftest import InMemoryEventStore
+
+
+def _simple_team_card(agent_class: type[Akgent[Any, Any]] = RecordingAgent) -> TeamCard:
+    """Single entry-point agent team — the minimal lifecycle unit."""
+    entry = TeamCardMember(
+        card=make_integration_agent_card(name="entry", role="Entry", agent_class=agent_class),
+    )
+    return TeamCard(
+        name="leak-probe-team",
+        description="Minimal team for memory-release tests",
+        entry_point=entry,
+        members=[],
+        message_types=[UserMessage],
+    )
+
+
+def _run_one_cycle(manager: TeamManager, actor_system: ActorSystem, probe: TeamMemoryProbe) -> Any:
+    """Create a team, exercise it, snapshot at peak, then stop + delete.
+
+    Returns the LeakReport. Crucially keeps NO strong handle to the runtime past
+    ``mark_peak`` so the probe measures the framework's retention, not the test's.
+    """
+    probe.mark_baseline()
+    runtime = manager.create_team(_simple_team_card())
+    team_id = runtime.id
+
+    actor_system.tell(runtime.entry_addr, UserMessage(content="ping"))
+    wait_for_agent_state(
+        runtime.entry_addr,
+        lambda state: getattr(state, "counter", 0) >= 1,
+        timeout=3.0,
+    )
+
+    probe.mark_peak()
+    del runtime  # drop the only test-side strong ref before teardown
+
+    manager.stop_team(team_id)
+    manager.delete_team(team_id)
+    return probe.report(label=f"team-{team_id}")
+
+
+class TestTeamMemoryRelease:
+    """Lifecycle teardown must release framework objects, cycle after cycle."""
+
+    def test_single_cycle_releases_all_team_objects(
+        self,
+        actor_system: ActorSystem,
+    ) -> None:
+        """After stop + delete, no orchestrator/agent/state/subscriber survives."""
+        manager = TeamManager(actor_system, InMemoryEventStore())
+        probe = TeamMemoryProbe(tracked_names=frozenset())
+        gc.collect()
+
+        report = _run_one_cycle(manager, actor_system, probe)
+
+        assert not report.leaked, report.format()
+
+    def test_repeated_cycles_do_not_accumulate(
+        self,
+        actor_system: ActorSystem,
+    ) -> None:
+        """Live framework-object count stays flat across 5 create/stop/delete cycles.
+
+        A genuine leak makes residual grow cycle on cycle; a clean teardown keeps
+        it at zero. Auto-GC is disabled so the probe's own gc.collect() is the
+        only collection — making the before/after-gc distinction meaningful.
+        """
+        manager = TeamManager(actor_system, InMemoryEventStore())
+        probe = TeamMemoryProbe(tracked_names=frozenset())
+
+        gc.collect()
+        gc.disable()
+        try:
+            residuals: list[int] = []
+            for _ in range(5):
+                report = _run_one_cycle(manager, actor_system, probe)
+                residuals.append(report.alive_after_gc)
+        finally:
+            gc.enable()
+
+        assert all(r == 0 for r in residuals), (
+            f"Team objects leaked across cycles (residual per cycle: {residuals}). "
+            f"Last report:\n{report.format()}"
+        )
+
+    def test_probe_detects_a_deliberately_retained_runtime(
+        self,
+        actor_system: ActorSystem,
+    ) -> None:
+        """Guard the probe itself: a held runtime must be reported with its holder.
+
+        If this fails, the probe is blind and the green lifecycle tests above are
+        meaningless — so we prove a real leak is caught and the referrer named.
+        """
+        manager = TeamManager(actor_system, InMemoryEventStore())
+        probe = TeamMemoryProbe(tracked_names=frozenset())
+        gc.collect()
+
+        probe.mark_baseline()
+        runtime = manager.create_team(_simple_team_card())
+        team_id = runtime.id
+        probe.mark_peak()
+
+        # Deliberately leak: stash the runtime in a container that outlives stop.
+        leaked_holder = {"runtime": runtime}
+        del runtime
+        manager.stop_team(team_id)
+
+        report = probe.report(label="deliberate-leak")
+        try:
+            assert report.leaked, "Probe failed to detect a retained runtime"
+            runtime_leak = next(
+                (rt for rt in report.retained if rt.type_name == "TeamRuntime"), None
+            )
+            assert runtime_leak is not None, report.format()
+            assert any("dict" in ref.referrer_type for ref in runtime_leak.referrers), (
+                f"Holder (the leaking dict) not identified:\n{report.format()}"
+            )
+        finally:
+            leaked_holder.clear()
+            manager.delete_team(team_id)

--- a/tests/integration/test_object_census.py
+++ b/tests/integration/test_object_census.py
@@ -1,0 +1,91 @@
+"""Differential object-census over the real team lifecycle.
+
+Mirrors the server A/B the operators run (no-teams vs created-then-stopped-teams,
+captured just before shutdown): here the baseline is captured before any team is
+built and the candidate after K full create -> stop -> delete cycles. The diff
+ranks the classes the team activity left resident — the leak suspects — and the
+ObjectCensus save/load path is exercised end to end.
+
+This is a *diagnostic* test: it asserts the tooling works and that the heavy
+agent objects are released (BaseAgent/Orchestrator do not accumulate). It does
+NOT assert zero growth overall, because the known residual is per-actor Pykka
+infrastructure (ActorRef/Queue/...) owned by akgentic-core, out of this package's
+scope to fix. The ranked diff is logged so operators can see it.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from akgentic.core.actor_system_impl import ActorSystem
+from akgentic.core.messages.message import UserMessage
+
+from akgentic.team.manager import TeamManager
+from akgentic.team.models import TeamCard, TeamCardMember
+from akgentic.team.sampler import ObjectCensus
+from tests.integration.conftest import RecordingAgent, make_integration_agent_card
+from tests.services.conftest import InMemoryEventStore
+
+logger = logging.getLogger(__name__)
+
+
+def _simple_team_card() -> TeamCard:
+    entry = TeamCardMember(
+        card=make_integration_agent_card(name="entry", role="Entry", agent_class=RecordingAgent),
+    )
+    return TeamCard(
+        name="census-team",
+        description="Team for differential census",
+        entry_point=entry,
+        members=[],
+        message_types=[UserMessage],
+    )
+
+
+def _create_stop_delete(actor_system: ActorSystem) -> None:
+    """One full lifecycle on a fresh manager, leaving nothing tracked behind."""
+    manager = TeamManager(actor_system, InMemoryEventStore())
+    runtime = manager.create_team(_simple_team_card())
+    team_id = runtime.id
+    actor_system.tell(runtime.entry_addr, UserMessage(content="ping"))
+    del runtime
+    manager.stop_team(team_id)
+    manager.delete_team(team_id)
+
+
+class TestLifecycleObjectCensus:
+    """A/B census across the team lifecycle, with save/load + heavy-object check."""
+
+    def test_diff_round_trips_and_releases_heavy_objects(
+        self,
+        actor_system: ActorSystem,
+        tmp_path: Path,
+    ) -> None:
+        # Run A: baseline before any team exists.
+        baseline = ObjectCensus.capture(label="no-teams")
+        baseline.save(tmp_path / "census-a.json")
+
+        # Run B activity: K full lifecycles, all stopped + deleted.
+        for _ in range(5):
+            _create_stop_delete(actor_system)
+        candidate = ObjectCensus.capture(label="after-teams")
+        candidate.save(tmp_path / "census-b.json")
+
+        # The persisted captures diff exactly as the in-memory ones (operator path).
+        rows = ObjectCensus.diff(
+            ObjectCensus.load(tmp_path / "census-a.json"),
+            ObjectCensus.load(tmp_path / "census-b.json"),
+            top=25,
+        )
+        logger.info("lifecycle census diff:\n%s", ObjectCensus.format_diff(rows))
+
+        # Heavy per-team objects must be fully released — they are owned by the
+        # team layer and torn down on stop. Their presence in the diff would be a
+        # team-package regression (the per-actor wrappers are core-owned, allowed).
+        grew = {r.type_name for r in rows}
+        for heavy in ("RecordingAgent", "Orchestrator", "TeamRuntime", "PersistenceSubscriber"):
+            assert heavy not in grew, (
+                f"{heavy} accumulated across lifecycles — team-layer leak:\n"
+                f"{ObjectCensus.format_diff(rows)}"
+            )

--- a/tests/services/test_diagnostics.py
+++ b/tests/services/test_diagnostics.py
@@ -1,0 +1,121 @@
+"""Unit tests for TeamMemoryProbe and its report models.
+
+Actor-free: the probe is exercised against synthetic tracked objects so the
+detection logic (baseline exclusion, survivor counting, holder naming) is
+verified in isolation from the actor runtime.
+"""
+
+from __future__ import annotations
+
+import gc
+
+from akgentic.team.diagnostics import (
+    LeakReport,
+    RetainedType,
+    TeamMemoryProbe,
+)
+
+
+class Widget:
+    """Stand-in tracked object with no framework coupling."""
+
+
+def _probe() -> TeamMemoryProbe:
+    """Probe that tracks only the local Widget class."""
+    return TeamMemoryProbe(tracked_bases=(Widget,), tracked_names=frozenset())
+
+
+class TestLeakReportModel:
+    """The Pydantic report exposes the right derived flags and rendering."""
+
+    def test_leaked_and_cycle_held_flags(self) -> None:
+        report = LeakReport(
+            label="x",
+            total_tracked=5,
+            alive_before_gc=3,
+            alive_after_gc=1,
+            gc_collected=2,
+            uncollectable=0,
+            retained=[RetainedType(type_name="Widget", count=1)],
+        )
+        assert report.leaked is True
+        assert report.cycle_held is True  # before(3) > after(1): cycle reclaimed some
+
+    def test_clean_report_is_not_leaked(self) -> None:
+        report = LeakReport(
+            label="x",
+            total_tracked=4,
+            alive_before_gc=0,
+            alive_after_gc=0,
+            gc_collected=0,
+            uncollectable=0,
+        )
+        assert report.leaked is False
+        assert report.cycle_held is False
+        assert "no survivors" in report.format()
+
+    def test_format_lists_holders(self) -> None:
+        report = LeakReport(
+            label="leak",
+            total_tracked=1,
+            alive_before_gc=1,
+            alive_after_gc=1,
+            gc_collected=0,
+            uncollectable=0,
+            retained=[
+                RetainedType(
+                    type_name="Widget",
+                    count=2,
+                    referrers=[],
+                )
+            ],
+        )
+        rendered = report.format()
+        assert "LEAK Widget x2" in rendered
+        assert "[leak]" in rendered
+
+
+class TestTeamMemoryProbe:
+    """Detection logic: baseline exclusion, survivor count, holder naming."""
+
+    def test_count_live_sees_tracked_objects(self) -> None:
+        probe = _probe()
+        widgets = [Widget(), Widget()]  # noqa: F841 — kept alive for the count
+        assert probe.count_live().get("Widget", 0) >= 2
+
+    def test_no_leak_when_object_is_dropped(self) -> None:
+        probe = _probe()
+        probe.mark_baseline()
+        w = Widget()
+        probe.mark_peak()
+        del w
+        report = probe.report(label="clean")
+        assert not report.leaked, report.format()
+
+    def test_detects_retained_object_and_names_dict_holder(self) -> None:
+        probe = _probe()
+        probe.mark_baseline()
+        w = Widget()
+        probe.mark_peak()
+        holder = {"w": w}  # the leak: a dict keeps the Widget alive
+        del w
+        report = probe.report(label="held")
+        try:
+            assert report.leaked
+            widget = next(rt for rt in report.retained if rt.type_name == "Widget")
+            assert widget.count == 1
+            assert any("dict" in r.referrer_type for r in widget.referrers)
+        finally:
+            holder.clear()
+
+    def test_baseline_excludes_pre_existing_objects(self) -> None:
+        probe = _probe()
+        pre_existing = Widget()  # exists before baseline
+        probe.mark_baseline()
+        probe.mark_peak()  # nothing new created
+        # pre_existing is alive but was captured at baseline → not a survivor
+        report = probe.report(label="baseline")
+        assert report.total_tracked == 0
+        assert not report.leaked
+        del pre_existing
+        gc.collect()

--- a/tests/services/test_sampler.py
+++ b/tests/services/test_sampler.py
@@ -1,0 +1,129 @@
+"""Unit tests for MemorySampler trend classification.
+
+Drives the sampler against a synthetic, controllable allocation pattern so the
+heap-vs-RSS verdict logic is verified without an actor runtime.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from akgentic.team.sampler import (
+    MemorySample,
+    MemorySampler,
+    MemoryTrend,
+    ObjectCensus,
+)
+
+
+class Blob:
+    """Allocation unit large enough to move the traced-heap needle."""
+
+    def __init__(self) -> None:
+        self.payload = bytearray(64 * 1024)  # 64 KiB
+
+
+class TestMemoryTrendVerdict:
+    """The trend's verdict classifies leak vs arena vs stable."""
+
+    def _trend(self, heap_growth: int, obj_growth: int, rss_growth: int = 0) -> MemoryTrend:
+        first = MemorySample(label="a", iteration=0, heap_bytes=0, rss_bytes=0, gc_objects=0)
+        last = MemorySample(
+            label="b",
+            iteration=1,
+            heap_bytes=heap_growth,
+            rss_bytes=rss_growth,
+            gc_objects=obj_growth,
+        )
+        return MemoryTrend(
+            samples=[first, last],
+            rss_available=rss_growth > 0,
+            heap_growth_bytes=heap_growth,
+            rss_growth_bytes=rss_growth,
+            object_growth=obj_growth,
+        )
+
+    def test_growing_heap_is_real_leak(self) -> None:
+        trend = self._trend(heap_growth=8 * 1024 * 1024, obj_growth=5000)
+        assert trend.is_object_leak
+        assert "REAL LEAK" in trend.verdict
+
+    def test_rss_only_is_arena_retention(self) -> None:
+        trend = self._trend(heap_growth=100_000, obj_growth=10, rss_growth=20 * 1024 * 1024)
+        assert not trend.is_object_leak
+        assert "ARENA RETENTION" in trend.verdict
+        assert "ARENA RETENTION" in trend.format()  # render path
+
+    def test_flat_is_stable(self) -> None:
+        trend = self._trend(heap_growth=50_000, obj_growth=5)
+        assert not trend.is_object_leak
+        assert "STABLE" in trend.verdict
+
+
+class TestObjectCensusDiff:
+    """A/B differential census: capture, persist, diff, render."""
+
+    def test_capture_counts_live_instances(self) -> None:
+        widgets = [Blob() for _ in range(5)]  # noqa: F841 — keep alive for the count
+        census = ObjectCensus.capture(label="with-blobs")
+        assert census.label == "with-blobs"
+        assert census.counts.get("Blob", 0) >= 5
+
+    def test_diff_ranks_classes_the_candidate_added(self) -> None:
+        baseline = ObjectCensus(label="a", counts={"Foo": 10, "Bar": 5})
+        candidate = ObjectCensus(label="b", counts={"Foo": 14, "Bar": 5, "Baz": 3})
+        rows = ObjectCensus.diff(baseline, candidate)
+        # Only positive deltas, sorted by delta desc: Foo (+4), Baz (+3); Bar (0) dropped.
+        assert [(r.type_name, r.delta) for r in rows] == [("Foo", 4), ("Baz", 3)]
+
+    def test_diff_empty_when_nothing_grew(self) -> None:
+        same = {"Foo": 7}
+        rows = ObjectCensus.diff(ObjectCensus(counts=same), ObjectCensus(counts=same))
+        assert rows == []
+        assert "no object leak" in ObjectCensus.format_diff(rows)
+
+    def test_save_load_round_trip(self, tmp_path: Path) -> None:
+        census = ObjectCensus(label="run-a", counts={"Foo": 3, "Bar": 9})
+        path = tmp_path / "census-a.json"
+        census.save(path)
+        loaded = ObjectCensus.load(path)
+        assert loaded.label == "run-a"
+        assert loaded.counts == {"Foo": 3, "Bar": 9}
+
+
+class TestMemorySamplerDetectsAccumulation:
+    """End-to-end: a deliberate accumulation is flagged with the culprit type."""
+
+    def test_retained_blobs_show_as_heap_and_type_growth(self) -> None:
+        sampler = MemorySampler()
+        sampler.start()
+
+        retained: list[Blob] = []
+        for i in range(40):
+            retained.extend(Blob() for _ in range(10))  # leak 10 blobs/iteration
+            sampler.sample(label="leak", iteration=i)
+
+        trend = sampler.report()
+        sampler.stop()
+
+        rendered = trend.format()
+        assert trend.is_object_leak, rendered
+        assert "Blob" in rendered  # the culprit type is named in the report
+        blob_growth = next((t for t in trend.top_type_growth if t.type_name == "Blob"), None)
+        assert blob_growth is not None, rendered
+        assert blob_growth.delta >= 350  # ~400 retained, minus baseline noise
+        assert len(retained) == 400  # keep them alive through the assertions
+
+    def test_dropped_blobs_do_not_accumulate(self) -> None:
+        sampler = MemorySampler()
+        sampler.start()
+
+        for i in range(20):
+            transient = [Blob() for _ in range(10)]  # created then dropped
+            del transient
+            sampler.sample(label="clean", iteration=i)
+
+        trend = sampler.report()
+        sampler.stop()
+
+        assert not trend.is_object_leak, trend.format()


### PR DESCRIPTION
## Memory-leak diagnostics for the team lifecycle

Reusable, **core-only** diagnostics (no new deps) to investigate and regression-guard memory retention:

- **`ObjectCensus`** — `capture`/`save`/`load`/`diff` of per-class live counts (after `gc.collect()`); the A/B primitive behind the worker debug endpoint.
- **`TeamMemoryProbe`** — weak-ref probe that, after teardown, reports which framework objects survived and *who holds them* (`gc.get_referrers` chain).
- **`MemorySampler`** — per-iteration heap (`tracemalloc`) vs RSS sampler that classifies a real object leak from allocator/arena retention, and names the accumulating types.

All exported from `akgentic.team`. Cross-cycle create→stop→delete regression tests assert the team layer releases its objects (probe scoped to team-owned bases to avoid the benign asyncio default-loop-policy residual).

Tests: probe round-trip + holder detection; census diff/save/load; sampler verdict classification; lifecycle release + deliberate-leak detection.

Relates to #134
