### PR TITLE
feat(akgentic-team): 25-1 TeamRuntime messaging surface

### DIFF
--- a/src/akgentic/team/models.py
+++ b/src/akgentic/team/models.py
@@ -192,7 +192,7 @@ class TeamRuntime(SerializableBaseModel):
     )
 
     _orchestrator_proxy: Orchestrator = PrivateAttr()
-    _orchestrator_tell: Orchestrator = PrivateAttr()
+    _orchestrator_proxy_tell: Orchestrator = PrivateAttr()
     _entry_proxy: Akgent[Any, Any] = PrivateAttr()
     _message_cls: type[Message] | None = PrivateAttr(default=None)
     _addr_map: dict[uuid.UUID, ActorAddress] = PrivateAttr(default_factory=dict)
@@ -207,7 +207,9 @@ class TeamRuntime(SerializableBaseModel):
             __context: Pydantic validation context (unused).
         """
         self._orchestrator_proxy = self.actor_system.proxy_ask(self.orchestrator_addr, Orchestrator)
-        self._orchestrator_tell = self.actor_system.proxy_tell(self.orchestrator_addr, Orchestrator)
+        self._orchestrator_proxy_tell = self.actor_system.proxy_tell(
+            self.orchestrator_addr, Orchestrator
+        )
         entry_agent_class = self.team.entry_point.card.get_agent_class()
         self._entry_proxy = self.actor_system.proxy_tell(self.entry_addr, entry_agent_class)
 
@@ -245,7 +247,7 @@ class TeamRuntime(SerializableBaseModel):
         fans out to subscribers (persist + live stream) with no agent processing
         and no outbound dispatch. Rationale: ADR-22.
         """
-        self._orchestrator_tell.emitMessage(message)
+        self._orchestrator_proxy_tell.emitMessage(message)
 
     def send(self, content: str | Message) -> None:
         """Send a message into the team through the entry-point agent.
@@ -397,12 +399,12 @@ class TeamRuntime(SerializableBaseModel):
 
     @property
     def orchestrator_proxy(self) -> Orchestrator:
-        """Read-only access to the orchestrator proxy."""
+        """Read-only access to the orchestrator proxy (ask)."""
         return self._orchestrator_proxy
 
     @property
     def entry_proxy(self) -> Akgent[Any, Any]:
-        """Read-only access to the entry-point proxy."""
+        """Read-only access to the entry-point proxy (tell)."""
         return self._entry_proxy
 
 

--- a/src/akgentic/team/models.py
+++ b/src/akgentic/team/models.py
@@ -192,8 +192,8 @@ class TeamRuntime(SerializableBaseModel):
     )
 
     _orchestrator_proxy: Orchestrator = PrivateAttr()
+    _orchestrator_tell: Orchestrator = PrivateAttr()
     _entry_proxy: Akgent[Any, Any] = PrivateAttr()
-    _supervisor_proxies: dict[str, Akgent[Any, Any]] = PrivateAttr(default_factory=dict)
     _message_cls: type[Message] | None = PrivateAttr(default=None)
     _addr_map: dict[uuid.UUID, ActorAddress] = PrivateAttr(default_factory=dict)
 
@@ -207,16 +207,9 @@ class TeamRuntime(SerializableBaseModel):
             __context: Pydantic validation context (unused).
         """
         self._orchestrator_proxy = self.actor_system.proxy_ask(self.orchestrator_addr, Orchestrator)
+        self._orchestrator_tell = self.actor_system.proxy_tell(self.orchestrator_addr, Orchestrator)
         entry_agent_class = self.team.entry_point.card.get_agent_class()
         self._entry_proxy = self.actor_system.proxy_tell(self.entry_addr, entry_agent_class)
-
-        self._supervisor_proxies = {}
-        for card in self.team.supervisors:
-            addr = self.supervisor_addrs.get(card.config.name)
-            if addr is not None:
-                self._supervisor_proxies[card.config.name] = self.actor_system.proxy_ask(
-                    addr, card.get_agent_class()
-                )
 
         self._message_cls = self.team.message_types[0] if self.team.message_types else None
 
@@ -237,19 +230,37 @@ class TeamRuntime(SerializableBaseModel):
             raise RuntimeError(msg)
         return self._message_cls(content=content)  # type: ignore[call-arg]
 
-    def send(self, content: str) -> None:
+    def _coerce_message(self, content: str | Message) -> Message:
+        """Coerce a routing payload to a Message.
+
+        A ``str`` is wrapped in the team's default type via ``_make_message``;
+        a ``Message`` is passed through untouched (the caller picked the type).
+        """
+        return content if isinstance(content, Message) else self._make_message(content)
+
+    def emitMessage(self, message: Message) -> None:  # noqa: N802
+        """Publish a pre-formed message into the team's event record.
+
+        Fire-and-forget tell to the orchestrator, which stamps ``team_id`` and
+        fans out to subscribers (persist + live stream) with no agent processing
+        and no outbound dispatch. Rationale: ADR-22.
+        """
+        self._orchestrator_tell.emitMessage(message)
+
+    def send(self, content: str | Message) -> None:
         """Send a message into the team through the entry-point agent.
 
         Routes through the entry proxy so that ``sender`` is set to the
-        entry agent.  Each supervisor receives its own message instance
-        to avoid shared mutable state between actors.  The entry point
-        itself never receives a copy -- it is the sender, not a recipient.
+        entry agent.  The entry point itself never receives a copy -- it is
+        the sender, not a recipient.
 
         Args:
-            content: The message content to send.
+            content: The message content, or a pre-formed ``Message`` to route
+                untouched (a passed ``Message`` is the SAME instance for every
+                supervisor -- passthrough per ADR-22, not cloned per recipient).
         """
         for addr in self.supervisor_addrs.values():
-            self._entry_proxy.send(addr, self._make_message(content))
+            self._entry_proxy.send(addr, self._coerce_message(content))
 
     def _resolve_addr(self, agent_name: str, addr: ActorAddress) -> ActorAddress:
         """Resolve a potentially stale proxy address to a live address.
@@ -297,7 +308,7 @@ class TeamRuntime(SerializableBaseModel):
             raise ValueError(msg)
         return self._resolve_addr(agent_name, addr)
 
-    def send_to(self, agent_name: str, content: str) -> None:
+    def send_to(self, agent_name: str, content: str | Message) -> None:
         """Send a directed message to a specific agent by name.
 
         Looks up the agent via the orchestrator proxy and sends a message
@@ -306,20 +317,21 @@ class TeamRuntime(SerializableBaseModel):
 
         Args:
             agent_name: Name of the target agent.
-            content: The message content.
+            content: The message content, or a pre-formed ``Message`` to route
+                untouched.
 
         Raises:
             ValueError: If the agent is not found or has a stale proxy address.
         """
         actor_addr = self._lookup_member(agent_name)
-        message = self._make_message(content)
+        message = self._coerce_message(content)
         self._entry_proxy.send(actor_addr, message)
 
     def send_from_to(
         self,
         sender_name: str,
         recipient_name: str,
-        content: str,
+        content: str | Message,
     ) -> None:
         """Send a message from a specified agent to another agent.
 
@@ -339,7 +351,7 @@ class TeamRuntime(SerializableBaseModel):
         sender_addr = self._lookup_member(sender_name)
         recipient_addr = self._lookup_member(recipient_name)
         sender_proxy = self.actor_system.proxy_tell(sender_addr, Akgent)
-        sender_proxy.send(recipient_addr, self._make_message(content))
+        sender_proxy.send(recipient_addr, self._coerce_message(content))
 
     def process_human_input(self, content: str, message: Message) -> None:
         """Route human input to the correct UserProxy by recipient name.
@@ -392,11 +404,6 @@ class TeamRuntime(SerializableBaseModel):
     def entry_proxy(self) -> Akgent[Any, Any]:
         """Read-only access to the entry-point proxy."""
         return self._entry_proxy
-
-    @property
-    def supervisor_proxies(self) -> dict[str, Akgent[Any, Any]]:
-        """Read-only access to the supervisor proxies."""
-        return self._supervisor_proxies
 
 
 # --- Persistence Models ---

--- a/tests/models/test_team_runtime.py
+++ b/tests/models/test_team_runtime.py
@@ -104,10 +104,10 @@ class TestTeamRuntimeConstruction:
         )
         assert runtime.supervisor_addrs == {"supervisor": sup_addr}
 
-    def test_model_post_init_builds_orchestrator_tell(self) -> None:
-        """AC1: model_post_init builds _orchestrator_tell via proxy_tell(orchestrator_addr)."""
+    def test_model_post_init_builds_orchestrator_proxy_tell(self) -> None:
+        """AC1: model_post_init builds _orchestrator_proxy_tell via proxy_tell(orchestrator_addr)."""
         runtime = make_team_runtime()
-        assert runtime._orchestrator_tell is not None
+        assert runtime._orchestrator_proxy_tell is not None
         runtime.actor_system.proxy_tell.assert_any_call(runtime.orchestrator_addr, Orchestrator)
 
 
@@ -118,7 +118,7 @@ class TestTeamRuntimeSerialization:
         runtime = make_team_runtime()
         data = runtime.model_dump()
         assert "_orchestrator_proxy" not in data
-        assert "_orchestrator_tell" not in data
+        assert "_orchestrator_proxy_tell" not in data
         assert "_entry_proxy" not in data
         assert "_message_cls" not in data
 
@@ -241,11 +241,11 @@ class TestTeamRuntimeEmitMessage:
     """AC3: emitMessage tell-forwards a pre-formed message to the orchestrator."""
 
     def test_emit_message_tell_forwards(self) -> None:
-        """emitMessage delegates to _orchestrator_tell.emitMessage with the same instance."""
+        """emitMessage delegates to _orchestrator_proxy_tell.emitMessage with the same instance."""
         runtime = make_team_runtime(message_types=[UserMessage])
         msg = UserMessage(content="banner")
         runtime.emitMessage(msg)
-        runtime._orchestrator_tell.emitMessage.assert_called_once_with(msg)
+        runtime._orchestrator_proxy_tell.emitMessage.assert_called_once_with(msg)
 
     def test_emit_message_returns_none(self) -> None:
         """emitMessage is fire-and-forget — returns None."""

--- a/tests/models/test_team_runtime.py
+++ b/tests/models/test_team_runtime.py
@@ -10,6 +10,7 @@ from akgentic.core.actor_address import ActorAddress
 from akgentic.core.actor_address_impl import ActorAddressProxy
 from akgentic.core.agent import Akgent
 from akgentic.core.messages.message import UserMessage
+from akgentic.core.orchestrator import Orchestrator
 from akgentic.core.user_proxy import UserProxy
 from akgentic.core.utils.deserializer import ActorAddressDict
 from pydantic import ValidationError
@@ -77,8 +78,8 @@ class TestTeamRuntimeConstruction:
         assert runtime.actor_system.proxy_ask.call_count > initial_call_count
         assert runtime._orchestrator_proxy is not None
 
-    def test_model_post_init_builds_supervisor_proxies(self) -> None:
-        """AC3: model_post_init rebuilds supervisor proxies from addresses."""
+    def test_model_post_init_keeps_supervisor_addrs(self) -> None:
+        """AC2: supervisor_addrs is preserved (the removed proxy build is gone)."""
         supervisor_card = make_agent_card(name="supervisor", role="Supervisor", agent_class=Akgent)
         worker_card = make_agent_card(name="worker", role="Worker", agent_class=Akgent)
         entry_member = TeamCardMember(
@@ -101,8 +102,13 @@ class TestTeamRuntimeConstruction:
             team_card=tc,
             supervisor_addrs={"supervisor": sup_addr},
         )
-        assert "supervisor" in runtime._supervisor_proxies
-        runtime.actor_system.proxy_ask.assert_any_call(sup_addr, Akgent)
+        assert runtime.supervisor_addrs == {"supervisor": sup_addr}
+
+    def test_model_post_init_builds_orchestrator_tell(self) -> None:
+        """AC1: model_post_init builds _orchestrator_tell via proxy_tell(orchestrator_addr)."""
+        runtime = make_team_runtime()
+        assert runtime._orchestrator_tell is not None
+        runtime.actor_system.proxy_tell.assert_any_call(runtime.orchestrator_addr, Orchestrator)
 
 
 class TestTeamRuntimeSerialization:
@@ -112,8 +118,8 @@ class TestTeamRuntimeSerialization:
         runtime = make_team_runtime()
         data = runtime.model_dump()
         assert "_orchestrator_proxy" not in data
+        assert "_orchestrator_tell" not in data
         assert "_entry_proxy" not in data
-        assert "_supervisor_proxies" not in data
         assert "_message_cls" not in data
 
     def test_actor_system_excluded_from_dump(self) -> None:
@@ -229,7 +235,88 @@ class TestTeamRuntimeMessaging:
         runtime = make_team_runtime()
         assert runtime.orchestrator_proxy is runtime._orchestrator_proxy
         assert runtime.entry_proxy is runtime._entry_proxy
-        assert runtime.supervisor_proxies is runtime._supervisor_proxies
+
+
+class TestTeamRuntimeEmitMessage:
+    """AC3: emitMessage tell-forwards a pre-formed message to the orchestrator."""
+
+    def test_emit_message_tell_forwards(self) -> None:
+        """emitMessage delegates to _orchestrator_tell.emitMessage with the same instance."""
+        runtime = make_team_runtime(message_types=[UserMessage])
+        msg = UserMessage(content="banner")
+        runtime.emitMessage(msg)
+        runtime._orchestrator_tell.emitMessage.assert_called_once_with(msg)
+
+    def test_emit_message_returns_none(self) -> None:
+        """emitMessage is fire-and-forget — returns None."""
+        runtime = make_team_runtime(message_types=[UserMessage])
+        assert runtime.emitMessage(UserMessage(content="x")) is None
+
+
+class TestTeamRuntimeCoerceMessage:
+    """AC4: _coerce_message wraps a str and passes a Message through untouched."""
+
+    def test_coerce_str_wraps_via_make_message(self) -> None:
+        runtime = make_team_runtime(message_types=[UserMessage])
+        result = runtime._coerce_message("hello")
+        assert isinstance(result, UserMessage)
+        assert result.content == "hello"
+
+    def test_coerce_message_passthrough_identity(self) -> None:
+        runtime = make_team_runtime(message_types=[UserMessage])
+        original = UserMessage(content="preformed")
+        assert runtime._coerce_message(original) is original
+
+
+class TestTeamRuntimeTypedSend:
+    """AC4, AC5: send/send_to/send_from_to accept a Message and route it untouched."""
+
+    def test_send_with_message_routes_same_instance(self) -> None:
+        sup_addr = make_stub_addr("supervisor")
+        runtime = make_team_runtime(
+            message_types=[UserMessage],
+            supervisor_addrs={"sup": sup_addr},
+        )
+        preformed = UserMessage(content="typed")
+        runtime.send(preformed)
+        call_args = runtime._entry_proxy.send.call_args
+        assert call_args.args[0] is sup_addr
+        assert call_args.args[1] is preformed
+
+    def test_send_with_str_still_wraps(self) -> None:
+        sup_addr = make_stub_addr("supervisor")
+        runtime = make_team_runtime(
+            message_types=[UserMessage],
+            supervisor_addrs={"sup": sup_addr},
+        )
+        runtime.send("plain")
+        msg = runtime._entry_proxy.send.call_args.args[1]
+        assert isinstance(msg, UserMessage)
+        assert msg.content == "plain"
+
+    def test_send_to_with_message_routes_same_instance(self) -> None:
+        target_addr = make_stub_addr("worker")
+        runtime = make_team_runtime(message_types=[UserMessage])
+        runtime._orchestrator_proxy.get_team_member = MagicMock(return_value=target_addr)
+        preformed = UserMessage(content="typed")
+        runtime.send_to("worker", preformed)
+        call_args = runtime._entry_proxy.send.call_args
+        assert call_args.args[0] is target_addr
+        assert call_args.args[1] is preformed
+
+    def test_send_from_to_with_message_routes_same_instance(self) -> None:
+        sender_addr = make_stub_addr("developer")
+        recipient_addr = make_stub_addr("manager")
+        runtime = make_team_runtime(message_types=[UserMessage])
+        runtime._orchestrator_proxy.get_team_member = MagicMock(
+            side_effect=lambda name: sender_addr if name == "developer" else recipient_addr,
+        )
+        preformed = UserMessage(content="typed")
+        runtime.send_from_to("developer", "manager", preformed)
+        sender_proxy = runtime.actor_system.proxy_tell.return_value
+        call_args = sender_proxy.send.call_args
+        assert call_args.args[0] is recipient_addr
+        assert call_args.args[1] is preformed
 
 
 class TestTeamRuntimeSendToResolution:

--- a/tests/services/test_factory.py
+++ b/tests/services/test_factory.py
@@ -440,16 +440,15 @@ class TestFactoryProxySpawning:
         for addr in team:
             assert addr.is_alive()
 
-    def test_build_entry_point_not_in_supervisor_proxies_without_subordinates(
+    def test_build_entry_point_not_in_supervisor_addrs_without_subordinates(
         self, actor_system: ActorSystem
     ) -> None:
-        """Entry point without subordinates is NOT in supervisor_proxies."""
+        """Entry point without subordinates is NOT in supervisor_addrs."""
         tc = _make_team_card()  # lead has no subordinates
 
         runtime = TeamFactory.build(tc, actor_system)
 
         assert "lead" not in runtime.supervisor_addrs
-        assert "lead" not in runtime.supervisor_proxies
         # Entry point is still reachable via entry_proxy
         assert runtime.entry_proxy is not None
 


### PR DESCRIPTION
## Summary

Completes the **akgentic-team slice** of the Team Message-Injection API on `TeamRuntime` (the umbrella epic-25 / decision doc "team emit + notification injection"). One cohesive change to `models.py`:

- **`emitMessage(message)`** — fire-and-forget tell that forwards to the orchestrator via a new ephemeral `_orchestrator_tell` proxy (the tell analog of the ask `_orchestrator_proxy`, built from the same `orchestrator_addr`). The orchestrator stamps `team_id` and fans out to subscribers with no agent processing and no outbound dispatch.
- **Widened processing verbs** — `send` / `send_to` / `send_from_to` now accept `str | Message`. A single `_coerce_message` helper wraps a `str` via `_make_message` and passes a `Message` through untouched. Routing and sender/recipient rules are unchanged: sender comes from the routing proxy, recipient from the method args; a passed `Message`'s own `sender`/`recipient` are not authoritative.
- **Removed the dead `supervisor_proxies`** — the ask-based `_supervisor_proxies` PrivateAttr, its `model_post_init` build loop, and the `supervisor_proxies` property are deleted. The persistent `supervisor_addrs` field (still read by `send`) is kept unchanged.
- **Tests** updated for the removal and the new surface: `emitMessage` tell-forwarding, `_orchestrator_tell` build, `_coerce_message` str-wrap / Message-passthrough (identity), and typed `send*` routing.

## Dependency

Consumes akgentic-core `Orchestrator.emitMessage` (akgentic-core #98) via the tell proxy. Workspace-editable core is the local gate until that release lands; remote CI is expected red until then.

## Verification (local gate)

- `pytest packages/akgentic-team/tests -m "not integration"` — 398 passed, 5 skipped
- `ruff check src/` — clean
- `mypy src/` — clean (20 files)

Scope is confined to `packages/akgentic-team/` (Golden Rule #4).

Closes #146
