### PR TITLE
feat(akgentic-team): epic 24 slice — load_events(after_event_id) cursor (24-1, 24-3)

### DIFF
--- a/src/akgentic/team/__init__.py
+++ b/src/akgentic/team/__init__.py
@@ -18,6 +18,7 @@ from akgentic.team.models import (
     TeamStatus,
 )
 from akgentic.team.ports import (
+    EventNotFoundError,
     EventStore,
     NullServiceRegistry,
     ServiceRegistry,
@@ -31,6 +32,7 @@ __version__ = "1.0.0-alpha.2"
 __all__: list[str] = [
     "__version__",
     "AgentStateSnapshot",
+    "EventNotFoundError",
     "EventStore",
     "NullServiceRegistry",
     "PersistenceSubscriber",

--- a/src/akgentic/team/ports.py
+++ b/src/akgentic/team/ports.py
@@ -12,6 +12,14 @@ from akgentic.team.models import (
 )
 
 
+class EventNotFoundError(LookupError):
+    """Raised when ``load_events(after_event_id=...)`` cannot resolve the anchor.
+
+    Subclasses ``LookupError`` — never ``ValueError`` — so the corrupted-document
+    handlers in the YAML and Mongo backends cannot swallow a stale cursor.
+    """
+
+
 class EventStore(Protocol):
     """Typed persistence surface for team event sourcing.
 
@@ -27,10 +35,29 @@ class EventStore(Protocol):
         """
         ...
 
-    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
-        """Load all persisted events for a team.
+    def load_events(
+        self, team_id: uuid.UUID, after_event_id: uuid.UUID | None = None
+    ) -> list[PersistedEvent]:
+        """Load persisted events for a team, ordered by ``sequence`` ASC.
 
-        Called by TeamRestorer to replay events during team resumption.
+        Args:
+            team_id: Team whose events to load.
+            after_event_id: If provided, return only events persisted *after*
+                the event whose ``event.id`` matches — exclusive of the anchor
+                itself. If ``None`` (default), return the full log, which is
+                what TeamRestorer replays on resume.
+
+        Raises:
+            EventNotFoundError: If ``after_event_id`` is not an event of this
+                team. A stale cursor MUST fail loudly, never silently degrade
+                into a full-log return.
+
+        Implementations MUST resolve the anchor to its ``sequence`` and push a
+        ``sequence > N`` range filter down to the backend (SQL WHERE, Mongo find
+        filter, list slice) rather than load-all-then-filter in Python — the
+        infra read path calls this per client poll.
+
+        See ADR-21 §1 for the additive, backwards-compatible Protocol change.
         """
         ...
 

--- a/src/akgentic/team/repositories/mongo.py
+++ b/src/akgentic/team/repositories/mongo.py
@@ -36,6 +36,7 @@ except ImportError as exc:
     ) from exc
 
 from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process
+from akgentic.team.ports import EventNotFoundError
 
 if TYPE_CHECKING:
     import pymongo.collection
@@ -201,17 +202,22 @@ class MongoEventStore:
         self._events.insert_one(doc)
         logger.debug("Saved event seq=%d for team %s", event.sequence, event.team_id)
 
-    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
-        """Load all persisted events for a team, ordered by sequence.
-
-        Queries the ``events`` collection by ``team_id`` and sorts by
-        ``sequence`` ascending.
+    def load_events(
+        self, team_id: uuid.UUID, after_event_id: uuid.UUID | None = None
+    ) -> list[PersistedEvent]:
+        """Load persisted events for a team, ordered by sequence.
 
         Args:
             team_id: Unique identifier of the team.
+            after_event_id: If provided, return only events after the matching
+                event — anchor excluded. If ``None`` (default), the full log.
 
         Returns:
             List of PersistedEvent ordered by sequence, or empty list if none.
+
+        Raises:
+            EventNotFoundError: If ``after_event_id`` does not resolve to an
+                event of this team.
         """
         cursor = self._events.find({"team_id": str(team_id)}).sort("sequence", 1)
         events: list[PersistedEvent] = []
@@ -224,7 +230,14 @@ class MongoEventStore:
                     "Skipping corrupted event for team %s: %s", team_id, exc
                 )
         logger.debug("Loaded %d events for team %s", len(events), team_id)
-        return events
+        if after_event_id is None:
+            return events
+        # Interim in-memory slice; the $gt push-down lands in story 24-3.
+        # event.id is persisted as a string, so compare stringified ids.
+        for index, event in enumerate(events):
+            if str(event.event.id) == str(after_event_id):
+                return events[index + 1 :]
+        raise EventNotFoundError(f"Event {after_event_id} not found for team {team_id}")
 
     def get_max_sequence(self, team_id: uuid.UUID) -> int:
         """Return the highest event sequence number for a team, or 0.

--- a/src/akgentic/team/repositories/mongo.py
+++ b/src/akgentic/team/repositories/mongo.py
@@ -97,6 +97,12 @@ class MongoEventStore:
         # same database returns silently when an index with the same key spec
         # already exists, so this is safe across redeploys.
         self._teams.create_index("user_id", name="teams_user_id_idx")
+        # ADR-21 §5: backs the load_events(after_event_id=...) anchor lookup.
+        # Not unique — a unique index would turn a read-path ambiguity into a
+        # write-path DuplicateKeyError on save_event.
+        self._events.create_index(
+            [("team_id", 1), ("event.id", 1)], name="events_team_event_id_idx"
+        )
         logger.debug("Initialized MongoEventStore with database '%s'", db.name)
 
     def save_team(self, process: Process) -> None:
@@ -207,6 +213,10 @@ class MongoEventStore:
     ) -> list[PersistedEvent]:
         """Load persisted events for a team, ordered by sequence.
 
+        Both the anchor resolve and the ``sequence > N`` range filter run in
+        MongoDB — the anchor via an indexed, projected ``find_one``, the range
+        as a ``$gt`` clause on the find (ADR-21 §5).
+
         Args:
             team_id: Unique identifier of the team.
             after_event_id: If provided, return only events after the matching
@@ -219,7 +229,10 @@ class MongoEventStore:
             EventNotFoundError: If ``after_event_id`` does not resolve to an
                 event of this team.
         """
-        cursor = self._events.find({"team_id": str(team_id)}).sort("sequence", 1)
+        query: dict[str, object] = {"team_id": str(team_id)}
+        if after_event_id is not None:
+            query["sequence"] = {"$gt": self._resolve_anchor_sequence(team_id, after_event_id)}
+        cursor = self._events.find(query).sort("sequence", 1)
         events: list[PersistedEvent] = []
         for doc in cursor:
             doc.pop("_id", None)
@@ -230,14 +243,27 @@ class MongoEventStore:
                     "Skipping corrupted event for team %s: %s", team_id, exc
                 )
         logger.debug("Loaded %d events for team %s", len(events), team_id)
-        if after_event_id is None:
-            return events
-        # Interim in-memory slice; the $gt push-down lands in story 24-3.
-        # event.id is persisted as a string, so compare stringified ids.
-        for index, event in enumerate(events):
-            if str(event.event.id) == str(after_event_id):
-                return events[index + 1 :]
-        raise EventNotFoundError(f"Event {after_event_id} not found for team {team_id}")
+        return events
+
+    def _resolve_anchor_sequence(self, team_id: uuid.UUID, after_event_id: uuid.UUID) -> int:
+        """Return the ``sequence`` of the cursor anchor, or raise if absent.
+
+        ``event.id`` is persisted as a string, so both ids are coerced with
+        ``str()``: a raw ``uuid.UUID`` would be BSON-encoded as Binary
+        subtype-4 and match nothing. The projection keeps this to a single
+        indexed lookup returning one integer — the document is never hydrated.
+
+        Raises:
+            EventNotFoundError: If the anchor is not an event of this team.
+        """
+        anchor = self._events.find_one(
+            {"team_id": str(team_id), "event.id": str(after_event_id)},
+            projection={"sequence": 1, "_id": 0},
+        )
+        if anchor is None:
+            raise EventNotFoundError(f"Event {after_event_id} not found for team {team_id}")
+        sequence: int = anchor["sequence"]
+        return sequence
 
     def get_max_sequence(self, team_id: uuid.UUID) -> int:
         """Return the highest event sequence number for a team, or 0.

--- a/src/akgentic/team/repositories/postgres/event_store.py
+++ b/src/akgentic/team/repositories/postgres/event_store.py
@@ -21,6 +21,7 @@ import uuid
 from nagra import Transaction  # type: ignore[import-untyped]
 
 from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process
+from akgentic.team.ports import EventNotFoundError
 from akgentic.team.repositories.postgres._queries import decode_jsonb_column
 
 
@@ -125,8 +126,20 @@ class NagraEventStore:
                 (str(event.team_id), event.sequence, data),
             )
 
-    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
-        """Return all events for a team ordered by ``sequence`` ASC."""
+    def load_events(
+        self, team_id: uuid.UUID, after_event_id: uuid.UUID | None = None
+    ) -> list[PersistedEvent]:
+        """Return events for a team ordered by ``sequence`` ASC.
+
+        Args:
+            team_id: Team whose events to load.
+            after_event_id: If provided, return only events after the matching
+                event — anchor excluded. If ``None`` (default), the full log.
+
+        Raises:
+            EventNotFoundError: If ``after_event_id`` does not resolve to an
+                event of this team.
+        """
         with Transaction(self._conn_string) as trn:
             cursor = trn.execute(
                 "SELECT data FROM event_entries WHERE team_id = %s "
@@ -134,7 +147,15 @@ class NagraEventStore:
                 (str(team_id),),
             )
             rows = cursor.fetchall()
-        return [PersistedEvent.model_validate(decode_jsonb_column(r[0])) for r in rows]
+        events = [PersistedEvent.model_validate(decode_jsonb_column(r[0])) for r in rows]
+        if after_event_id is None:
+            return events
+        # Interim in-memory slice; the range-query push-down lands in story 24-4.
+        # event.id is persisted as a string, so compare stringified ids.
+        for index, event in enumerate(events):
+            if str(event.event.id) == str(after_event_id):
+                return events[index + 1 :]
+        raise EventNotFoundError(f"Event {after_event_id} not found for team {team_id}")
 
     def get_max_sequence(self, team_id: uuid.UUID) -> int:
         """Return the largest sequence for a team, or ``0`` if empty.

--- a/src/akgentic/team/repositories/yaml.py
+++ b/src/akgentic/team/repositories/yaml.py
@@ -25,6 +25,7 @@ from pathlib import Path
 import yaml
 
 from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process
+from akgentic.team.ports import EventNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -169,28 +170,49 @@ class YamlEventStore:
             yaml.dump(data, f, default_flow_style=False)
         logger.debug("Appended event seq=%d for team %s", event.sequence, event.team_id)
 
-    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
-        """Load all persisted events for a team from events.yaml.
+    @staticmethod
+    def _unreadable_log(
+        team_id: uuid.UUID, after_event_id: uuid.UUID | None
+    ) -> list[PersistedEvent]:
+        """Result for a team whose events.yaml is absent or unparseable.
 
-        Reads multi-document YAML and reconstructs each document as a
-        PersistedEvent, returned sorted by sequence number.
+        Raises:
+            EventNotFoundError: If a cursor was passed — an unreadable log
+                cannot resolve an anchor, and ``[]`` would be read by the
+                caller as "you are already up to date".
+        """
+        if after_event_id is not None:
+            raise EventNotFoundError(f"Event {after_event_id} not found for team {team_id}")
+        return []
+
+    def load_events(
+        self, team_id: uuid.UUID, after_event_id: uuid.UUID | None = None
+    ) -> list[PersistedEvent]:
+        """Load persisted events for a team from events.yaml, ordered by sequence.
 
         Args:
             team_id: Unique identifier of the team.
+            after_event_id: If provided, return only events after the matching
+                event — anchor excluded. If ``None`` (default), the full log.
 
         Returns:
-            List of PersistedEvent ordered by sequence, or empty list if
-            no events file exists.
+            List of PersistedEvent ordered by sequence, or empty list if no
+            events file exists and no cursor was passed.
+
+        Raises:
+            EventNotFoundError: If ``after_event_id`` does not resolve to an
+                event of this team, including when the events file is absent
+                or unparseable.
         """
         events_path = self._team_dir(team_id) / "events.yaml"
         if not events_path.exists():
-            return []
+            return self._unreadable_log(team_id, after_event_id)
         try:
             with open(events_path) as f:
                 docs = list(yaml.safe_load_all(f))
         except yaml.YAMLError as exc:
             logger.error("Corrupted events.yaml for team %s: %s", team_id, exc)
-            return []
+            return self._unreadable_log(team_id, after_event_id)
         events: list[PersistedEvent] = []
         for doc in docs:
             if doc is None:
@@ -202,7 +224,15 @@ class YamlEventStore:
                     "Skipping corrupted event for team %s: %s", team_id, exc
                 )
         logger.debug("Loaded %d events for team %s", len(events), team_id)
-        return sorted(events, key=lambda e: e.sequence)
+        ordered = sorted(events, key=lambda e: e.sequence)
+        if after_event_id is None:
+            return ordered
+        # Interim in-memory slice; YAML keeps it permanently (ADR-21 §4).
+        # event.id is persisted as a string, so compare stringified ids.
+        for index, event in enumerate(ordered):
+            if str(event.event.id) == str(after_event_id):
+                return ordered[index + 1 :]
+        raise EventNotFoundError(f"Event {after_event_id} not found for team {team_id}")
 
     def get_max_sequence(self, team_id: uuid.UUID) -> int:
         """Return the highest event sequence number for a team, or 0.

--- a/tests/models/test_ports.py
+++ b/tests/models/test_ports.py
@@ -10,13 +10,37 @@ import uuid
 
 import pytest
 
-from akgentic.team.ports import NullServiceRegistry, ServiceRegistry
+from akgentic.team.ports import EventNotFoundError, NullServiceRegistry, ServiceRegistry
 
 
 @pytest.fixture()
 def registry() -> NullServiceRegistry:
     """Shared NullServiceRegistry instance for tests."""
     return NullServiceRegistry()
+
+
+class TestEventNotFoundError:
+    """Verify the exception's base class, which is load-bearing (ADR-21 §2)."""
+
+    def test_is_a_lookup_error(self) -> None:
+        """``EventNotFoundError`` is catchable as the standard "key not here" category."""
+        assert issubclass(EventNotFoundError, LookupError)
+
+    def test_is_not_a_value_error(self) -> None:
+        """A stale cursor must not be swallowed by a corrupted-document handler.
+
+        The YAML and Mongo backends both ``except ValueError`` to skip corrupt
+        documents. If ``EventNotFoundError`` were a ``ValueError``, those
+        handlers would silently absorb it and degrade the cursored read back
+        into the full-log read the cursor exists to avoid.
+        """
+        assert not issubclass(EventNotFoundError, ValueError)
+
+        with pytest.raises(EventNotFoundError):
+            try:
+                raise EventNotFoundError("stale cursor")
+            except ValueError:  # pragma: no cover - must not catch
+                pytest.fail("EventNotFoundError was caught by `except ValueError`")
 
 
 class TestNullServiceRegistry:

--- a/tests/repositories/mongo/test_mongo.py
+++ b/tests/repositories/mongo/test_mongo.py
@@ -138,6 +138,52 @@ class TestMongoEventStoreMongoSpecific:
         assert info["teams_user_id_idx"]["key"] == [("user_id", 1)]
         assert list(info.keys()).count("teams_user_id_idx") == 1
 
+    # --- event.id index presence --------------------------------------------
+
+    def test_events_team_event_id_index_created_on_init(
+        self, mongo_store: MongoEventStore, mongo_db: Any
+    ) -> None:
+        """``__init__`` creates ``events_team_event_id_idx`` on ``events``.
+
+        Compound ascending key on ``team_id`` + the nested ``event.id``,
+        backing the anchor lookup in ``load_events(after_event_id=...)``
+        (ADR-21 §5). Deliberately not unique: a unique index would turn a
+        read-path ambiguity into a write-path ``DuplicateKeyError`` on
+        ``save_event``.
+        """
+        info = mongo_db["events"].index_information()
+        assert "events_team_event_id_idx" in info
+        assert info["events_team_event_id_idx"]["key"] == [("team_id", 1), ("event.id", 1)]
+        assert not info["events_team_event_id_idx"].get("unique")
+
+    def test_events_team_event_id_index_creation_is_idempotent(
+        self, mongo_store: MongoEventStore, mongo_db: Any
+    ) -> None:
+        """Re-running the constructor against the same database does not raise.
+
+        ``create_index`` returns silently when an index with the same key
+        spec already exists, so redeploys against a long-lived MongoDB are
+        safe. After the second construction the entry is still present
+        exactly once with the same key spec.
+        """
+        # First construction already happened via the ``mongo_store`` fixture.
+        MongoEventStore(mongo_db)  # second construction — must not raise
+
+        info = mongo_db["events"].index_information()
+        assert info["events_team_event_id_idx"]["key"] == [("team_id", 1), ("event.id", 1)]
+        assert list(info.keys()).count("events_team_event_id_idx") == 1
+
+    def test_existing_events_team_sequence_index_still_created(
+        self, mongo_store: MongoEventStore, mongo_db: Any
+    ) -> None:
+        """The pre-existing ``(team_id, sequence)`` index is untouched.
+
+        It already backs the ``{"sequence": {"$gt": n}}`` range filter and
+        needs no change for the cursor push-down.
+        """
+        specs = [entry["key"] for entry in mongo_db["events"].index_information().values()]
+        assert [("team_id", 1), ("sequence", 1)] in specs
+
     # --- Collection name configuration --------------------------------------
 
     def test_collection_names_default_when_env_unset(

--- a/tests/repositories/test_event_store_contract.py
+++ b/tests/repositories/test_event_store_contract.py
@@ -20,7 +20,7 @@ import pytest
 from akgentic.core.messages.message import UserMessage
 
 from akgentic.team.models import TeamStatus
-from akgentic.team.ports import EventStore
+from akgentic.team.ports import EventNotFoundError, EventStore
 from tests.models.conftest import (
     SampleAgentState,
     make_agent_state_snapshot,
@@ -151,6 +151,32 @@ class TestEventStoreContract:
     def test_load_events_returns_empty_list_when_missing(self, event_store: EventStore) -> None:
         """Protocol contract: no events for a team yields ``[]``."""
         assert event_store.load_events(uuid.uuid4()) == []
+
+    # --- load_events(after_event_id) cursor baseline -----------------------
+
+    def test_load_events_after_event_id_none_equals_no_arg(self, event_store: EventStore) -> None:
+        """``load_events(t, after_event_id=None)`` is equivalent to ``load_events(t)``."""
+        team_id = uuid.uuid4()
+        for seq in (1, 2, 3):
+            event_store.save_event(make_persisted_event(team_id=team_id, sequence=seq))
+
+        no_arg = event_store.load_events(team_id)
+        with_none = event_store.load_events(team_id, after_event_id=None)
+        assert [e.event.id for e in with_none] == [e.event.id for e in no_arg]
+        assert [e.sequence for e in with_none] == [1, 2, 3]
+
+    def test_load_events_unknown_after_event_id_raises(self, event_store: EventStore) -> None:
+        """An anchor that was never persisted raises rather than returning ``[]``.
+
+        Returning ``[]`` would be indistinguishable from the legitimate
+        "you are already up to date" answer (ADR-21 §2).
+        """
+        team_id = uuid.uuid4()
+        for seq in (1, 2, 3):
+            event_store.save_event(make_persisted_event(team_id=team_id, sequence=seq))
+
+        with pytest.raises(EventNotFoundError):
+            event_store.load_events(team_id, after_event_id=uuid.uuid4())
 
     # --- get_max_sequence -------------------------------------------------
 

--- a/tests/repositories/test_event_store_contract.py
+++ b/tests/repositories/test_event_store_contract.py
@@ -191,6 +191,69 @@ class TestEventStoreContract:
         with pytest.raises(EventNotFoundError):
             event_store.load_events(team_id, after_event_id=uuid.uuid4())
 
+    def test_load_events_first_event_anchor_returns_all_but_first(
+        self, event_store: EventStore
+    ) -> None:
+        """The first event as anchor yields every event except that one."""
+        team_id = uuid.uuid4()
+        for seq in (1, 2, 3, 4, 5):
+            event_store.save_event(make_persisted_event(team_id=team_id, sequence=seq))
+
+        first = event_store.load_events(team_id)[0]
+        tail = event_store.load_events(team_id, after_event_id=first.event.id)
+        assert [e.sequence for e in tail] == [2, 3, 4, 5]
+
+    def test_load_events_last_event_anchor_returns_empty(self, event_store: EventStore) -> None:
+        """The last event as anchor yields ``[]`` — the caller is up to date."""
+        team_id = uuid.uuid4()
+        for seq in (1, 2, 3):
+            event_store.save_event(make_persisted_event(team_id=team_id, sequence=seq))
+
+        last = event_store.load_events(team_id)[-1]
+        assert event_store.load_events(team_id, after_event_id=last.event.id) == []
+
+    def test_load_events_anchor_from_other_team_raises(self, event_store: EventStore) -> None:
+        """An anchor belonging to another team raises — the lookup is team-scoped.
+
+        Returning team A's whole log because the caller passed team B's
+        cursor is the silent degradation ADR-21 §2 exists to prevent.
+        """
+        team_a = uuid.uuid4()
+        team_b = uuid.uuid4()
+        for seq in (1, 2, 3):
+            event_store.save_event(make_persisted_event(team_id=team_a, sequence=seq))
+            event_store.save_event(make_persisted_event(team_id=team_b, sequence=seq))
+
+        foreign_anchor = event_store.load_events(team_b)[0]
+        with pytest.raises(EventNotFoundError):
+            event_store.load_events(team_a, after_event_id=foreign_anchor.event.id)
+
+    def test_load_events_after_event_id_on_empty_store_raises(
+        self, event_store: EventStore
+    ) -> None:
+        """An anchor queried against a team with no events raises, never ``[]``."""
+        with pytest.raises(EventNotFoundError):
+            event_store.load_events(uuid.uuid4(), after_event_id=uuid.uuid4())
+
+    def test_load_events_cursor_round_trip(self, event_store: EventStore) -> None:
+        """The incremental-reader usage pattern: poll, append, poll again.
+
+        This is the case that would catch a silent regression back to a
+        full-log return — the second poll must yield exactly the one new
+        event, not the whole history.
+        """
+        team_id = uuid.uuid4()
+        for seq in (1, 2, 3):
+            event_store.save_event(make_persisted_event(team_id=team_id, sequence=seq))
+
+        cursor = event_store.load_events(team_id)[-1].event.id
+        assert event_store.load_events(team_id, after_event_id=cursor) == []
+
+        event_store.save_event(make_persisted_event(team_id=team_id, sequence=4))
+
+        fresh = event_store.load_events(team_id, after_event_id=cursor)
+        assert [e.sequence for e in fresh] == [4]
+
     # --- get_max_sequence -------------------------------------------------
 
     def test_get_max_sequence_returns_zero_when_empty(self, event_store: EventStore) -> None:

--- a/tests/repositories/test_event_store_contract.py
+++ b/tests/repositories/test_event_store_contract.py
@@ -165,6 +165,19 @@ class TestEventStoreContract:
         assert [e.event.id for e in with_none] == [e.event.id for e in no_arg]
         assert [e.sequence for e in with_none] == [1, 2, 3]
 
+    def test_load_events_after_event_id_excludes_anchor(self, event_store: EventStore) -> None:
+        """A resolving anchor yields the strict tail — the anchor itself is excluded."""
+        team_id = uuid.uuid4()
+        for seq in (1, 2, 3, 4, 5):
+            event_store.save_event(make_persisted_event(team_id=team_id, sequence=seq))
+
+        anchor = event_store.load_events(team_id)[2]
+        assert anchor.sequence == 3
+
+        tail = event_store.load_events(team_id, after_event_id=anchor.event.id)
+        assert [e.sequence for e in tail] == [4, 5]
+        assert anchor.event.id not in [e.event.id for e in tail]
+
     def test_load_events_unknown_after_event_id_raises(self, event_store: EventStore) -> None:
         """An anchor that was never persisted raises rather than returning ``[]``.
 

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -52,16 +52,18 @@ class InMemoryEventStore:
         Round-trips through model_dump/model_validate so that
         ActorAddressImpl becomes ActorAddressProxy, matching real
         persistence backends (YAML, MongoDB). Honours the same tail-slice
-        contract as the real backends.
+        contract as the real backends, which slice a ``sequence``-ordered
+        list — so sort before slicing rather than trusting insertion order.
 
         Raises:
             EventNotFoundError: If ``after_event_id`` does not resolve to an
                 event of this team.
         """
         tid = str(team_id)
-        events = [
-            PersistedEvent.model_validate(d) for d in self._event_dicts if d["team_id"] == tid
-        ]
+        events = sorted(
+            (PersistedEvent.model_validate(d) for d in self._event_dicts if d["team_id"] == tid),
+            key=lambda e: e.sequence,
+        )
         if after_event_id is None:
             return events
         # event.id is persisted as a string, so compare stringified ids.

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -7,6 +7,7 @@ import uuid
 from typing import Any
 
 from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process
+from akgentic.team.ports import EventNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -43,15 +44,31 @@ class InMemoryEventStore:
             # those tests never call load_events, so a missing dict is safe.
             logger.debug("Event serialization skipped (mock sender): %s", type(event.event))
 
-    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
-        """Load all persisted events for a team (deserialized from dicts).
+    def load_events(
+        self, team_id: uuid.UUID, after_event_id: uuid.UUID | None = None
+    ) -> list[PersistedEvent]:
+        """Load persisted events for a team (deserialized from dicts).
 
         Round-trips through model_dump/model_validate so that
         ActorAddressImpl becomes ActorAddressProxy, matching real
-        persistence backends (YAML, MongoDB).
+        persistence backends (YAML, MongoDB). Honours the same tail-slice
+        contract as the real backends.
+
+        Raises:
+            EventNotFoundError: If ``after_event_id`` does not resolve to an
+                event of this team.
         """
         tid = str(team_id)
-        return [PersistedEvent.model_validate(d) for d in self._event_dicts if d["team_id"] == tid]
+        events = [
+            PersistedEvent.model_validate(d) for d in self._event_dicts if d["team_id"] == tid
+        ]
+        if after_event_id is None:
+            return events
+        # event.id is persisted as a string, so compare stringified ids.
+        for index, event in enumerate(events):
+            if str(event.event.id) == str(after_event_id):
+                return events[index + 1 :]
+        raise EventNotFoundError(f"Event {after_event_id} not found for team {team_id}")
 
     def save_team(self, process: Process) -> None:
         """Persist team process snapshot."""


### PR DESCRIPTION
Epic 24 ships an additive `after_event_id` cursor on `EventStore.load_events`, so incremental readers fetch only what they have not seen instead of re-hydrating a team's entire history on every poll. A stale cursor raises `EventNotFoundError` rather than silently degrading into the full-log read the cursor exists to eliminate.

## Stories in this slice

- [x] **24-1** — `EventStore` Protocol `after_event_id` parameter + `EventNotFoundError` (Relates to #138)
- [x] **24-3** — Mongo `load_events` anchor resolve, `$gt` push-down, and `event.id` index (Relates to #140)

## Epic 24 slice complete

Both in-scope stories are `done`. This PR is the complete epic-24 slice for the `version-1.3.1` line.

**What landed:**

- **24-1** — additive `after_event_id: uuid.UUID | None = None` on the `EventStore` Protocol, the new `EventNotFoundError(LookupError)` exported from the package's public surface, and interim in-memory tail slices in all three backends so the contract holds everywhere from day one.
- **24-3** — the Mongo backend's real push-down: the anchor resolves through a projected, indexed `find_one` returning one integer, and `{"sequence": {"$gt": n}}` is added to the existing `find` so MongoDB does the filtering. Ships with `events_team_event_id_idx` on `(team_id, event.id)` — the index is the load-bearing half, since `event.id` is a nested field that MongoDB would otherwise collection-scan, and without it the change would have traded a full-history hydration for a full-collection scan plus a range query.

**What is deferred and why:**

Stories **24-2** (YAML push-down) and **24-4** (Postgres push-down) stay in `backlog` by user decision. Their 24-1 interim stubs **are intended to remain in place** — they honour the same contract and are not incomplete work. `epic-24` therefore stays `in-progress`, not `done`.

**Verification — local only:**

CI cannot run on this line at all. `ci.yml` pins the workspace checkout to `akgentic-quick-start@feat/enterprise-alpha-release-4`, whose `.gitmodules` declares only `infra-enterprise` and `infra-department` — `packages/akgentic-team` is absent, so the quality job dies at checkout in ~35s and never executes a test. This is deterministic and pre-existing, not caused by this PR:

| Evidence | Result |
|---|---|
| bare `version-1.3.1` tip, no epic-24 code (run `28490832185`) | fails identically at checkout |
| the same story code on `master` (run `29503326042`) | passed in 1m21s |

Golden Rule #7 is **waived for this epic by explicit user decision**, recorded in the epic-24 block of `sprint-status.yaml`. The CI harness is deliberately not being fixed on this line. Verification is local, and reported below.

## Base branch

This PR targets **`version-1.3.1`**, not `master`. Epic 24 ships on the version-1.3.1 / enterprise-alpha line by product decision.

`version-1.3.1` and `master` are **divergent** branches — not fast-forwardable. The branch was originally cut from `master` and has been rebased onto `version-1.3.1`; it now carries exactly the epic's commits on top of that base. Do not retarget this PR at `master`.

CI on this line is pinned to `feat/enterprise-alpha-release-4` (commit `6dfd7d8`), so it is a different pipeline from `master`'s.

## Deferred

Stories **24-2** (YAML push-down) and **24-4** (Postgres push-down) remain in `backlog` by user decision and are **not** part of this slice.

Consequently the interim in-memory tail slices that 24-1 ships for the YAML and Postgres backends **are intended to remain in place**. They are not incomplete work and should not be flagged as such. The YAML backend keeps an in-memory slice permanently by design; only the database backends were ever slated for real query-engine push-downs.

One accepted, documented divergence: a corrupt-but-present anchor resolves on Mongo (a projected read reaches `sequence` without validating the payload) but raises on YAML (which hydrates first). `EventNotFoundError` signals absence, not integrity, so YAML's behaviour is a known gap handed to deferred story 24-2. It is deliberately **not** a shared contract test, since a parametrized assertion would pin the wrong behaviour on one backend.

## Known pre-existing base flake

`version-1.3.1` is **flaky-red on its own, independent of this PR**. Verified by running the full suite against the bare base *without* the epic's commits:

| Run | Result | Failing tests |
|---|---|---|
| bare `version-1.3.1` #1 | 2 failed / 339 passed | `test_stop_after_resume_triggers_on_stop_fanout`, `test_stop_running_team_succeeds` |
| bare `version-1.3.1` #2 | 2 failed / 339 passed | `test_resume_no_duplicate_subscriber_creation`, `test_stop_running_team_triggers_on_stop_fanout` |
| this branch #1 | 347 passed / 0 failed | — |
| this branch #2 | 3 failed / 344 passed | same family |
| this branch, 24-3 review, randomized | 2 failed / 368 passed | `test_stop_after_resume_triggers_on_stop_fanout`, `test_stop_running_team_triggers_on_stop_fanout` |
| this branch, 24-3 review, ordered (`-p no:randomly`) | 370 passed / 0 failed | — |

Different tests fail on each run — the failures are **nondeterministic**. All live in `tests/services/test_manager.py`, in the on-stop fan-out / actor-teardown family, and all pass when run in isolation or in deterministic order.

**Root cause** (diagnosed, not speculation): `Orchestrator.stop(grace_timeout)` in `akgentic-core` is non-blocking and returns a `threading.Event`. The team code on this line does not wait on that Event, so `stop_team()` returns before the orchestrator has died and the assertions race. The fix that waits on it exists only on `master` and is deliberately not being backported — no new work is being integrated into the 1.3.1 line beyond this epic's decision.

This flake is therefore **out of scope for this PR by user decision** and is not a regression introduced here. If a run fails *only* on that test family, it is this known base defect.

## Review status

**24-1 — done.** Reviewed commit `8e39b13`; review fixes in `f4465ff`.

All 10 acceptance criteria implemented. Verified independently on the rebased base: mypy strict clean (19 source files), ruff clean, coverage 95.25% (gate: 80%). The Protocol docstring carries Args, anchor exclusivity, `None` = full log, `Raises:`, and the push-down requirement, mirroring the existing `list_teams` house style.

Three issues found and fixed — all **verification gaps, no implementation defects**:

| Sev | Finding | Fix |
|---|---|---|
| HIGH | Anchor-exclusivity had no test on any backend. The suite asserted only `None`-equivalence and unknown-anchor-raises, so a slice returning `events[index:]` — anchor *included* — passed every test on all three backends. | Added a parametrized contract test; confirmed it fails against that exact mutation while the other eight cursor tests still passed, proving the prior gap. |
| MEDIUM | The `EventNotFoundError` base class was unguarded. It subclasses `LookupError` rather than `ValueError` so the corrupted-document handlers in the YAML and Mongo backends cannot swallow a stale cursor — but nothing failed if that were reverted. | Added a base-class contract test. |
| MEDIUM | The `InMemoryEventStore` test fake sliced an insertion-ordered list while every real backend slices a `sequence`-ordered one, so it could return a different tail than the contract it mirrors. | Sort by `sequence` before slicing. |

Noted, not fixed (LOW, cosmetic — changing them would add unrelated diff noise): the `"Loaded %d events"` debug line reports the pre-slice count on a cursored read, and `_unreadable_log` reads as a verb phrase.

**24-3 — done.** Reviewed commit `7ee0859`. **No fixup commit was required** — no HIGH or MEDIUM issues found.

All 12 acceptance criteria implemented; all 5 tasks verified genuinely done. Every ADR-21 §5 contract point was checked against the code rather than taken on trust:

- Anchor resolve is exactly the specified shape — projected `find_one({"team_id": str(team_id), "event.id": str(after_event_id)}, projection={"sequence": 1, "_id": 0})`, `None` → `EventNotFoundError`, otherwise `{"sequence": {"$gt": n}}` on the existing `find`. Extracted into a `_resolve_anchor_sequence` helper, which is the extraction the story's own Dev Notes prescribe.
- `str()` coercion is present on **both** ids. This is genuinely load-bearing under the fixture, not just on a real server: mongomock stores `event.id` as a string, so a raw `uuid.UUID` matches nothing there either and the cursor tests would fail. The coercion is not a same-fake round-trip artefact.
- The index is created in `__init__` with the right name and key spec, and is **not** unique — asserted directly (`assert not info[...].get("unique")`). A unique index would convert a read-path ambiguity into a write-path `DuplicateKeyError` on `save_event`, i.e. event-log data loss.
- The existing `[("team_id", 1), ("sequence", 1)]` index is untouched, and a new guard test pins that it is still created.
- `sort("sequence", 1)` is preserved on both the cursored and uncursored paths (one `find`, one `sort`).
- The 24-1 interim tail-slice loop, its `if after_event_id is None: return events` early-return, and its trailing `raise` are all deleted — no post-hydration filtering remains. The corrupted-document skip-with-WARNING loop is preserved verbatim on the range query.
- The new cursor tests assert the **strict tail with the anchor excluded** (`[2,3,4,5]` from a first-event anchor; `[4]` from the round-trip) — they pass a genuinely resolving anchor, closing the gap found in 24-1.
- Golden Rule #8 clean: no test asserts on an `ADR-NNN` string, and the commit message carries none. ADR references appear only in docstrings and comments, which is explicitly allowed.
- Golden Rule #4 clean: all three files are inside `packages/akgentic-team/`.

Noted, not fixed (all LOW — fixing any of them would add cosmetic diff noise to a clean, verified commit and violate one-commit-one-responsibility):

| Finding | Why not fixed |
|---|---|
| `sequence: int = anchor["sequence"]` narrows `Any` → `int` with no runtime validation, to satisfy mypy's `warn_return_any`. A corrupt string `sequence` would silently produce a string `$gt` comparison rather than raising. | Remote: the write path always persists an int via `model_dump()`. Adding coercion would be an unrequested behaviour change, and ADR-21 §2 rules that this error signals absence, not integrity. |
| The idempotency test's `list(info.keys()).count(...) == 1` is tautological — `dict` keys are unique, so it cannot fail once the preceding key assertion passes. | It faithfully mirrors the Epic-19 `teams_user_id_idx` precedent the story explicitly mandated. The test's real content — "second construction must not raise" plus unchanged key spec — is sound. |
| AC2's projection clause is not itself asserted; nothing pins `projection={"sequence": 1, "_id": 0}`. | Asserting it would require spying on `find_one` — testing an implementation detail. Consistent with the story's own accepted caveat that index *effectiveness* is unverifiable under mongomock. |
| The `_resolve_anchor_sequence` docstring and the two index-test docstrings carry design rationale that ADR-21 already owns. | The BSON `Binary` subtype-4 note earns its place: it is precisely the trap that would tempt a future reader to "simplify" the `str()` away and break every cursored call silently. |

**Fixture caveat, recorded not defected:** the Mongo fixtures are **mongomock**, not testcontainers (which is Postgres-only in this submodule). mongomock records dotted-path indexes and serves dot-notation queries, and it declines only to enforce nested *uniqueness* — irrelevant here, since this index is deliberately not unique. It therefore proves query shape and index registration, but **not** that a real MongoDB planner selects the index. Index effectiveness is not claimed by any AC. The epic text's instruction to verify this index "via the testcontainers fixture" is wrong for this backend and was correctly not followed.

**Local verification of `7ee0859` (CI not run — harness broken on this line, see above):**

- `pytest packages/akgentic-team/tests/` → **368 passed, 2 failed, 5 skipped, 1 deselected**. Both failures are the known base flake above; a deterministic-order run of the same code was **370 passed, 0 failed**.
- `pytest packages/akgentic-team/tests/repositories/` → **129 passed, 5 skipped, 0 failed**.
- `mypy packages/akgentic-team/src/` → clean, 19 source files.
- `ruff check` on `src/` and `tests/repositories/` → clean.

**Skip accounting** (a skip is not a pass): the 5 skips are 2 CI-only `test_ci_env_wiring.py` cases (`DB_CONN_STRING_PERSISTENCE` unset) and 3 deliberate per-backend `test_validation_failure_propagates_pydantic_error` slots. **Postgres was not skipped** — Docker was available, the testcontainers fixture ran, and all 8 `[postgres]` cursor params passed. The new FR6 cases therefore genuinely executed against the yaml and postgres 24-1 stubs, so no HALT was warranted.

## Scope guard

All changes stay inside `packages/akgentic-team/`. The full branch diff against `version-1.3.1` touches 9 files, all within this submodule:

```
src/akgentic/team/__init__.py
src/akgentic/team/ports.py
src/akgentic/team/repositories/mongo.py
src/akgentic/team/repositories/postgres/event_store.py
src/akgentic/team/repositories/yaml.py
tests/models/test_ports.py
tests/repositories/mongo/test_mongo.py
tests/repositories/test_event_store_contract.py
tests/services/conftest.py
```

No Postgres index DDL, no schema change, no new dependencies, no new files. 24-3 adds exactly one index — `events_team_event_id_idx`, created idempotently in `MongoEventStore.__init__`. The `EventStore` test fakes in `akgentic-infra`, `akgentic-infra-enterprise`, `akgentic-infra-department`, and `sdworx-core` will need the widened signature to satisfy mypy strict; each is a separate story in its own submodule's sprint and is deliberately untouched here.

The `ruff format` non-cleanliness of `yaml.py`, `mongo.py`, and `postgres/event_store.py` is **pre-existing on this base** and was deliberately not touched — CI runs `ruff check` (green), not `ruff format`, and reformatting would add unrelated diff noise.
