### PR TITLE
chore(akgentic-team): port epic 24 load_events(after_event_id) cursor slice to master

### DIFF
--- a/src/akgentic/team/__init__.py
+++ b/src/akgentic/team/__init__.py
@@ -19,6 +19,7 @@ from akgentic.team.models import (
     TeamStatus,
 )
 from akgentic.team.ports import (
+    EventNotFoundError,
     EventStore,
     NullServiceRegistry,
     ServiceRegistry,
@@ -32,6 +33,7 @@ __version__ = "1.0.0-alpha.2"
 __all__: list[str] = [
     "__version__",
     "AgentStateSnapshot",
+    "EventNotFoundError",
     "EventStore",
     "NullServiceRegistry",
     "PersistenceSubscriber",

--- a/src/akgentic/team/ports.py
+++ b/src/akgentic/team/ports.py
@@ -12,6 +12,14 @@ from akgentic.team.models import (
 )
 
 
+class EventNotFoundError(LookupError):
+    """Raised when ``load_events(after_event_id=...)`` cannot resolve the anchor.
+
+    Subclasses ``LookupError`` — never ``ValueError`` — so the corrupted-document
+    handlers in the YAML and Mongo backends cannot swallow a stale cursor.
+    """
+
+
 class EventStore(Protocol):
     """Typed persistence surface for team event sourcing.
 
@@ -27,10 +35,29 @@ class EventStore(Protocol):
         """
         ...
 
-    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
-        """Load all persisted events for a team.
+    def load_events(
+        self, team_id: uuid.UUID, after_event_id: uuid.UUID | None = None
+    ) -> list[PersistedEvent]:
+        """Load persisted events for a team, ordered by ``sequence`` ASC.
 
-        Called by TeamRestorer to replay events during team resumption.
+        Args:
+            team_id: Team whose events to load.
+            after_event_id: If provided, return only events persisted *after*
+                the event whose ``event.id`` matches — exclusive of the anchor
+                itself. If ``None`` (default), return the full log, which is
+                what TeamRestorer replays on resume.
+
+        Raises:
+            EventNotFoundError: If ``after_event_id`` is not an event of this
+                team. A stale cursor MUST fail loudly, never silently degrade
+                into a full-log return.
+
+        Implementations MUST resolve the anchor to its ``sequence`` and push a
+        ``sequence > N`` range filter down to the backend (SQL WHERE, Mongo find
+        filter, list slice) rather than load-all-then-filter in Python — the
+        infra read path calls this per client poll.
+
+        See ADR-21 §1 for the additive, backwards-compatible Protocol change.
         """
         ...
 

--- a/src/akgentic/team/repositories/mongo.py
+++ b/src/akgentic/team/repositories/mongo.py
@@ -25,6 +25,7 @@ except ImportError as exc:
     ) from exc
 
 from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process
+from akgentic.team.ports import EventNotFoundError
 
 if TYPE_CHECKING:
     import pymongo.collection
@@ -61,6 +62,12 @@ class MongoEventStore:
         # same database returns silently when an index with the same key spec
         # already exists, so this is safe across redeploys.
         self._teams.create_index("user_id", name="teams_user_id_idx")
+        # ADR-21 §5: backs the load_events(after_event_id=...) anchor lookup.
+        # Not unique — a unique index would turn a read-path ambiguity into a
+        # write-path DuplicateKeyError on save_event.
+        self._events.create_index(
+            [("team_id", 1), ("event.id", 1)], name="events_team_event_id_idx"
+        )
         logger.debug("Initialized MongoEventStore with database '%s'", db.name)
 
     def save_team(self, process: Process) -> None:
@@ -147,19 +154,31 @@ class MongoEventStore:
         self._events.insert_one(doc)
         logger.debug("Saved event seq=%d for team %s", event.sequence, event.team_id)
 
-    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
-        """Load all persisted events for a team, ordered by sequence.
+    def load_events(
+        self, team_id: uuid.UUID, after_event_id: uuid.UUID | None = None
+    ) -> list[PersistedEvent]:
+        """Load persisted events for a team, ordered by sequence.
 
-        Queries the ``events`` collection by ``team_id`` and sorts by
-        ``sequence`` ascending.
+        Both the anchor resolve and the ``sequence > N`` range filter run in
+        MongoDB — the anchor via an indexed, projected ``find_one``, the range
+        as a ``$gt`` clause on the find (ADR-21 §5).
 
         Args:
             team_id: Unique identifier of the team.
+            after_event_id: If provided, return only events after the matching
+                event — anchor excluded. If ``None`` (default), the full log.
 
         Returns:
             List of PersistedEvent ordered by sequence, or empty list if none.
+
+        Raises:
+            EventNotFoundError: If ``after_event_id`` does not resolve to an
+                event of this team.
         """
-        cursor = self._events.find({"team_id": str(team_id)}).sort("sequence", 1)
+        query: dict[str, object] = {"team_id": str(team_id)}
+        if after_event_id is not None:
+            query["sequence"] = {"$gt": self._resolve_anchor_sequence(team_id, after_event_id)}
+        cursor = self._events.find(query).sort("sequence", 1)
         events: list[PersistedEvent] = []
         for doc in cursor:
             doc.pop("_id", None)
@@ -171,6 +190,26 @@ class MongoEventStore:
                 )
         logger.debug("Loaded %d events for team %s", len(events), team_id)
         return events
+
+    def _resolve_anchor_sequence(self, team_id: uuid.UUID, after_event_id: uuid.UUID) -> int:
+        """Return the ``sequence`` of the cursor anchor, or raise if absent.
+
+        ``event.id`` is persisted as a string, so both ids are coerced with
+        ``str()``: a raw ``uuid.UUID`` would be BSON-encoded as Binary
+        subtype-4 and match nothing. The projection keeps this to a single
+        indexed lookup returning one integer — the document is never hydrated.
+
+        Raises:
+            EventNotFoundError: If the anchor is not an event of this team.
+        """
+        anchor = self._events.find_one(
+            {"team_id": str(team_id), "event.id": str(after_event_id)},
+            projection={"sequence": 1, "_id": 0},
+        )
+        if anchor is None:
+            raise EventNotFoundError(f"Event {after_event_id} not found for team {team_id}")
+        sequence: int = anchor["sequence"]
+        return sequence
 
     def get_max_sequence(self, team_id: uuid.UUID) -> int:
         """Return the highest event sequence number for a team, or 0.

--- a/src/akgentic/team/repositories/mongo.py
+++ b/src/akgentic/team/repositories/mongo.py
@@ -24,6 +24,8 @@ except ImportError as exc:
         "Install with: pip install akgentic-team[mongo]"
     ) from exc
 
+from pymongo.errors import PyMongoError
+
 from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process
 from akgentic.team.ports import EventNotFoundError
 
@@ -63,11 +65,26 @@ class MongoEventStore:
         # already exists, so this is safe across redeploys.
         self._teams.create_index("user_id", name="teams_user_id_idx")
         # ADR-21 §5: backs the load_events(after_event_id=...) anchor lookup.
+        # Single-field on the nested path, NOT compound with team_id: Cosmos for
+        # MongoDB rejects compound indexes on nested paths unless the account sets
+        # EnableUniqueCompoundNestedDocs, and event.id is a uuid4 — already maximally
+        # selective, so leading with team_id buys nothing for this equality lookup.
         # Not unique — a unique index would turn a read-path ambiguity into a
         # write-path DuplicateKeyError on save_event.
-        self._events.create_index(
-            [("team_id", 1), ("event.id", 1)], name="events_team_event_id_idx"
-        )
+        # Guarded: the index is a performance optimization, not a correctness
+        # requirement. If the backend rejects the spec, the anchor lookup degrades
+        # to a collection scan and load_events still returns the right events —
+        # which beats failing construction and refusing to start the process.
+        try:
+            self._events.create_index("event.id", name="events_event_id_idx")
+        except PyMongoError:
+            logger.warning(
+                "Could not create index 'events_event_id_idx' on '%s.event.id'; "
+                "load_events(after_event_id=...) anchor lookups will fall back to a "
+                "collection scan and degrade on large event logs. Results stay correct.",
+                self._events.name,
+                exc_info=True,
+            )
         logger.debug("Initialized MongoEventStore with database '%s'", db.name)
 
     def save_team(self, process: Process) -> None:

--- a/src/akgentic/team/repositories/postgres/event_store.py
+++ b/src/akgentic/team/repositories/postgres/event_store.py
@@ -21,6 +21,7 @@ import uuid
 from nagra import Transaction  # type: ignore[import-untyped]
 
 from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process
+from akgentic.team.ports import EventNotFoundError
 from akgentic.team.repositories.postgres._queries import decode_jsonb_column
 
 
@@ -125,8 +126,20 @@ class NagraEventStore:
                 (str(event.team_id), event.sequence, data),
             )
 
-    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
-        """Return all events for a team ordered by ``sequence`` ASC."""
+    def load_events(
+        self, team_id: uuid.UUID, after_event_id: uuid.UUID | None = None
+    ) -> list[PersistedEvent]:
+        """Return events for a team ordered by ``sequence`` ASC.
+
+        Args:
+            team_id: Team whose events to load.
+            after_event_id: If provided, return only events after the matching
+                event — anchor excluded. If ``None`` (default), the full log.
+
+        Raises:
+            EventNotFoundError: If ``after_event_id`` does not resolve to an
+                event of this team.
+        """
         with Transaction(self._conn_string) as trn:
             cursor = trn.execute(
                 "SELECT data FROM event_entries WHERE team_id = %s "
@@ -134,7 +147,15 @@ class NagraEventStore:
                 (str(team_id),),
             )
             rows = cursor.fetchall()
-        return [PersistedEvent.model_validate(decode_jsonb_column(r[0])) for r in rows]
+        events = [PersistedEvent.model_validate(decode_jsonb_column(r[0])) for r in rows]
+        if after_event_id is None:
+            return events
+        # Interim in-memory slice; the range-query push-down lands in story 24-4.
+        # event.id is persisted as a string, so compare stringified ids.
+        for index, event in enumerate(events):
+            if str(event.event.id) == str(after_event_id):
+                return events[index + 1 :]
+        raise EventNotFoundError(f"Event {after_event_id} not found for team {team_id}")
 
     def get_max_sequence(self, team_id: uuid.UUID) -> int:
         """Return the largest sequence for a team, or ``0`` if empty.

--- a/src/akgentic/team/repositories/yaml.py
+++ b/src/akgentic/team/repositories/yaml.py
@@ -25,6 +25,7 @@ from pathlib import Path
 import yaml
 
 from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process
+from akgentic.team.ports import EventNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -169,28 +170,49 @@ class YamlEventStore:
             yaml.dump(data, f, default_flow_style=False)
         logger.debug("Appended event seq=%d for team %s", event.sequence, event.team_id)
 
-    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
-        """Load all persisted events for a team from events.yaml.
+    @staticmethod
+    def _unreadable_log(
+        team_id: uuid.UUID, after_event_id: uuid.UUID | None
+    ) -> list[PersistedEvent]:
+        """Result for a team whose events.yaml is absent or unparseable.
 
-        Reads multi-document YAML and reconstructs each document as a
-        PersistedEvent, returned sorted by sequence number.
+        Raises:
+            EventNotFoundError: If a cursor was passed — an unreadable log
+                cannot resolve an anchor, and ``[]`` would be read by the
+                caller as "you are already up to date".
+        """
+        if after_event_id is not None:
+            raise EventNotFoundError(f"Event {after_event_id} not found for team {team_id}")
+        return []
+
+    def load_events(
+        self, team_id: uuid.UUID, after_event_id: uuid.UUID | None = None
+    ) -> list[PersistedEvent]:
+        """Load persisted events for a team from events.yaml, ordered by sequence.
 
         Args:
             team_id: Unique identifier of the team.
+            after_event_id: If provided, return only events after the matching
+                event — anchor excluded. If ``None`` (default), the full log.
 
         Returns:
-            List of PersistedEvent ordered by sequence, or empty list if
-            no events file exists.
+            List of PersistedEvent ordered by sequence, or empty list if no
+            events file exists and no cursor was passed.
+
+        Raises:
+            EventNotFoundError: If ``after_event_id`` does not resolve to an
+                event of this team, including when the events file is absent
+                or unparseable.
         """
         events_path = self._team_dir(team_id) / "events.yaml"
         if not events_path.exists():
-            return []
+            return self._unreadable_log(team_id, after_event_id)
         try:
             with open(events_path) as f:
                 docs = list(yaml.safe_load_all(f))
         except yaml.YAMLError as exc:
             logger.error("Corrupted events.yaml for team %s: %s", team_id, exc)
-            return []
+            return self._unreadable_log(team_id, after_event_id)
         events: list[PersistedEvent] = []
         for doc in docs:
             if doc is None:
@@ -202,7 +224,15 @@ class YamlEventStore:
                     "Skipping corrupted event for team %s: %s", team_id, exc
                 )
         logger.debug("Loaded %d events for team %s", len(events), team_id)
-        return sorted(events, key=lambda e: e.sequence)
+        ordered = sorted(events, key=lambda e: e.sequence)
+        if after_event_id is None:
+            return ordered
+        # Interim in-memory slice; YAML keeps it permanently (ADR-21 §4).
+        # event.id is persisted as a string, so compare stringified ids.
+        for index, event in enumerate(ordered):
+            if str(event.event.id) == str(after_event_id):
+                return ordered[index + 1 :]
+        raise EventNotFoundError(f"Event {after_event_id} not found for team {team_id}")
 
     def get_max_sequence(self, team_id: uuid.UUID) -> int:
         """Return the highest event sequence number for a team, or 0.

--- a/tests/models/test_ports.py
+++ b/tests/models/test_ports.py
@@ -10,13 +10,37 @@ import uuid
 
 import pytest
 
-from akgentic.team.ports import NullServiceRegistry, ServiceRegistry
+from akgentic.team.ports import EventNotFoundError, NullServiceRegistry, ServiceRegistry
 
 
 @pytest.fixture()
 def registry() -> NullServiceRegistry:
     """Shared NullServiceRegistry instance for tests."""
     return NullServiceRegistry()
+
+
+class TestEventNotFoundError:
+    """Verify the exception's base class, which is load-bearing (ADR-21 §2)."""
+
+    def test_is_a_lookup_error(self) -> None:
+        """``EventNotFoundError`` is catchable as the standard "key not here" category."""
+        assert issubclass(EventNotFoundError, LookupError)
+
+    def test_is_not_a_value_error(self) -> None:
+        """A stale cursor must not be swallowed by a corrupted-document handler.
+
+        The YAML and Mongo backends both ``except ValueError`` to skip corrupt
+        documents. If ``EventNotFoundError`` were a ``ValueError``, those
+        handlers would silently absorb it and degrade the cursored read back
+        into the full-log read the cursor exists to avoid.
+        """
+        assert not issubclass(EventNotFoundError, ValueError)
+
+        with pytest.raises(EventNotFoundError):
+            try:
+                raise EventNotFoundError("stale cursor")
+            except ValueError:  # pragma: no cover - must not catch
+                pytest.fail("EventNotFoundError was caught by `except ValueError`")
 
 
 class TestNullServiceRegistry:

--- a/tests/repositories/mongo/test_mongo.py
+++ b/tests/repositories/mongo/test_mongo.py
@@ -14,9 +14,13 @@ once per backend. This module retains only Mongo-specific invariants:
 
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
+
+import pytest
+from pymongo.errors import OperationFailure
 
 from akgentic.team.repositories.mongo import MongoEventStore
 
@@ -136,23 +140,26 @@ class TestMongoEventStoreMongoSpecific:
 
     # --- event.id index presence --------------------------------------------
 
-    def test_events_team_event_id_index_created_on_init(
+    def test_events_event_id_index_created_on_init(
         self, mongo_store: MongoEventStore, mongo_db: Any
     ) -> None:
-        """``__init__`` creates ``events_team_event_id_idx`` on ``events``.
+        """``__init__`` creates ``events_event_id_idx`` on ``events``.
 
-        Compound ascending key on ``team_id`` + the nested ``event.id``,
-        backing the anchor lookup in ``load_events(after_event_id=...)``
-        (ADR-21 §5). Deliberately not unique: a unique index would turn a
-        read-path ambiguity into a write-path ``DuplicateKeyError`` on
-        ``save_event``.
+        Single-field ascending key on the nested ``event.id``, backing the
+        anchor lookup in ``load_events(after_event_id=...)``. Deliberately
+        NOT compound with ``team_id``: Cosmos for MongoDB rejects compound
+        indexes on nested paths unless the account enables
+        ``EnableUniqueCompoundNestedDocs``, and ``event.id`` is a uuid4 —
+        already maximally selective for this equality lookup. Deliberately
+        not unique: a unique index would turn a read-path ambiguity into a
+        write-path ``DuplicateKeyError`` on ``save_event``.
         """
         info = mongo_db["events"].index_information()
-        assert "events_team_event_id_idx" in info
-        assert info["events_team_event_id_idx"]["key"] == [("team_id", 1), ("event.id", 1)]
-        assert not info["events_team_event_id_idx"].get("unique")
+        assert "events_event_id_idx" in info
+        assert info["events_event_id_idx"]["key"] == [("event.id", 1)]
+        assert not info["events_event_id_idx"].get("unique")
 
-    def test_events_team_event_id_index_creation_is_idempotent(
+    def test_events_event_id_index_creation_is_idempotent(
         self, mongo_store: MongoEventStore, mongo_db: Any
     ) -> None:
         """Re-running the constructor against the same database does not raise.
@@ -166,8 +173,33 @@ class TestMongoEventStoreMongoSpecific:
         MongoEventStore(mongo_db)  # second construction — must not raise
 
         info = mongo_db["events"].index_information()
-        assert info["events_team_event_id_idx"]["key"] == [("team_id", 1), ("event.id", 1)]
-        assert list(info.keys()).count("events_team_event_id_idx") == 1
+        assert info["events_event_id_idx"]["key"] == [("event.id", 1)]
+        assert list(info.keys()).count("events_event_id_idx") == 1
+
+    def test_index_rejection_is_logged_and_does_not_block_construction(
+        self, mongo_db: Any, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A backend that rejects the event.id spec must not stop the process.
+
+        Cosmos for MongoDB rejects compound-on-nested by default and may
+        reject other specs depending on account capabilities. The index is a
+        performance optimization, not a correctness requirement — so
+        construction logs and continues rather than raising, which would
+        refuse to start the server on every replica.
+        """
+        real_create_index = type(mongo_db["events"]).create_index
+
+        def _reject_event_id(self: Any, keys: Any, **kwargs: Any) -> Any:
+            if keys == "event.id":
+                raise OperationFailure("index not supported on this account")
+            return real_create_index(self, keys, **kwargs)
+
+        with patch.object(type(mongo_db["events"]), "create_index", _reject_event_id):
+            with caplog.at_level(logging.WARNING):
+                MongoEventStore(mongo_db)  # must NOT raise
+
+        assert "events_event_id_idx" in caplog.text
+        assert "collection scan" in caplog.text
 
     def test_existing_events_team_sequence_index_still_created(
         self, mongo_store: MongoEventStore, mongo_db: Any

--- a/tests/repositories/mongo/test_mongo.py
+++ b/tests/repositories/mongo/test_mongo.py
@@ -134,6 +134,52 @@ class TestMongoEventStoreMongoSpecific:
         assert info["teams_user_id_idx"]["key"] == [("user_id", 1)]
         assert list(info.keys()).count("teams_user_id_idx") == 1
 
+    # --- event.id index presence --------------------------------------------
+
+    def test_events_team_event_id_index_created_on_init(
+        self, mongo_store: MongoEventStore, mongo_db: Any
+    ) -> None:
+        """``__init__`` creates ``events_team_event_id_idx`` on ``events``.
+
+        Compound ascending key on ``team_id`` + the nested ``event.id``,
+        backing the anchor lookup in ``load_events(after_event_id=...)``
+        (ADR-21 §5). Deliberately not unique: a unique index would turn a
+        read-path ambiguity into a write-path ``DuplicateKeyError`` on
+        ``save_event``.
+        """
+        info = mongo_db["events"].index_information()
+        assert "events_team_event_id_idx" in info
+        assert info["events_team_event_id_idx"]["key"] == [("team_id", 1), ("event.id", 1)]
+        assert not info["events_team_event_id_idx"].get("unique")
+
+    def test_events_team_event_id_index_creation_is_idempotent(
+        self, mongo_store: MongoEventStore, mongo_db: Any
+    ) -> None:
+        """Re-running the constructor against the same database does not raise.
+
+        ``create_index`` returns silently when an index with the same key
+        spec already exists, so redeploys against a long-lived MongoDB are
+        safe. After the second construction the entry is still present
+        exactly once with the same key spec.
+        """
+        # First construction already happened via the ``mongo_store`` fixture.
+        MongoEventStore(mongo_db)  # second construction — must not raise
+
+        info = mongo_db["events"].index_information()
+        assert info["events_team_event_id_idx"]["key"] == [("team_id", 1), ("event.id", 1)]
+        assert list(info.keys()).count("events_team_event_id_idx") == 1
+
+    def test_existing_events_team_sequence_index_still_created(
+        self, mongo_store: MongoEventStore, mongo_db: Any
+    ) -> None:
+        """The pre-existing ``(team_id, sequence)`` index is untouched.
+
+        It already backs the ``{"sequence": {"$gt": n}}`` range filter and
+        needs no change for the cursor push-down.
+        """
+        specs = [entry["key"] for entry in mongo_db["events"].index_information().values()]
+        assert [("team_id", 1), ("sequence", 1)] in specs
+
     # --- Import guards ------------------------------------------------------
 
     def test_import_succeeds_when_pymongo_installed(self) -> None:

--- a/tests/repositories/test_event_store_contract.py
+++ b/tests/repositories/test_event_store_contract.py
@@ -20,7 +20,7 @@ import pytest
 from akgentic.core.messages.message import UserMessage
 
 from akgentic.team.models import TeamStatus
-from akgentic.team.ports import EventStore
+from akgentic.team.ports import EventNotFoundError, EventStore
 from tests.models.conftest import (
     SampleAgentState,
     make_agent_state_snapshot,
@@ -167,6 +167,108 @@ class TestEventStoreContract:
     def test_load_events_returns_empty_list_when_missing(self, event_store: EventStore) -> None:
         """Protocol contract: no events for a team yields ``[]``."""
         assert event_store.load_events(uuid.uuid4()) == []
+
+    # --- load_events(after_event_id) cursor baseline -----------------------
+
+    def test_load_events_after_event_id_none_equals_no_arg(self, event_store: EventStore) -> None:
+        """``load_events(t, after_event_id=None)`` is equivalent to ``load_events(t)``."""
+        team_id = uuid.uuid4()
+        for seq in (1, 2, 3):
+            event_store.save_event(make_persisted_event(team_id=team_id, sequence=seq))
+
+        no_arg = event_store.load_events(team_id)
+        with_none = event_store.load_events(team_id, after_event_id=None)
+        assert [e.event.id for e in with_none] == [e.event.id for e in no_arg]
+        assert [e.sequence for e in with_none] == [1, 2, 3]
+
+    def test_load_events_after_event_id_excludes_anchor(self, event_store: EventStore) -> None:
+        """A resolving anchor yields the strict tail — the anchor itself is excluded."""
+        team_id = uuid.uuid4()
+        for seq in (1, 2, 3, 4, 5):
+            event_store.save_event(make_persisted_event(team_id=team_id, sequence=seq))
+
+        anchor = event_store.load_events(team_id)[2]
+        assert anchor.sequence == 3
+
+        tail = event_store.load_events(team_id, after_event_id=anchor.event.id)
+        assert [e.sequence for e in tail] == [4, 5]
+        assert anchor.event.id not in [e.event.id for e in tail]
+
+    def test_load_events_unknown_after_event_id_raises(self, event_store: EventStore) -> None:
+        """An anchor that was never persisted raises rather than returning ``[]``.
+
+        Returning ``[]`` would be indistinguishable from the legitimate
+        "you are already up to date" answer (ADR-21 §2).
+        """
+        team_id = uuid.uuid4()
+        for seq in (1, 2, 3):
+            event_store.save_event(make_persisted_event(team_id=team_id, sequence=seq))
+
+        with pytest.raises(EventNotFoundError):
+            event_store.load_events(team_id, after_event_id=uuid.uuid4())
+
+    def test_load_events_first_event_anchor_returns_all_but_first(
+        self, event_store: EventStore
+    ) -> None:
+        """The first event as anchor yields every event except that one."""
+        team_id = uuid.uuid4()
+        for seq in (1, 2, 3, 4, 5):
+            event_store.save_event(make_persisted_event(team_id=team_id, sequence=seq))
+
+        first = event_store.load_events(team_id)[0]
+        tail = event_store.load_events(team_id, after_event_id=first.event.id)
+        assert [e.sequence for e in tail] == [2, 3, 4, 5]
+
+    def test_load_events_last_event_anchor_returns_empty(self, event_store: EventStore) -> None:
+        """The last event as anchor yields ``[]`` — the caller is up to date."""
+        team_id = uuid.uuid4()
+        for seq in (1, 2, 3):
+            event_store.save_event(make_persisted_event(team_id=team_id, sequence=seq))
+
+        last = event_store.load_events(team_id)[-1]
+        assert event_store.load_events(team_id, after_event_id=last.event.id) == []
+
+    def test_load_events_anchor_from_other_team_raises(self, event_store: EventStore) -> None:
+        """An anchor belonging to another team raises — the lookup is team-scoped.
+
+        Returning team A's whole log because the caller passed team B's
+        cursor is the silent degradation ADR-21 §2 exists to prevent.
+        """
+        team_a = uuid.uuid4()
+        team_b = uuid.uuid4()
+        for seq in (1, 2, 3):
+            event_store.save_event(make_persisted_event(team_id=team_a, sequence=seq))
+            event_store.save_event(make_persisted_event(team_id=team_b, sequence=seq))
+
+        foreign_anchor = event_store.load_events(team_b)[0]
+        with pytest.raises(EventNotFoundError):
+            event_store.load_events(team_a, after_event_id=foreign_anchor.event.id)
+
+    def test_load_events_after_event_id_on_empty_store_raises(
+        self, event_store: EventStore
+    ) -> None:
+        """An anchor queried against a team with no events raises, never ``[]``."""
+        with pytest.raises(EventNotFoundError):
+            event_store.load_events(uuid.uuid4(), after_event_id=uuid.uuid4())
+
+    def test_load_events_cursor_round_trip(self, event_store: EventStore) -> None:
+        """The incremental-reader usage pattern: poll, append, poll again.
+
+        This is the case that would catch a silent regression back to a
+        full-log return — the second poll must yield exactly the one new
+        event, not the whole history.
+        """
+        team_id = uuid.uuid4()
+        for seq in (1, 2, 3):
+            event_store.save_event(make_persisted_event(team_id=team_id, sequence=seq))
+
+        cursor = event_store.load_events(team_id)[-1].event.id
+        assert event_store.load_events(team_id, after_event_id=cursor) == []
+
+        event_store.save_event(make_persisted_event(team_id=team_id, sequence=4))
+
+        fresh = event_store.load_events(team_id, after_event_id=cursor)
+        assert [e.sequence for e in fresh] == [4]
 
     # --- get_max_sequence -------------------------------------------------
 

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -7,6 +7,7 @@ import uuid
 from typing import Any
 
 from akgentic.team.models import AgentStateSnapshot, PersistedEvent, Process
+from akgentic.team.ports import EventNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -43,15 +44,33 @@ class InMemoryEventStore:
             # those tests never call load_events, so a missing dict is safe.
             logger.debug("Event serialization skipped (mock sender): %s", type(event.event))
 
-    def load_events(self, team_id: uuid.UUID) -> list[PersistedEvent]:
-        """Load all persisted events for a team (deserialized from dicts).
+    def load_events(
+        self, team_id: uuid.UUID, after_event_id: uuid.UUID | None = None
+    ) -> list[PersistedEvent]:
+        """Load persisted events for a team (deserialized from dicts).
 
         Round-trips through model_dump/model_validate so that
         ActorAddressImpl becomes ActorAddressProxy, matching real
-        persistence backends (YAML, MongoDB).
+        persistence backends (YAML, MongoDB). Honours the same tail-slice
+        contract as the real backends, which slice a ``sequence``-ordered
+        list — so sort before slicing rather than trusting insertion order.
+
+        Raises:
+            EventNotFoundError: If ``after_event_id`` does not resolve to an
+                event of this team.
         """
         tid = str(team_id)
-        return [PersistedEvent.model_validate(d) for d in self._event_dicts if d["team_id"] == tid]
+        events = sorted(
+            (PersistedEvent.model_validate(d) for d in self._event_dicts if d["team_id"] == tid),
+            key=lambda e: e.sequence,
+        )
+        if after_event_id is None:
+            return events
+        # event.id is persisted as a string, so compare stringified ids.
+        for index, event in enumerate(events):
+            if str(event.event.id) == str(after_event_id):
+                return events[index + 1 :]
+        raise EventNotFoundError(f"Event {after_event_id} not found for team {team_id}")
 
     def save_team(self, process: Process) -> None:
         """Persist team process snapshot."""


### PR DESCRIPTION
Ports the Epic 24 cursor slice onto `master`, where it is not yet present.

Cherry-picks two commits:

- `a0fc45d` — feat: epic 24 slice, `load_events(after_event_id)` cursor (24-1, 24-3) (#139)
- `eafeee8` — fix: use a guarded single-field `event.id` index (#143)

Together these add the additive optional `after_event_id` cursor to `EventStore.load_events`, `EventNotFoundError`, the Mongo anchor resolve + `$gt` push-down, and the guarded single-field `events_event_id_idx`. `load_events(team_id)` and `load_events(team_id, None)` keep the existing full-log semantics.

## Conflict resolution

Both cherry-picks conflicted for the same underlying reason: the source branch carries an env-var-driven collection-name feature (`MONGO_TEAMS_COLLECTION` and friends) that `master` does not have. That feature is out of scope here and is deliberately not ported.

**Dropped the two `test_collection_names_*` tests** that came in as conflict collateral. They cover a feature absent from `master`, and referenced `os` / `make_process` — neither of which is imported in this file on `master`, so they could not have run here regardless.

**Fixed a silent semantic conflict in `mongo.py`.** The second cherry-pick merged with no conflict markers but produced a reference to `events_name`, a branch-only variable, inside the `except PyMongoError` handler. That argument is evaluated eagerly, so it would raise `NameError` precisely when a backend rejects the index — the Cosmos scenario the fix exists to survive. Replaced with `self._events.name`, which reads the name from the driver and is correct with or without the env-var feature. The rejection test covers this path.

## Verification

- 389 passed, 5 skipped (full suite)
- All 12 `test_mongo.py` tests execute — none skipped
- `ruff check src/ tests/` clean
- `mypy src/` clean — no issues in 20 source files

## Follow-up

The env-var collection-name feature remains branch-only. If it is ported later it needs both its source change and the two `test_collection_names_*` tests dropped here.

Relates to #144
Relates to #138
Relates to #140
Relates to #142