### PR TITLE
fix(akgentic-team): use a guarded single-field event.id index

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akgentic-team"
-version = "1.3.3"
+version = "1.3.4"
 description = "Team lifecycle management — create, resume, stop, delete teams with event-sourced persistence"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/akgentic/team/repositories/mongo.py
+++ b/src/akgentic/team/repositories/mongo.py
@@ -35,6 +35,8 @@ except ImportError as exc:
         "Install with: pip install akgentic-team[mongo]"
     ) from exc
 
+from pymongo.errors import PyMongoError
+
 from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process
 from akgentic.team.ports import EventNotFoundError
 
@@ -98,11 +100,26 @@ class MongoEventStore:
         # already exists, so this is safe across redeploys.
         self._teams.create_index("user_id", name="teams_user_id_idx")
         # ADR-21 §5: backs the load_events(after_event_id=...) anchor lookup.
+        # Single-field on the nested path, NOT compound with team_id: Cosmos for
+        # MongoDB rejects compound indexes on nested paths unless the account sets
+        # EnableUniqueCompoundNestedDocs, and event.id is a uuid4 — already maximally
+        # selective, so leading with team_id buys nothing for this equality lookup.
         # Not unique — a unique index would turn a read-path ambiguity into a
         # write-path DuplicateKeyError on save_event.
-        self._events.create_index(
-            [("team_id", 1), ("event.id", 1)], name="events_team_event_id_idx"
-        )
+        # Guarded: the index is a performance optimization, not a correctness
+        # requirement. If the backend rejects the spec, the anchor lookup degrades
+        # to a collection scan and load_events still returns the right events —
+        # which beats failing construction and refusing to start the process.
+        try:
+            self._events.create_index("event.id", name="events_event_id_idx")
+        except PyMongoError:
+            logger.warning(
+                "Could not create index 'events_event_id_idx' on '%s.event.id'; "
+                "load_events(after_event_id=...) anchor lookups will fall back to a "
+                "collection scan and degrade on large event logs. Results stay correct.",
+                events_name,
+                exc_info=True,
+            )
         logger.debug("Initialized MongoEventStore with database '%s'", db.name)
 
     def save_team(self, process: Process) -> None:

--- a/tests/repositories/mongo/test_mongo.py
+++ b/tests/repositories/mongo/test_mongo.py
@@ -14,10 +14,14 @@ once per backend. This module retains only Mongo-specific invariants:
 
 from __future__ import annotations
 
+import logging
 import os
 import uuid
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
+
+import pytest
+from pymongo.errors import OperationFailure
 
 from akgentic.team.repositories.mongo import MongoEventStore
 
@@ -140,23 +144,26 @@ class TestMongoEventStoreMongoSpecific:
 
     # --- event.id index presence --------------------------------------------
 
-    def test_events_team_event_id_index_created_on_init(
+    def test_events_event_id_index_created_on_init(
         self, mongo_store: MongoEventStore, mongo_db: Any
     ) -> None:
-        """``__init__`` creates ``events_team_event_id_idx`` on ``events``.
+        """``__init__`` creates ``events_event_id_idx`` on ``events``.
 
-        Compound ascending key on ``team_id`` + the nested ``event.id``,
-        backing the anchor lookup in ``load_events(after_event_id=...)``
-        (ADR-21 §5). Deliberately not unique: a unique index would turn a
-        read-path ambiguity into a write-path ``DuplicateKeyError`` on
-        ``save_event``.
+        Single-field ascending key on the nested ``event.id``, backing the
+        anchor lookup in ``load_events(after_event_id=...)``. Deliberately
+        NOT compound with ``team_id``: Cosmos for MongoDB rejects compound
+        indexes on nested paths unless the account enables
+        ``EnableUniqueCompoundNestedDocs``, and ``event.id`` is a uuid4 —
+        already maximally selective for this equality lookup. Deliberately
+        not unique: a unique index would turn a read-path ambiguity into a
+        write-path ``DuplicateKeyError`` on ``save_event``.
         """
         info = mongo_db["events"].index_information()
-        assert "events_team_event_id_idx" in info
-        assert info["events_team_event_id_idx"]["key"] == [("team_id", 1), ("event.id", 1)]
-        assert not info["events_team_event_id_idx"].get("unique")
+        assert "events_event_id_idx" in info
+        assert info["events_event_id_idx"]["key"] == [("event.id", 1)]
+        assert not info["events_event_id_idx"].get("unique")
 
-    def test_events_team_event_id_index_creation_is_idempotent(
+    def test_events_event_id_index_creation_is_idempotent(
         self, mongo_store: MongoEventStore, mongo_db: Any
     ) -> None:
         """Re-running the constructor against the same database does not raise.
@@ -170,8 +177,33 @@ class TestMongoEventStoreMongoSpecific:
         MongoEventStore(mongo_db)  # second construction — must not raise
 
         info = mongo_db["events"].index_information()
-        assert info["events_team_event_id_idx"]["key"] == [("team_id", 1), ("event.id", 1)]
-        assert list(info.keys()).count("events_team_event_id_idx") == 1
+        assert info["events_event_id_idx"]["key"] == [("event.id", 1)]
+        assert list(info.keys()).count("events_event_id_idx") == 1
+
+    def test_index_rejection_is_logged_and_does_not_block_construction(
+        self, mongo_db: Any, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A backend that rejects the event.id spec must not stop the process.
+
+        Cosmos for MongoDB rejects compound-on-nested by default and may
+        reject other specs depending on account capabilities. The index is a
+        performance optimization, not a correctness requirement — so
+        construction logs and continues rather than raising, which would
+        refuse to start the server on every replica.
+        """
+        real_create_index = type(mongo_db["events"]).create_index
+
+        def _reject_event_id(self: Any, keys: Any, **kwargs: Any) -> Any:
+            if keys == "event.id":
+                raise OperationFailure("index not supported on this account")
+            return real_create_index(self, keys, **kwargs)
+
+        with patch.object(type(mongo_db["events"]), "create_index", _reject_event_id):
+            with caplog.at_level(logging.WARNING):
+                MongoEventStore(mongo_db)  # must NOT raise
+
+        assert "events_event_id_idx" in caplog.text
+        assert "collection scan" in caplog.text
 
     def test_existing_events_team_sequence_index_still_created(
         self, mongo_store: MongoEventStore, mongo_db: Any


### PR DESCRIPTION
Fixes #142. Follow-up to #139 (epic 24), found while assessing deployment readiness.

## What was wrong

Epic 24 added the ADR-21 anchor-lookup index to `MongoEventStore.__init__`, unguarded:

```python
self._events.create_index(
    [("team_id", 1), ("event.id", 1)], name="events_team_event_id_idx"
)
```

**1. Unsupported by default on the deployment target.** Per [Microsoft's Cosmos DB for MongoDB indexing docs](https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/indexing):

> "Compound indexes on nested fields aren't supported by default because of limitations with arrays... Enable this feature for your database account by enabling the **'EnableUniqueCompoundNestedDocs'** capability."

That spec is a compound index over a nested path — exactly the unsupported case. It can work (no array on the path), but only on an account with that capability set, which this design never required and cannot assume. The target is Cosmos for MongoDB — not a guess: `save_team`/`save_agent_state` already carry shard-key-safe-upsert hardening for it.

**2. A rejected spec stops the server booting.** `create_index` is on the construction path with no error handling. A rejection doesn't degrade a read path — it raises, on every replica. The Mongo suite is mongomock-only, and mongomock records dotted-path specs without validating them, so nothing caught it.

## The fix

```python
try:
    self._events.create_index("event.id", name="events_event_id_idx")
except PyMongoError:
    logger.warning(...)  # states the consequence, not just the error
```

**Single-field is correct, not a workaround.** Same Microsoft page: *"For queries with multiple filters that don't need to sort, create multiple single field indexes instead of a compound index"* and *"A compound index or single field indexes for each field in the compound index result in the same performance for filtering in queries."* The anchor lookup is `find_one({"team_id": ..., "event.id": ...})` — multi-filter, no sort.

It's also the better index on stock MongoDB. `event.id` is a **uuid4** — already maximally selective, resolving to ~1 document, after which `team_id` is a free check on that doc. The leading-`team_id` composite buys nothing for an equality lookup on a near-unique key. ADR-21 originally argued the composite from "the lookup always filters on both" — true, but the relevant property is cardinality, not the filter's shape.

**Why guard.** The index is a performance optimization, not a correctness requirement: without it the anchor lookup falls back to a collection scan and `load_events(after_event_id=...)` still returns exactly the right events. Slow beats dead. Only this index is guarded — the three pre-existing ones are proven against the real target and load-bearing; wrapping them would mask genuine failures. `PyMongoError` rather than bare `Exception` (Cosmos raises `OperationFailure`, a subclass); the guard is naturally narrow, since an unreachable database fails the three earlier calls first.

The existing `(team_id, sequence)` index still backs the `$gt` range filter and is unchanged.

## Changes

- `src/akgentic/team/repositories/mongo.py` — spec + guard + import
- `tests/repositories/mongo/test_mongo.py` — assertions follow the spec; **new test** that a rejected spec logs and still constructs
- ADR-21 §5 — Amendments 2026-07-16 (a) and (b) (planning repo)

## Verification

Local — `version-1.3.1` CI cannot run (see #141: the workspace pin lacks the `akgentic-team` submodule, so the job dies at checkout; Golden Rule #7 waived for this line by decision):

- mypy strict: clean, 19 source files
- ruff check: clean
- mongo suite: **20 passed**
- full suite: **368 passed**, 3 failed — all in the known pre-existing `test_manager.py` `on_stop`/teardown flake family (this line lacks 22-1/ADR-19; varies run to run; unrelated to this change)

## Caveat

Cited docs are the **RU-based** API. On Cosmos **vCore** / Azure DocumentDB parity is closer and the compound-nested limit may not apply — but the single-field index is safe on all three targets, so it's right regardless. **No doc substitutes for constructing a `MongoEventStore` against the real target once** — that verification is still outstanding, and this PR makes its failure survivable rather than fatal.
